### PR TITLE
Remove "Service" suffix from API wrappers

### DIFF
--- a/api_auth.go
+++ b/api_auth.go
@@ -19,12 +19,14 @@ import (
 	"strings"
 )
 
-// AuthService Auth service
-type AuthService service
+// Auth is a simple wrapper around the client for Auth requests
+type Auth struct {
+	client *Client
+}
 
 // DeleteAuthAlicloudRoleRole Create a role and associate policies to it.
 // role: The name of the role as it should appear in Vault.
-func (a *AuthService) DeleteAuthAlicloudRoleRole(ctx context.Context, role string) (*http.Response, error) {
+func (a *Auth) DeleteAuthAlicloudRoleRole(ctx context.Context, role string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -91,7 +93,7 @@ func (a *AuthService) DeleteAuthAlicloudRoleRole(ctx context.Context, role strin
 
 // DeleteAuthAppIdMapAppIdKey Read/write/delete a single app-id mapping
 // key: Key for the app-id mapping
-func (a *AuthService) DeleteAuthAppIdMapAppIdKey(ctx context.Context, key string) (*http.Response, error) {
+func (a *Auth) DeleteAuthAppIdMapAppIdKey(ctx context.Context, key string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -158,7 +160,7 @@ func (a *AuthService) DeleteAuthAppIdMapAppIdKey(ctx context.Context, key string
 
 // DeleteAuthAppIdMapUserIdKey Read/write/delete a single user-id mapping
 // key: Key for the user-id mapping
-func (a *AuthService) DeleteAuthAppIdMapUserIdKey(ctx context.Context, key string) (*http.Response, error) {
+func (a *Auth) DeleteAuthAppIdMapUserIdKey(ctx context.Context, key string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -225,7 +227,7 @@ func (a *AuthService) DeleteAuthAppIdMapUserIdKey(ctx context.Context, key strin
 
 // DeleteAuthApproleRoleRoleName Register an role with the backend.
 // roleName: Name of the role.
-func (a *AuthService) DeleteAuthApproleRoleRoleName(ctx context.Context, roleName string) (*http.Response, error) {
+func (a *Auth) DeleteAuthApproleRoleRoleName(ctx context.Context, roleName string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -292,7 +294,7 @@ func (a *AuthService) DeleteAuthApproleRoleRoleName(ctx context.Context, roleNam
 
 // DeleteAuthApproleRoleRoleNameBindSecretId Impose secret_id to be presented during login using this role.
 // roleName: Name of the role.
-func (a *AuthService) DeleteAuthApproleRoleRoleNameBindSecretId(ctx context.Context, roleName string) (*http.Response, error) {
+func (a *Auth) DeleteAuthApproleRoleRoleNameBindSecretId(ctx context.Context, roleName string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -359,7 +361,7 @@ func (a *AuthService) DeleteAuthApproleRoleRoleNameBindSecretId(ctx context.Cont
 
 // DeleteAuthApproleRoleRoleNameBoundCidrList Deprecated: Comma separated list of CIDR blocks, if set, specifies blocks of IP addresses which can perform the login operation
 // roleName: Name of the role.
-func (a *AuthService) DeleteAuthApproleRoleRoleNameBoundCidrList(ctx context.Context, roleName string) (*http.Response, error) {
+func (a *Auth) DeleteAuthApproleRoleRoleNameBoundCidrList(ctx context.Context, roleName string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -426,7 +428,7 @@ func (a *AuthService) DeleteAuthApproleRoleRoleNameBoundCidrList(ctx context.Con
 
 // DeleteAuthApproleRoleRoleNamePeriod Updates the value of 'period' on the role
 // roleName: Name of the role.
-func (a *AuthService) DeleteAuthApproleRoleRoleNamePeriod(ctx context.Context, roleName string) (*http.Response, error) {
+func (a *Auth) DeleteAuthApproleRoleRoleNamePeriod(ctx context.Context, roleName string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -493,7 +495,7 @@ func (a *AuthService) DeleteAuthApproleRoleRoleNamePeriod(ctx context.Context, r
 
 // DeleteAuthApproleRoleRoleNamePolicies Policies of the role.
 // roleName: Name of the role.
-func (a *AuthService) DeleteAuthApproleRoleRoleNamePolicies(ctx context.Context, roleName string) (*http.Response, error) {
+func (a *Auth) DeleteAuthApproleRoleRoleNamePolicies(ctx context.Context, roleName string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -560,7 +562,7 @@ func (a *AuthService) DeleteAuthApproleRoleRoleNamePolicies(ctx context.Context,
 
 // DeleteAuthApproleRoleRoleNameSecretIdAccessorDestroy
 // roleName: Name of the role.
-func (a *AuthService) DeleteAuthApproleRoleRoleNameSecretIdAccessorDestroy(ctx context.Context, roleName string) (*http.Response, error) {
+func (a *Auth) DeleteAuthApproleRoleRoleNameSecretIdAccessorDestroy(ctx context.Context, roleName string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -627,7 +629,7 @@ func (a *AuthService) DeleteAuthApproleRoleRoleNameSecretIdAccessorDestroy(ctx c
 
 // DeleteAuthApproleRoleRoleNameSecretIdBoundCidrs Comma separated list of CIDR blocks, if set, specifies blocks of IP addresses which can perform the login operation
 // roleName: Name of the role.
-func (a *AuthService) DeleteAuthApproleRoleRoleNameSecretIdBoundCidrs(ctx context.Context, roleName string) (*http.Response, error) {
+func (a *Auth) DeleteAuthApproleRoleRoleNameSecretIdBoundCidrs(ctx context.Context, roleName string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -694,7 +696,7 @@ func (a *AuthService) DeleteAuthApproleRoleRoleNameSecretIdBoundCidrs(ctx contex
 
 // DeleteAuthApproleRoleRoleNameSecretIdDestroy Invalidate an issued secret_id
 // roleName: Name of the role.
-func (a *AuthService) DeleteAuthApproleRoleRoleNameSecretIdDestroy(ctx context.Context, roleName string) (*http.Response, error) {
+func (a *Auth) DeleteAuthApproleRoleRoleNameSecretIdDestroy(ctx context.Context, roleName string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -761,7 +763,7 @@ func (a *AuthService) DeleteAuthApproleRoleRoleNameSecretIdDestroy(ctx context.C
 
 // DeleteAuthApproleRoleRoleNameSecretIdNumUses Use limit of the SecretID generated against the role.
 // roleName: Name of the role.
-func (a *AuthService) DeleteAuthApproleRoleRoleNameSecretIdNumUses(ctx context.Context, roleName string) (*http.Response, error) {
+func (a *Auth) DeleteAuthApproleRoleRoleNameSecretIdNumUses(ctx context.Context, roleName string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -828,7 +830,7 @@ func (a *AuthService) DeleteAuthApproleRoleRoleNameSecretIdNumUses(ctx context.C
 
 // DeleteAuthApproleRoleRoleNameSecretIdTtl Duration in seconds, representing the lifetime of the SecretIDs that are generated against the role using 'role/<role_name>/secret-id' or 'role/<role_name>/custom-secret-id' endpoints.
 // roleName: Name of the role.
-func (a *AuthService) DeleteAuthApproleRoleRoleNameSecretIdTtl(ctx context.Context, roleName string) (*http.Response, error) {
+func (a *Auth) DeleteAuthApproleRoleRoleNameSecretIdTtl(ctx context.Context, roleName string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -895,7 +897,7 @@ func (a *AuthService) DeleteAuthApproleRoleRoleNameSecretIdTtl(ctx context.Conte
 
 // DeleteAuthApproleRoleRoleNameTokenBoundCidrs Comma separated string or list of CIDR blocks. If set, specifies the blocks of IP addresses which can use the returned token.
 // roleName: Name of the role.
-func (a *AuthService) DeleteAuthApproleRoleRoleNameTokenBoundCidrs(ctx context.Context, roleName string) (*http.Response, error) {
+func (a *Auth) DeleteAuthApproleRoleRoleNameTokenBoundCidrs(ctx context.Context, roleName string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -962,7 +964,7 @@ func (a *AuthService) DeleteAuthApproleRoleRoleNameTokenBoundCidrs(ctx context.C
 
 // DeleteAuthApproleRoleRoleNameTokenMaxTtl Duration in seconds, the maximum lifetime of the tokens issued by using the SecretIDs that were generated against this role, after which the tokens are not allowed to be renewed.
 // roleName: Name of the role.
-func (a *AuthService) DeleteAuthApproleRoleRoleNameTokenMaxTtl(ctx context.Context, roleName string) (*http.Response, error) {
+func (a *Auth) DeleteAuthApproleRoleRoleNameTokenMaxTtl(ctx context.Context, roleName string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -1029,7 +1031,7 @@ func (a *AuthService) DeleteAuthApproleRoleRoleNameTokenMaxTtl(ctx context.Conte
 
 // DeleteAuthApproleRoleRoleNameTokenNumUses Number of times issued tokens can be used
 // roleName: Name of the role.
-func (a *AuthService) DeleteAuthApproleRoleRoleNameTokenNumUses(ctx context.Context, roleName string) (*http.Response, error) {
+func (a *Auth) DeleteAuthApproleRoleRoleNameTokenNumUses(ctx context.Context, roleName string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -1096,7 +1098,7 @@ func (a *AuthService) DeleteAuthApproleRoleRoleNameTokenNumUses(ctx context.Cont
 
 // DeleteAuthApproleRoleRoleNameTokenTtl Duration in seconds, the lifetime of the token issued by using the SecretID that is generated against this role, before which the token needs to be renewed.
 // roleName: Name of the role.
-func (a *AuthService) DeleteAuthApproleRoleRoleNameTokenTtl(ctx context.Context, roleName string) (*http.Response, error) {
+func (a *Auth) DeleteAuthApproleRoleRoleNameTokenTtl(ctx context.Context, roleName string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -1163,7 +1165,7 @@ func (a *AuthService) DeleteAuthApproleRoleRoleNameTokenTtl(ctx context.Context,
 
 // DeleteAuthAwsConfigCertificateCertName
 // certName: Name of the certificate.
-func (a *AuthService) DeleteAuthAwsConfigCertificateCertName(ctx context.Context, certName string) (*http.Response, error) {
+func (a *Auth) DeleteAuthAwsConfigCertificateCertName(ctx context.Context, certName string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -1229,7 +1231,7 @@ func (a *AuthService) DeleteAuthAwsConfigCertificateCertName(ctx context.Context
 }
 
 // DeleteAuthAwsConfigClient
-func (a *AuthService) DeleteAuthAwsConfigClient(ctx context.Context) (*http.Response, error) {
+func (a *Auth) DeleteAuthAwsConfigClient(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -1295,7 +1297,7 @@ func (a *AuthService) DeleteAuthAwsConfigClient(ctx context.Context) (*http.Resp
 
 // DeleteAuthAwsConfigStsAccountId
 // accountId: AWS account ID to be associated with STS role. If set, Vault will use assumed credentials to verify any login attempts from EC2 instances in this account.
-func (a *AuthService) DeleteAuthAwsConfigStsAccountId(ctx context.Context, accountId string) (*http.Response, error) {
+func (a *Auth) DeleteAuthAwsConfigStsAccountId(ctx context.Context, accountId string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -1361,7 +1363,7 @@ func (a *AuthService) DeleteAuthAwsConfigStsAccountId(ctx context.Context, accou
 }
 
 // DeleteAuthAwsConfigTidyIdentityAccesslist
-func (a *AuthService) DeleteAuthAwsConfigTidyIdentityAccesslist(ctx context.Context) (*http.Response, error) {
+func (a *Auth) DeleteAuthAwsConfigTidyIdentityAccesslist(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -1426,7 +1428,7 @@ func (a *AuthService) DeleteAuthAwsConfigTidyIdentityAccesslist(ctx context.Cont
 }
 
 // DeleteAuthAwsConfigTidyIdentityWhitelist
-func (a *AuthService) DeleteAuthAwsConfigTidyIdentityWhitelist(ctx context.Context) (*http.Response, error) {
+func (a *Auth) DeleteAuthAwsConfigTidyIdentityWhitelist(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -1491,7 +1493,7 @@ func (a *AuthService) DeleteAuthAwsConfigTidyIdentityWhitelist(ctx context.Conte
 }
 
 // DeleteAuthAwsConfigTidyRoletagBlacklist
-func (a *AuthService) DeleteAuthAwsConfigTidyRoletagBlacklist(ctx context.Context) (*http.Response, error) {
+func (a *Auth) DeleteAuthAwsConfigTidyRoletagBlacklist(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -1556,7 +1558,7 @@ func (a *AuthService) DeleteAuthAwsConfigTidyRoletagBlacklist(ctx context.Contex
 }
 
 // DeleteAuthAwsConfigTidyRoletagDenylist
-func (a *AuthService) DeleteAuthAwsConfigTidyRoletagDenylist(ctx context.Context) (*http.Response, error) {
+func (a *Auth) DeleteAuthAwsConfigTidyRoletagDenylist(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -1622,7 +1624,7 @@ func (a *AuthService) DeleteAuthAwsConfigTidyRoletagDenylist(ctx context.Context
 
 // DeleteAuthAwsIdentityAccesslistInstanceId
 // instanceId: EC2 instance ID. A successful login operation from an EC2 instance gets cached in this accesslist, keyed off of instance ID.
-func (a *AuthService) DeleteAuthAwsIdentityAccesslistInstanceId(ctx context.Context, instanceId string) (*http.Response, error) {
+func (a *Auth) DeleteAuthAwsIdentityAccesslistInstanceId(ctx context.Context, instanceId string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -1689,7 +1691,7 @@ func (a *AuthService) DeleteAuthAwsIdentityAccesslistInstanceId(ctx context.Cont
 
 // DeleteAuthAwsIdentityWhitelistInstanceId
 // instanceId: EC2 instance ID. A successful login operation from an EC2 instance gets cached in this accesslist, keyed off of instance ID.
-func (a *AuthService) DeleteAuthAwsIdentityWhitelistInstanceId(ctx context.Context, instanceId string) (*http.Response, error) {
+func (a *Auth) DeleteAuthAwsIdentityWhitelistInstanceId(ctx context.Context, instanceId string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -1756,7 +1758,7 @@ func (a *AuthService) DeleteAuthAwsIdentityWhitelistInstanceId(ctx context.Conte
 
 // DeleteAuthAwsRoleRole
 // role: Name of the role.
-func (a *AuthService) DeleteAuthAwsRoleRole(ctx context.Context, role string) (*http.Response, error) {
+func (a *Auth) DeleteAuthAwsRoleRole(ctx context.Context, role string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -1823,7 +1825,7 @@ func (a *AuthService) DeleteAuthAwsRoleRole(ctx context.Context, role string) (*
 
 // DeleteAuthAwsRoletagBlacklistRoleTag
 // roleTag: Role tag to be deny listed. The tag can be supplied as-is. In order to avoid any encoding problems, it can be base64 encoded.
-func (a *AuthService) DeleteAuthAwsRoletagBlacklistRoleTag(ctx context.Context, roleTag string) (*http.Response, error) {
+func (a *Auth) DeleteAuthAwsRoletagBlacklistRoleTag(ctx context.Context, roleTag string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -1890,7 +1892,7 @@ func (a *AuthService) DeleteAuthAwsRoletagBlacklistRoleTag(ctx context.Context, 
 
 // DeleteAuthAwsRoletagDenylistRoleTag
 // roleTag: Role tag to be deny listed. The tag can be supplied as-is. In order to avoid any encoding problems, it can be base64 encoded.
-func (a *AuthService) DeleteAuthAwsRoletagDenylistRoleTag(ctx context.Context, roleTag string) (*http.Response, error) {
+func (a *Auth) DeleteAuthAwsRoletagDenylistRoleTag(ctx context.Context, roleTag string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -1956,7 +1958,7 @@ func (a *AuthService) DeleteAuthAwsRoletagDenylistRoleTag(ctx context.Context, r
 }
 
 // DeleteAuthAzureConfig
-func (a *AuthService) DeleteAuthAzureConfig(ctx context.Context) (*http.Response, error) {
+func (a *Auth) DeleteAuthAzureConfig(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -2022,7 +2024,7 @@ func (a *AuthService) DeleteAuthAzureConfig(ctx context.Context) (*http.Response
 
 // DeleteAuthAzureRoleName
 // name: Name of the role.
-func (a *AuthService) DeleteAuthAzureRoleName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Auth) DeleteAuthAzureRoleName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -2089,7 +2091,7 @@ func (a *AuthService) DeleteAuthAzureRoleName(ctx context.Context, name string) 
 
 // DeleteAuthCertCertsName Manage trusted certificates used for authentication.
 // name: The name of the certificate
-func (a *AuthService) DeleteAuthCertCertsName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Auth) DeleteAuthCertCertsName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -2156,7 +2158,7 @@ func (a *AuthService) DeleteAuthCertCertsName(ctx context.Context, name string) 
 
 // DeleteAuthCertCrlsName Manage Certificate Revocation Lists checked during authentication.
 // name: The name of the certificate
-func (a *AuthService) DeleteAuthCertCrlsName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Auth) DeleteAuthCertCrlsName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -2222,7 +2224,7 @@ func (a *AuthService) DeleteAuthCertCrlsName(ctx context.Context, name string) (
 }
 
 // DeleteAuthCfConfig
-func (a *AuthService) DeleteAuthCfConfig(ctx context.Context) (*http.Response, error) {
+func (a *Auth) DeleteAuthCfConfig(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -2288,7 +2290,7 @@ func (a *AuthService) DeleteAuthCfConfig(ctx context.Context) (*http.Response, e
 
 // DeleteAuthCfRolesRole
 // role: The name of the role.
-func (a *AuthService) DeleteAuthCfRolesRole(ctx context.Context, role string) (*http.Response, error) {
+func (a *Auth) DeleteAuthCfRolesRole(ctx context.Context, role string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -2355,7 +2357,7 @@ func (a *AuthService) DeleteAuthCfRolesRole(ctx context.Context, role string) (*
 
 // DeleteAuthGcpRoleName Create a GCP role with associated policies and required attributes.
 // name: Name of the role.
-func (a *AuthService) DeleteAuthGcpRoleName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Auth) DeleteAuthGcpRoleName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -2422,7 +2424,7 @@ func (a *AuthService) DeleteAuthGcpRoleName(ctx context.Context, name string) (*
 
 // DeleteAuthGithubMapTeamsKey Read/write/delete a single teams mapping
 // key: Key for the teams mapping
-func (a *AuthService) DeleteAuthGithubMapTeamsKey(ctx context.Context, key string) (*http.Response, error) {
+func (a *Auth) DeleteAuthGithubMapTeamsKey(ctx context.Context, key string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -2489,7 +2491,7 @@ func (a *AuthService) DeleteAuthGithubMapTeamsKey(ctx context.Context, key strin
 
 // DeleteAuthGithubMapUsersKey Read/write/delete a single users mapping
 // key: Key for the users mapping
-func (a *AuthService) DeleteAuthGithubMapUsersKey(ctx context.Context, key string) (*http.Response, error) {
+func (a *Auth) DeleteAuthGithubMapUsersKey(ctx context.Context, key string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -2556,7 +2558,7 @@ func (a *AuthService) DeleteAuthGithubMapUsersKey(ctx context.Context, key strin
 
 // DeleteAuthJwtRoleName Delete an existing role.
 // name: Name of the role.
-func (a *AuthService) DeleteAuthJwtRoleName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Auth) DeleteAuthJwtRoleName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -2623,7 +2625,7 @@ func (a *AuthService) DeleteAuthJwtRoleName(ctx context.Context, name string) (*
 
 // DeleteAuthKerberosGroupsName
 // name: Name of the LDAP group.
-func (a *AuthService) DeleteAuthKerberosGroupsName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Auth) DeleteAuthKerberosGroupsName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -2690,7 +2692,7 @@ func (a *AuthService) DeleteAuthKerberosGroupsName(ctx context.Context, name str
 
 // DeleteAuthKubernetesRoleName Register an role with the backend.
 // name: Name of the role.
-func (a *AuthService) DeleteAuthKubernetesRoleName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Auth) DeleteAuthKubernetesRoleName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -2757,7 +2759,7 @@ func (a *AuthService) DeleteAuthKubernetesRoleName(ctx context.Context, name str
 
 // DeleteAuthLdapGroupsName Manage additional groups for users allowed to authenticate.
 // name: Name of the LDAP group.
-func (a *AuthService) DeleteAuthLdapGroupsName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Auth) DeleteAuthLdapGroupsName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -2824,7 +2826,7 @@ func (a *AuthService) DeleteAuthLdapGroupsName(ctx context.Context, name string)
 
 // DeleteAuthLdapUsersName Manage users allowed to authenticate.
 // name: Name of the LDAP user.
-func (a *AuthService) DeleteAuthLdapUsersName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Auth) DeleteAuthLdapUsersName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -2890,7 +2892,7 @@ func (a *AuthService) DeleteAuthLdapUsersName(ctx context.Context, name string) 
 }
 
 // DeleteAuthOciConfig Manages the configuration for the Vault Auth Plugin.
-func (a *AuthService) DeleteAuthOciConfig(ctx context.Context) (*http.Response, error) {
+func (a *Auth) DeleteAuthOciConfig(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -2956,7 +2958,7 @@ func (a *AuthService) DeleteAuthOciConfig(ctx context.Context) (*http.Response, 
 
 // DeleteAuthOciRoleRole Create a role and associate policies to it.
 // role: Name of the role.
-func (a *AuthService) DeleteAuthOciRoleRole(ctx context.Context, role string) (*http.Response, error) {
+func (a *Auth) DeleteAuthOciRoleRole(ctx context.Context, role string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -3023,7 +3025,7 @@ func (a *AuthService) DeleteAuthOciRoleRole(ctx context.Context, role string) (*
 
 // DeleteAuthOidcRoleName Delete an existing role.
 // name: Name of the role.
-func (a *AuthService) DeleteAuthOidcRoleName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Auth) DeleteAuthOidcRoleName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -3090,7 +3092,7 @@ func (a *AuthService) DeleteAuthOidcRoleName(ctx context.Context, name string) (
 
 // DeleteAuthOktaGroupsName Manage users allowed to authenticate.
 // name: Name of the Okta group.
-func (a *AuthService) DeleteAuthOktaGroupsName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Auth) DeleteAuthOktaGroupsName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -3157,7 +3159,7 @@ func (a *AuthService) DeleteAuthOktaGroupsName(ctx context.Context, name string)
 
 // DeleteAuthOktaUsersName Manage additional groups for users allowed to authenticate.
 // name: Name of the user.
-func (a *AuthService) DeleteAuthOktaUsersName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Auth) DeleteAuthOktaUsersName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -3224,7 +3226,7 @@ func (a *AuthService) DeleteAuthOktaUsersName(ctx context.Context, name string) 
 
 // DeleteAuthRadiusUsersName Manage users allowed to authenticate.
 // name: Name of the RADIUS user.
-func (a *AuthService) DeleteAuthRadiusUsersName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Auth) DeleteAuthRadiusUsersName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -3291,7 +3293,7 @@ func (a *AuthService) DeleteAuthRadiusUsersName(ctx context.Context, name string
 
 // DeleteAuthTokenRolesRoleName
 // roleName: Name of the role
-func (a *AuthService) DeleteAuthTokenRolesRoleName(ctx context.Context, roleName string) (*http.Response, error) {
+func (a *Auth) DeleteAuthTokenRolesRoleName(ctx context.Context, roleName string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -3358,7 +3360,7 @@ func (a *AuthService) DeleteAuthTokenRolesRoleName(ctx context.Context, roleName
 
 // DeleteAuthUserpassUsersUsername Manage users allowed to authenticate.
 // username: Username for this user.
-func (a *AuthService) DeleteAuthUserpassUsersUsername(ctx context.Context, username string) (*http.Response, error) {
+func (a *Auth) DeleteAuthUserpassUsersUsername(ctx context.Context, username string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -3425,7 +3427,7 @@ func (a *AuthService) DeleteAuthUserpassUsersUsername(ctx context.Context, usern
 
 // GetAuthAlicloudRole Lists all the roles that are registered with Vault.
 // list: Must be set to &#x60;true&#x60;
-func (a *AuthService) GetAuthAlicloudRole(ctx context.Context, list string) (*http.Response, error) {
+func (a *Auth) GetAuthAlicloudRole(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -3492,7 +3494,7 @@ func (a *AuthService) GetAuthAlicloudRole(ctx context.Context, list string) (*ht
 
 // GetAuthAlicloudRoleRole Create a role and associate policies to it.
 // role: The name of the role as it should appear in Vault.
-func (a *AuthService) GetAuthAlicloudRoleRole(ctx context.Context, role string) (*http.Response, error) {
+func (a *Auth) GetAuthAlicloudRoleRole(ctx context.Context, role string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -3559,7 +3561,7 @@ func (a *AuthService) GetAuthAlicloudRoleRole(ctx context.Context, role string) 
 
 // GetAuthAlicloudRoles Lists all the roles that are registered with Vault.
 // list: Must be set to &#x60;true&#x60;
-func (a *AuthService) GetAuthAlicloudRoles(ctx context.Context, list string) (*http.Response, error) {
+func (a *Auth) GetAuthAlicloudRoles(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -3626,7 +3628,7 @@ func (a *AuthService) GetAuthAlicloudRoles(ctx context.Context, list string) (*h
 
 // GetAuthAppIdMapAppId Read mappings for app-id
 // list: Return a list if &#x60;true&#x60;
-func (a *AuthService) GetAuthAppIdMapAppId(ctx context.Context, list string) (*http.Response, error) {
+func (a *Auth) GetAuthAppIdMapAppId(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -3693,7 +3695,7 @@ func (a *AuthService) GetAuthAppIdMapAppId(ctx context.Context, list string) (*h
 
 // GetAuthAppIdMapAppIdKey Read/write/delete a single app-id mapping
 // key: Key for the app-id mapping
-func (a *AuthService) GetAuthAppIdMapAppIdKey(ctx context.Context, key string) (*http.Response, error) {
+func (a *Auth) GetAuthAppIdMapAppIdKey(ctx context.Context, key string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -3760,7 +3762,7 @@ func (a *AuthService) GetAuthAppIdMapAppIdKey(ctx context.Context, key string) (
 
 // GetAuthAppIdMapUserId Read mappings for user-id
 // list: Return a list if &#x60;true&#x60;
-func (a *AuthService) GetAuthAppIdMapUserId(ctx context.Context, list string) (*http.Response, error) {
+func (a *Auth) GetAuthAppIdMapUserId(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -3827,7 +3829,7 @@ func (a *AuthService) GetAuthAppIdMapUserId(ctx context.Context, list string) (*
 
 // GetAuthAppIdMapUserIdKey Read/write/delete a single user-id mapping
 // key: Key for the user-id mapping
-func (a *AuthService) GetAuthAppIdMapUserIdKey(ctx context.Context, key string) (*http.Response, error) {
+func (a *Auth) GetAuthAppIdMapUserIdKey(ctx context.Context, key string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -3894,7 +3896,7 @@ func (a *AuthService) GetAuthAppIdMapUserIdKey(ctx context.Context, key string) 
 
 // GetAuthApproleRole Lists all the roles registered with the backend.
 // list: Must be set to &#x60;true&#x60;
-func (a *AuthService) GetAuthApproleRole(ctx context.Context, list string) (*http.Response, error) {
+func (a *Auth) GetAuthApproleRole(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -3961,7 +3963,7 @@ func (a *AuthService) GetAuthApproleRole(ctx context.Context, list string) (*htt
 
 // GetAuthApproleRoleRoleName Register an role with the backend.
 // roleName: Name of the role.
-func (a *AuthService) GetAuthApproleRoleRoleName(ctx context.Context, roleName string) (*http.Response, error) {
+func (a *Auth) GetAuthApproleRoleRoleName(ctx context.Context, roleName string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -4028,7 +4030,7 @@ func (a *AuthService) GetAuthApproleRoleRoleName(ctx context.Context, roleName s
 
 // GetAuthApproleRoleRoleNameBindSecretId Impose secret_id to be presented during login using this role.
 // roleName: Name of the role.
-func (a *AuthService) GetAuthApproleRoleRoleNameBindSecretId(ctx context.Context, roleName string) (*http.Response, error) {
+func (a *Auth) GetAuthApproleRoleRoleNameBindSecretId(ctx context.Context, roleName string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -4095,7 +4097,7 @@ func (a *AuthService) GetAuthApproleRoleRoleNameBindSecretId(ctx context.Context
 
 // GetAuthApproleRoleRoleNameBoundCidrList Deprecated: Comma separated list of CIDR blocks, if set, specifies blocks of IP addresses which can perform the login operation
 // roleName: Name of the role.
-func (a *AuthService) GetAuthApproleRoleRoleNameBoundCidrList(ctx context.Context, roleName string) (*http.Response, error) {
+func (a *Auth) GetAuthApproleRoleRoleNameBoundCidrList(ctx context.Context, roleName string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -4162,7 +4164,7 @@ func (a *AuthService) GetAuthApproleRoleRoleNameBoundCidrList(ctx context.Contex
 
 // GetAuthApproleRoleRoleNameLocalSecretIds Enables cluster local secret IDs
 // roleName: Name of the role.
-func (a *AuthService) GetAuthApproleRoleRoleNameLocalSecretIds(ctx context.Context, roleName string) (*http.Response, error) {
+func (a *Auth) GetAuthApproleRoleRoleNameLocalSecretIds(ctx context.Context, roleName string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -4229,7 +4231,7 @@ func (a *AuthService) GetAuthApproleRoleRoleNameLocalSecretIds(ctx context.Conte
 
 // GetAuthApproleRoleRoleNamePeriod Updates the value of 'period' on the role
 // roleName: Name of the role.
-func (a *AuthService) GetAuthApproleRoleRoleNamePeriod(ctx context.Context, roleName string) (*http.Response, error) {
+func (a *Auth) GetAuthApproleRoleRoleNamePeriod(ctx context.Context, roleName string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -4296,7 +4298,7 @@ func (a *AuthService) GetAuthApproleRoleRoleNamePeriod(ctx context.Context, role
 
 // GetAuthApproleRoleRoleNamePolicies Policies of the role.
 // roleName: Name of the role.
-func (a *AuthService) GetAuthApproleRoleRoleNamePolicies(ctx context.Context, roleName string) (*http.Response, error) {
+func (a *Auth) GetAuthApproleRoleRoleNamePolicies(ctx context.Context, roleName string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -4363,7 +4365,7 @@ func (a *AuthService) GetAuthApproleRoleRoleNamePolicies(ctx context.Context, ro
 
 // GetAuthApproleRoleRoleNameRoleId Returns the 'role_id' of the role.
 // roleName: Name of the role.
-func (a *AuthService) GetAuthApproleRoleRoleNameRoleId(ctx context.Context, roleName string) (*http.Response, error) {
+func (a *Auth) GetAuthApproleRoleRoleNameRoleId(ctx context.Context, roleName string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -4431,7 +4433,7 @@ func (a *AuthService) GetAuthApproleRoleRoleNameRoleId(ctx context.Context, role
 // GetAuthApproleRoleRoleNameSecretId Generate a SecretID against this role.
 // roleName: Name of the role.
 // list: Must be set to &#x60;true&#x60;
-func (a *AuthService) GetAuthApproleRoleRoleNameSecretId(ctx context.Context, roleName string, list string) (*http.Response, error) {
+func (a *Auth) GetAuthApproleRoleRoleNameSecretId(ctx context.Context, roleName string, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -4499,7 +4501,7 @@ func (a *AuthService) GetAuthApproleRoleRoleNameSecretId(ctx context.Context, ro
 
 // GetAuthApproleRoleRoleNameSecretIdBoundCidrs Comma separated list of CIDR blocks, if set, specifies blocks of IP addresses which can perform the login operation
 // roleName: Name of the role.
-func (a *AuthService) GetAuthApproleRoleRoleNameSecretIdBoundCidrs(ctx context.Context, roleName string) (*http.Response, error) {
+func (a *Auth) GetAuthApproleRoleRoleNameSecretIdBoundCidrs(ctx context.Context, roleName string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -4566,7 +4568,7 @@ func (a *AuthService) GetAuthApproleRoleRoleNameSecretIdBoundCidrs(ctx context.C
 
 // GetAuthApproleRoleRoleNameSecretIdNumUses Use limit of the SecretID generated against the role.
 // roleName: Name of the role.
-func (a *AuthService) GetAuthApproleRoleRoleNameSecretIdNumUses(ctx context.Context, roleName string) (*http.Response, error) {
+func (a *Auth) GetAuthApproleRoleRoleNameSecretIdNumUses(ctx context.Context, roleName string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -4633,7 +4635,7 @@ func (a *AuthService) GetAuthApproleRoleRoleNameSecretIdNumUses(ctx context.Cont
 
 // GetAuthApproleRoleRoleNameSecretIdTtl Duration in seconds, representing the lifetime of the SecretIDs that are generated against the role using 'role/<role_name>/secret-id' or 'role/<role_name>/custom-secret-id' endpoints.
 // roleName: Name of the role.
-func (a *AuthService) GetAuthApproleRoleRoleNameSecretIdTtl(ctx context.Context, roleName string) (*http.Response, error) {
+func (a *Auth) GetAuthApproleRoleRoleNameSecretIdTtl(ctx context.Context, roleName string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -4700,7 +4702,7 @@ func (a *AuthService) GetAuthApproleRoleRoleNameSecretIdTtl(ctx context.Context,
 
 // GetAuthApproleRoleRoleNameTokenBoundCidrs Comma separated string or list of CIDR blocks. If set, specifies the blocks of IP addresses which can use the returned token.
 // roleName: Name of the role.
-func (a *AuthService) GetAuthApproleRoleRoleNameTokenBoundCidrs(ctx context.Context, roleName string) (*http.Response, error) {
+func (a *Auth) GetAuthApproleRoleRoleNameTokenBoundCidrs(ctx context.Context, roleName string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -4767,7 +4769,7 @@ func (a *AuthService) GetAuthApproleRoleRoleNameTokenBoundCidrs(ctx context.Cont
 
 // GetAuthApproleRoleRoleNameTokenMaxTtl Duration in seconds, the maximum lifetime of the tokens issued by using the SecretIDs that were generated against this role, after which the tokens are not allowed to be renewed.
 // roleName: Name of the role.
-func (a *AuthService) GetAuthApproleRoleRoleNameTokenMaxTtl(ctx context.Context, roleName string) (*http.Response, error) {
+func (a *Auth) GetAuthApproleRoleRoleNameTokenMaxTtl(ctx context.Context, roleName string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -4834,7 +4836,7 @@ func (a *AuthService) GetAuthApproleRoleRoleNameTokenMaxTtl(ctx context.Context,
 
 // GetAuthApproleRoleRoleNameTokenNumUses Number of times issued tokens can be used
 // roleName: Name of the role.
-func (a *AuthService) GetAuthApproleRoleRoleNameTokenNumUses(ctx context.Context, roleName string) (*http.Response, error) {
+func (a *Auth) GetAuthApproleRoleRoleNameTokenNumUses(ctx context.Context, roleName string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -4901,7 +4903,7 @@ func (a *AuthService) GetAuthApproleRoleRoleNameTokenNumUses(ctx context.Context
 
 // GetAuthApproleRoleRoleNameTokenTtl Duration in seconds, the lifetime of the token issued by using the SecretID that is generated against this role, before which the token needs to be renewed.
 // roleName: Name of the role.
-func (a *AuthService) GetAuthApproleRoleRoleNameTokenTtl(ctx context.Context, roleName string) (*http.Response, error) {
+func (a *Auth) GetAuthApproleRoleRoleNameTokenTtl(ctx context.Context, roleName string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -4968,7 +4970,7 @@ func (a *AuthService) GetAuthApproleRoleRoleNameTokenTtl(ctx context.Context, ro
 
 // GetAuthAwsConfigCertificateCertName
 // certName: Name of the certificate.
-func (a *AuthService) GetAuthAwsConfigCertificateCertName(ctx context.Context, certName string) (*http.Response, error) {
+func (a *Auth) GetAuthAwsConfigCertificateCertName(ctx context.Context, certName string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -5035,7 +5037,7 @@ func (a *AuthService) GetAuthAwsConfigCertificateCertName(ctx context.Context, c
 
 // GetAuthAwsConfigCertificates
 // list: Must be set to &#x60;true&#x60;
-func (a *AuthService) GetAuthAwsConfigCertificates(ctx context.Context, list string) (*http.Response, error) {
+func (a *Auth) GetAuthAwsConfigCertificates(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -5101,7 +5103,7 @@ func (a *AuthService) GetAuthAwsConfigCertificates(ctx context.Context, list str
 }
 
 // GetAuthAwsConfigClient
-func (a *AuthService) GetAuthAwsConfigClient(ctx context.Context) (*http.Response, error) {
+func (a *Auth) GetAuthAwsConfigClient(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -5166,7 +5168,7 @@ func (a *AuthService) GetAuthAwsConfigClient(ctx context.Context) (*http.Respons
 }
 
 // GetAuthAwsConfigIdentity
-func (a *AuthService) GetAuthAwsConfigIdentity(ctx context.Context) (*http.Response, error) {
+func (a *Auth) GetAuthAwsConfigIdentity(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -5232,7 +5234,7 @@ func (a *AuthService) GetAuthAwsConfigIdentity(ctx context.Context) (*http.Respo
 
 // GetAuthAwsConfigSts
 // list: Must be set to &#x60;true&#x60;
-func (a *AuthService) GetAuthAwsConfigSts(ctx context.Context, list string) (*http.Response, error) {
+func (a *Auth) GetAuthAwsConfigSts(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -5299,7 +5301,7 @@ func (a *AuthService) GetAuthAwsConfigSts(ctx context.Context, list string) (*ht
 
 // GetAuthAwsConfigStsAccountId
 // accountId: AWS account ID to be associated with STS role. If set, Vault will use assumed credentials to verify any login attempts from EC2 instances in this account.
-func (a *AuthService) GetAuthAwsConfigStsAccountId(ctx context.Context, accountId string) (*http.Response, error) {
+func (a *Auth) GetAuthAwsConfigStsAccountId(ctx context.Context, accountId string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -5365,7 +5367,7 @@ func (a *AuthService) GetAuthAwsConfigStsAccountId(ctx context.Context, accountI
 }
 
 // GetAuthAwsConfigTidyIdentityAccesslist
-func (a *AuthService) GetAuthAwsConfigTidyIdentityAccesslist(ctx context.Context) (*http.Response, error) {
+func (a *Auth) GetAuthAwsConfigTidyIdentityAccesslist(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -5430,7 +5432,7 @@ func (a *AuthService) GetAuthAwsConfigTidyIdentityAccesslist(ctx context.Context
 }
 
 // GetAuthAwsConfigTidyIdentityWhitelist
-func (a *AuthService) GetAuthAwsConfigTidyIdentityWhitelist(ctx context.Context) (*http.Response, error) {
+func (a *Auth) GetAuthAwsConfigTidyIdentityWhitelist(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -5495,7 +5497,7 @@ func (a *AuthService) GetAuthAwsConfigTidyIdentityWhitelist(ctx context.Context)
 }
 
 // GetAuthAwsConfigTidyRoletagBlacklist
-func (a *AuthService) GetAuthAwsConfigTidyRoletagBlacklist(ctx context.Context) (*http.Response, error) {
+func (a *Auth) GetAuthAwsConfigTidyRoletagBlacklist(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -5560,7 +5562,7 @@ func (a *AuthService) GetAuthAwsConfigTidyRoletagBlacklist(ctx context.Context) 
 }
 
 // GetAuthAwsConfigTidyRoletagDenylist
-func (a *AuthService) GetAuthAwsConfigTidyRoletagDenylist(ctx context.Context) (*http.Response, error) {
+func (a *Auth) GetAuthAwsConfigTidyRoletagDenylist(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -5626,7 +5628,7 @@ func (a *AuthService) GetAuthAwsConfigTidyRoletagDenylist(ctx context.Context) (
 
 // GetAuthAwsIdentityAccesslist
 // list: Must be set to &#x60;true&#x60;
-func (a *AuthService) GetAuthAwsIdentityAccesslist(ctx context.Context, list string) (*http.Response, error) {
+func (a *Auth) GetAuthAwsIdentityAccesslist(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -5693,7 +5695,7 @@ func (a *AuthService) GetAuthAwsIdentityAccesslist(ctx context.Context, list str
 
 // GetAuthAwsIdentityAccesslistInstanceId
 // instanceId: EC2 instance ID. A successful login operation from an EC2 instance gets cached in this accesslist, keyed off of instance ID.
-func (a *AuthService) GetAuthAwsIdentityAccesslistInstanceId(ctx context.Context, instanceId string) (*http.Response, error) {
+func (a *Auth) GetAuthAwsIdentityAccesslistInstanceId(ctx context.Context, instanceId string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -5760,7 +5762,7 @@ func (a *AuthService) GetAuthAwsIdentityAccesslistInstanceId(ctx context.Context
 
 // GetAuthAwsIdentityWhitelist
 // list: Must be set to &#x60;true&#x60;
-func (a *AuthService) GetAuthAwsIdentityWhitelist(ctx context.Context, list string) (*http.Response, error) {
+func (a *Auth) GetAuthAwsIdentityWhitelist(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -5827,7 +5829,7 @@ func (a *AuthService) GetAuthAwsIdentityWhitelist(ctx context.Context, list stri
 
 // GetAuthAwsIdentityWhitelistInstanceId
 // instanceId: EC2 instance ID. A successful login operation from an EC2 instance gets cached in this accesslist, keyed off of instance ID.
-func (a *AuthService) GetAuthAwsIdentityWhitelistInstanceId(ctx context.Context, instanceId string) (*http.Response, error) {
+func (a *Auth) GetAuthAwsIdentityWhitelistInstanceId(ctx context.Context, instanceId string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -5894,7 +5896,7 @@ func (a *AuthService) GetAuthAwsIdentityWhitelistInstanceId(ctx context.Context,
 
 // GetAuthAwsRole
 // list: Must be set to &#x60;true&#x60;
-func (a *AuthService) GetAuthAwsRole(ctx context.Context, list string) (*http.Response, error) {
+func (a *Auth) GetAuthAwsRole(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -5961,7 +5963,7 @@ func (a *AuthService) GetAuthAwsRole(ctx context.Context, list string) (*http.Re
 
 // GetAuthAwsRoleRole
 // role: Name of the role.
-func (a *AuthService) GetAuthAwsRoleRole(ctx context.Context, role string) (*http.Response, error) {
+func (a *Auth) GetAuthAwsRoleRole(ctx context.Context, role string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -6028,7 +6030,7 @@ func (a *AuthService) GetAuthAwsRoleRole(ctx context.Context, role string) (*htt
 
 // GetAuthAwsRoles
 // list: Must be set to &#x60;true&#x60;
-func (a *AuthService) GetAuthAwsRoles(ctx context.Context, list string) (*http.Response, error) {
+func (a *Auth) GetAuthAwsRoles(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -6095,7 +6097,7 @@ func (a *AuthService) GetAuthAwsRoles(ctx context.Context, list string) (*http.R
 
 // GetAuthAwsRoletagBlacklist
 // list: Must be set to &#x60;true&#x60;
-func (a *AuthService) GetAuthAwsRoletagBlacklist(ctx context.Context, list string) (*http.Response, error) {
+func (a *Auth) GetAuthAwsRoletagBlacklist(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -6162,7 +6164,7 @@ func (a *AuthService) GetAuthAwsRoletagBlacklist(ctx context.Context, list strin
 
 // GetAuthAwsRoletagBlacklistRoleTag
 // roleTag: Role tag to be deny listed. The tag can be supplied as-is. In order to avoid any encoding problems, it can be base64 encoded.
-func (a *AuthService) GetAuthAwsRoletagBlacklistRoleTag(ctx context.Context, roleTag string) (*http.Response, error) {
+func (a *Auth) GetAuthAwsRoletagBlacklistRoleTag(ctx context.Context, roleTag string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -6229,7 +6231,7 @@ func (a *AuthService) GetAuthAwsRoletagBlacklistRoleTag(ctx context.Context, rol
 
 // GetAuthAwsRoletagDenylist
 // list: Must be set to &#x60;true&#x60;
-func (a *AuthService) GetAuthAwsRoletagDenylist(ctx context.Context, list string) (*http.Response, error) {
+func (a *Auth) GetAuthAwsRoletagDenylist(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -6296,7 +6298,7 @@ func (a *AuthService) GetAuthAwsRoletagDenylist(ctx context.Context, list string
 
 // GetAuthAwsRoletagDenylistRoleTag
 // roleTag: Role tag to be deny listed. The tag can be supplied as-is. In order to avoid any encoding problems, it can be base64 encoded.
-func (a *AuthService) GetAuthAwsRoletagDenylistRoleTag(ctx context.Context, roleTag string) (*http.Response, error) {
+func (a *Auth) GetAuthAwsRoletagDenylistRoleTag(ctx context.Context, roleTag string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -6362,7 +6364,7 @@ func (a *AuthService) GetAuthAwsRoletagDenylistRoleTag(ctx context.Context, role
 }
 
 // GetAuthAzureConfig
-func (a *AuthService) GetAuthAzureConfig(ctx context.Context) (*http.Response, error) {
+func (a *Auth) GetAuthAzureConfig(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -6428,7 +6430,7 @@ func (a *AuthService) GetAuthAzureConfig(ctx context.Context) (*http.Response, e
 
 // GetAuthAzureRole
 // list: Must be set to &#x60;true&#x60;
-func (a *AuthService) GetAuthAzureRole(ctx context.Context, list string) (*http.Response, error) {
+func (a *Auth) GetAuthAzureRole(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -6495,7 +6497,7 @@ func (a *AuthService) GetAuthAzureRole(ctx context.Context, list string) (*http.
 
 // GetAuthAzureRoleName
 // name: Name of the role.
-func (a *AuthService) GetAuthAzureRoleName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Auth) GetAuthAzureRoleName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -6561,7 +6563,7 @@ func (a *AuthService) GetAuthAzureRoleName(ctx context.Context, name string) (*h
 }
 
 // GetAuthCentrifyConfig This path allows you to configure the centrify auth provider to interact with the Centrify Identity Services Platform for authenticating users.
-func (a *AuthService) GetAuthCentrifyConfig(ctx context.Context) (*http.Response, error) {
+func (a *Auth) GetAuthCentrifyConfig(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -6627,7 +6629,7 @@ func (a *AuthService) GetAuthCentrifyConfig(ctx context.Context) (*http.Response
 
 // GetAuthCertCerts Manage trusted certificates used for authentication.
 // list: Must be set to &#x60;true&#x60;
-func (a *AuthService) GetAuthCertCerts(ctx context.Context, list string) (*http.Response, error) {
+func (a *Auth) GetAuthCertCerts(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -6694,7 +6696,7 @@ func (a *AuthService) GetAuthCertCerts(ctx context.Context, list string) (*http.
 
 // GetAuthCertCertsName Manage trusted certificates used for authentication.
 // name: The name of the certificate
-func (a *AuthService) GetAuthCertCertsName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Auth) GetAuthCertCertsName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -6761,7 +6763,7 @@ func (a *AuthService) GetAuthCertCertsName(ctx context.Context, name string) (*h
 
 // GetAuthCertCrlsName Manage Certificate Revocation Lists checked during authentication.
 // name: The name of the certificate
-func (a *AuthService) GetAuthCertCrlsName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Auth) GetAuthCertCrlsName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -6827,7 +6829,7 @@ func (a *AuthService) GetAuthCertCrlsName(ctx context.Context, name string) (*ht
 }
 
 // GetAuthCfConfig
-func (a *AuthService) GetAuthCfConfig(ctx context.Context) (*http.Response, error) {
+func (a *Auth) GetAuthCfConfig(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -6893,7 +6895,7 @@ func (a *AuthService) GetAuthCfConfig(ctx context.Context) (*http.Response, erro
 
 // GetAuthCfRoles
 // list: Must be set to &#x60;true&#x60;
-func (a *AuthService) GetAuthCfRoles(ctx context.Context, list string) (*http.Response, error) {
+func (a *Auth) GetAuthCfRoles(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -6960,7 +6962,7 @@ func (a *AuthService) GetAuthCfRoles(ctx context.Context, list string) (*http.Re
 
 // GetAuthCfRolesRole
 // role: The name of the role.
-func (a *AuthService) GetAuthCfRolesRole(ctx context.Context, role string) (*http.Response, error) {
+func (a *Auth) GetAuthCfRolesRole(ctx context.Context, role string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -7026,7 +7028,7 @@ func (a *AuthService) GetAuthCfRolesRole(ctx context.Context, role string) (*htt
 }
 
 // GetAuthGcpConfig Configure credentials used to query the GCP IAM API to verify authenticating service accounts
-func (a *AuthService) GetAuthGcpConfig(ctx context.Context) (*http.Response, error) {
+func (a *Auth) GetAuthGcpConfig(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -7092,7 +7094,7 @@ func (a *AuthService) GetAuthGcpConfig(ctx context.Context) (*http.Response, err
 
 // GetAuthGcpRole Lists all the roles that are registered with Vault.
 // list: Must be set to &#x60;true&#x60;
-func (a *AuthService) GetAuthGcpRole(ctx context.Context, list string) (*http.Response, error) {
+func (a *Auth) GetAuthGcpRole(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -7159,7 +7161,7 @@ func (a *AuthService) GetAuthGcpRole(ctx context.Context, list string) (*http.Re
 
 // GetAuthGcpRoleName Create a GCP role with associated policies and required attributes.
 // name: Name of the role.
-func (a *AuthService) GetAuthGcpRoleName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Auth) GetAuthGcpRoleName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -7226,7 +7228,7 @@ func (a *AuthService) GetAuthGcpRoleName(ctx context.Context, name string) (*htt
 
 // GetAuthGcpRoles Lists all the roles that are registered with Vault.
 // list: Must be set to &#x60;true&#x60;
-func (a *AuthService) GetAuthGcpRoles(ctx context.Context, list string) (*http.Response, error) {
+func (a *Auth) GetAuthGcpRoles(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -7292,7 +7294,7 @@ func (a *AuthService) GetAuthGcpRoles(ctx context.Context, list string) (*http.R
 }
 
 // GetAuthGithubConfig
-func (a *AuthService) GetAuthGithubConfig(ctx context.Context) (*http.Response, error) {
+func (a *Auth) GetAuthGithubConfig(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -7358,7 +7360,7 @@ func (a *AuthService) GetAuthGithubConfig(ctx context.Context) (*http.Response, 
 
 // GetAuthGithubMapTeams Read mappings for teams
 // list: Return a list if &#x60;true&#x60;
-func (a *AuthService) GetAuthGithubMapTeams(ctx context.Context, list string) (*http.Response, error) {
+func (a *Auth) GetAuthGithubMapTeams(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -7425,7 +7427,7 @@ func (a *AuthService) GetAuthGithubMapTeams(ctx context.Context, list string) (*
 
 // GetAuthGithubMapTeamsKey Read/write/delete a single teams mapping
 // key: Key for the teams mapping
-func (a *AuthService) GetAuthGithubMapTeamsKey(ctx context.Context, key string) (*http.Response, error) {
+func (a *Auth) GetAuthGithubMapTeamsKey(ctx context.Context, key string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -7492,7 +7494,7 @@ func (a *AuthService) GetAuthGithubMapTeamsKey(ctx context.Context, key string) 
 
 // GetAuthGithubMapUsers Read mappings for users
 // list: Return a list if &#x60;true&#x60;
-func (a *AuthService) GetAuthGithubMapUsers(ctx context.Context, list string) (*http.Response, error) {
+func (a *Auth) GetAuthGithubMapUsers(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -7559,7 +7561,7 @@ func (a *AuthService) GetAuthGithubMapUsers(ctx context.Context, list string) (*
 
 // GetAuthGithubMapUsersKey Read/write/delete a single users mapping
 // key: Key for the users mapping
-func (a *AuthService) GetAuthGithubMapUsersKey(ctx context.Context, key string) (*http.Response, error) {
+func (a *Auth) GetAuthGithubMapUsersKey(ctx context.Context, key string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -7625,7 +7627,7 @@ func (a *AuthService) GetAuthGithubMapUsersKey(ctx context.Context, key string) 
 }
 
 // GetAuthJwtConfig Read the current JWT authentication backend configuration.
-func (a *AuthService) GetAuthJwtConfig(ctx context.Context) (*http.Response, error) {
+func (a *Auth) GetAuthJwtConfig(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -7690,7 +7692,7 @@ func (a *AuthService) GetAuthJwtConfig(ctx context.Context) (*http.Response, err
 }
 
 // GetAuthJwtOidcCallback Callback endpoint to complete an OIDC login.
-func (a *AuthService) GetAuthJwtOidcCallback(ctx context.Context) (*http.Response, error) {
+func (a *Auth) GetAuthJwtOidcCallback(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -7757,7 +7759,7 @@ func (a *AuthService) GetAuthJwtOidcCallback(ctx context.Context) (*http.Respons
 // GetAuthJwtRole Lists all the roles registered with the backend.
 // The list will contain the names of the roles.
 // list: Must be set to &#x60;true&#x60;
-func (a *AuthService) GetAuthJwtRole(ctx context.Context, list string) (*http.Response, error) {
+func (a *Auth) GetAuthJwtRole(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -7824,7 +7826,7 @@ func (a *AuthService) GetAuthJwtRole(ctx context.Context, list string) (*http.Re
 
 // GetAuthJwtRoleName Read an existing role.
 // name: Name of the role.
-func (a *AuthService) GetAuthJwtRoleName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Auth) GetAuthJwtRoleName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -7890,7 +7892,7 @@ func (a *AuthService) GetAuthJwtRoleName(ctx context.Context, name string) (*htt
 }
 
 // GetAuthKerberosConfig
-func (a *AuthService) GetAuthKerberosConfig(ctx context.Context) (*http.Response, error) {
+func (a *Auth) GetAuthKerberosConfig(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -7955,7 +7957,7 @@ func (a *AuthService) GetAuthKerberosConfig(ctx context.Context) (*http.Response
 }
 
 // GetAuthKerberosConfigLdap
-func (a *AuthService) GetAuthKerberosConfigLdap(ctx context.Context) (*http.Response, error) {
+func (a *Auth) GetAuthKerberosConfigLdap(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -8021,7 +8023,7 @@ func (a *AuthService) GetAuthKerberosConfigLdap(ctx context.Context) (*http.Resp
 
 // GetAuthKerberosGroups
 // list: Must be set to &#x60;true&#x60;
-func (a *AuthService) GetAuthKerberosGroups(ctx context.Context, list string) (*http.Response, error) {
+func (a *Auth) GetAuthKerberosGroups(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -8088,7 +8090,7 @@ func (a *AuthService) GetAuthKerberosGroups(ctx context.Context, list string) (*
 
 // GetAuthKerberosGroupsName
 // name: Name of the LDAP group.
-func (a *AuthService) GetAuthKerberosGroupsName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Auth) GetAuthKerberosGroupsName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -8154,7 +8156,7 @@ func (a *AuthService) GetAuthKerberosGroupsName(ctx context.Context, name string
 }
 
 // GetAuthKerberosLogin
-func (a *AuthService) GetAuthKerberosLogin(ctx context.Context) (*http.Response, error) {
+func (a *Auth) GetAuthKerberosLogin(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -8219,7 +8221,7 @@ func (a *AuthService) GetAuthKerberosLogin(ctx context.Context) (*http.Response,
 }
 
 // GetAuthKubernetesConfig Configures the JWT Public Key and Kubernetes API information.
-func (a *AuthService) GetAuthKubernetesConfig(ctx context.Context) (*http.Response, error) {
+func (a *Auth) GetAuthKubernetesConfig(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -8285,7 +8287,7 @@ func (a *AuthService) GetAuthKubernetesConfig(ctx context.Context) (*http.Respon
 
 // GetAuthKubernetesRole Lists all the roles registered with the backend.
 // list: Must be set to &#x60;true&#x60;
-func (a *AuthService) GetAuthKubernetesRole(ctx context.Context, list string) (*http.Response, error) {
+func (a *Auth) GetAuthKubernetesRole(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -8352,7 +8354,7 @@ func (a *AuthService) GetAuthKubernetesRole(ctx context.Context, list string) (*
 
 // GetAuthKubernetesRoleName Register an role with the backend.
 // name: Name of the role.
-func (a *AuthService) GetAuthKubernetesRoleName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Auth) GetAuthKubernetesRoleName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -8418,7 +8420,7 @@ func (a *AuthService) GetAuthKubernetesRoleName(ctx context.Context, name string
 }
 
 // GetAuthLdapConfig Configure the LDAP server to connect to, along with its options.
-func (a *AuthService) GetAuthLdapConfig(ctx context.Context) (*http.Response, error) {
+func (a *Auth) GetAuthLdapConfig(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -8484,7 +8486,7 @@ func (a *AuthService) GetAuthLdapConfig(ctx context.Context) (*http.Response, er
 
 // GetAuthLdapGroups Manage additional groups for users allowed to authenticate.
 // list: Must be set to &#x60;true&#x60;
-func (a *AuthService) GetAuthLdapGroups(ctx context.Context, list string) (*http.Response, error) {
+func (a *Auth) GetAuthLdapGroups(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -8551,7 +8553,7 @@ func (a *AuthService) GetAuthLdapGroups(ctx context.Context, list string) (*http
 
 // GetAuthLdapGroupsName Manage additional groups for users allowed to authenticate.
 // name: Name of the LDAP group.
-func (a *AuthService) GetAuthLdapGroupsName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Auth) GetAuthLdapGroupsName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -8618,7 +8620,7 @@ func (a *AuthService) GetAuthLdapGroupsName(ctx context.Context, name string) (*
 
 // GetAuthLdapUsers Manage users allowed to authenticate.
 // list: Must be set to &#x60;true&#x60;
-func (a *AuthService) GetAuthLdapUsers(ctx context.Context, list string) (*http.Response, error) {
+func (a *Auth) GetAuthLdapUsers(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -8685,7 +8687,7 @@ func (a *AuthService) GetAuthLdapUsers(ctx context.Context, list string) (*http.
 
 // GetAuthLdapUsersName Manage users allowed to authenticate.
 // name: Name of the LDAP user.
-func (a *AuthService) GetAuthLdapUsersName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Auth) GetAuthLdapUsersName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -8751,7 +8753,7 @@ func (a *AuthService) GetAuthLdapUsersName(ctx context.Context, name string) (*h
 }
 
 // GetAuthOciConfig Manages the configuration for the Vault Auth Plugin.
-func (a *AuthService) GetAuthOciConfig(ctx context.Context) (*http.Response, error) {
+func (a *Auth) GetAuthOciConfig(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -8817,7 +8819,7 @@ func (a *AuthService) GetAuthOciConfig(ctx context.Context) (*http.Response, err
 
 // GetAuthOciRole Lists all the roles that are registered with Vault.
 // list: Must be set to &#x60;true&#x60;
-func (a *AuthService) GetAuthOciRole(ctx context.Context, list string) (*http.Response, error) {
+func (a *Auth) GetAuthOciRole(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -8884,7 +8886,7 @@ func (a *AuthService) GetAuthOciRole(ctx context.Context, list string) (*http.Re
 
 // GetAuthOciRoleRole Create a role and associate policies to it.
 // role: Name of the role.
-func (a *AuthService) GetAuthOciRoleRole(ctx context.Context, role string) (*http.Response, error) {
+func (a *Auth) GetAuthOciRoleRole(ctx context.Context, role string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -8950,7 +8952,7 @@ func (a *AuthService) GetAuthOciRoleRole(ctx context.Context, role string) (*htt
 }
 
 // GetAuthOidcConfig Read the current JWT authentication backend configuration.
-func (a *AuthService) GetAuthOidcConfig(ctx context.Context) (*http.Response, error) {
+func (a *Auth) GetAuthOidcConfig(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -9015,7 +9017,7 @@ func (a *AuthService) GetAuthOidcConfig(ctx context.Context) (*http.Response, er
 }
 
 // GetAuthOidcOidcCallback Callback endpoint to complete an OIDC login.
-func (a *AuthService) GetAuthOidcOidcCallback(ctx context.Context) (*http.Response, error) {
+func (a *Auth) GetAuthOidcOidcCallback(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -9082,7 +9084,7 @@ func (a *AuthService) GetAuthOidcOidcCallback(ctx context.Context) (*http.Respon
 // GetAuthOidcRole Lists all the roles registered with the backend.
 // The list will contain the names of the roles.
 // list: Must be set to &#x60;true&#x60;
-func (a *AuthService) GetAuthOidcRole(ctx context.Context, list string) (*http.Response, error) {
+func (a *Auth) GetAuthOidcRole(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -9149,7 +9151,7 @@ func (a *AuthService) GetAuthOidcRole(ctx context.Context, list string) (*http.R
 
 // GetAuthOidcRoleName Read an existing role.
 // name: Name of the role.
-func (a *AuthService) GetAuthOidcRoleName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Auth) GetAuthOidcRoleName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -9215,7 +9217,7 @@ func (a *AuthService) GetAuthOidcRoleName(ctx context.Context, name string) (*ht
 }
 
 // GetAuthOktaConfig This endpoint allows you to configure the Okta and its configuration options.  The Okta organization are the characters at the front of the URL for Okta. Example https://ORG.okta.com
-func (a *AuthService) GetAuthOktaConfig(ctx context.Context) (*http.Response, error) {
+func (a *Auth) GetAuthOktaConfig(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -9281,7 +9283,7 @@ func (a *AuthService) GetAuthOktaConfig(ctx context.Context) (*http.Response, er
 
 // GetAuthOktaGroups Manage users allowed to authenticate.
 // list: Must be set to &#x60;true&#x60;
-func (a *AuthService) GetAuthOktaGroups(ctx context.Context, list string) (*http.Response, error) {
+func (a *Auth) GetAuthOktaGroups(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -9348,7 +9350,7 @@ func (a *AuthService) GetAuthOktaGroups(ctx context.Context, list string) (*http
 
 // GetAuthOktaGroupsName Manage users allowed to authenticate.
 // name: Name of the Okta group.
-func (a *AuthService) GetAuthOktaGroupsName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Auth) GetAuthOktaGroupsName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -9415,7 +9417,7 @@ func (a *AuthService) GetAuthOktaGroupsName(ctx context.Context, name string) (*
 
 // GetAuthOktaUsers Manage additional groups for users allowed to authenticate.
 // list: Must be set to &#x60;true&#x60;
-func (a *AuthService) GetAuthOktaUsers(ctx context.Context, list string) (*http.Response, error) {
+func (a *Auth) GetAuthOktaUsers(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -9482,7 +9484,7 @@ func (a *AuthService) GetAuthOktaUsers(ctx context.Context, list string) (*http.
 
 // GetAuthOktaUsersName Manage additional groups for users allowed to authenticate.
 // name: Name of the user.
-func (a *AuthService) GetAuthOktaUsersName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Auth) GetAuthOktaUsersName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -9549,7 +9551,7 @@ func (a *AuthService) GetAuthOktaUsersName(ctx context.Context, name string) (*h
 
 // GetAuthOktaVerifyNonce
 // nonce: Nonce provided during a login request to retrieve the number verification challenge for the matching request.
-func (a *AuthService) GetAuthOktaVerifyNonce(ctx context.Context, nonce string) (*http.Response, error) {
+func (a *Auth) GetAuthOktaVerifyNonce(ctx context.Context, nonce string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -9615,7 +9617,7 @@ func (a *AuthService) GetAuthOktaVerifyNonce(ctx context.Context, nonce string) 
 }
 
 // GetAuthRadiusConfig Configure the RADIUS server to connect to, along with its options.
-func (a *AuthService) GetAuthRadiusConfig(ctx context.Context) (*http.Response, error) {
+func (a *Auth) GetAuthRadiusConfig(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -9681,7 +9683,7 @@ func (a *AuthService) GetAuthRadiusConfig(ctx context.Context) (*http.Response, 
 
 // GetAuthRadiusUsers Manage users allowed to authenticate.
 // list: Must be set to &#x60;true&#x60;
-func (a *AuthService) GetAuthRadiusUsers(ctx context.Context, list string) (*http.Response, error) {
+func (a *Auth) GetAuthRadiusUsers(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -9748,7 +9750,7 @@ func (a *AuthService) GetAuthRadiusUsers(ctx context.Context, list string) (*htt
 
 // GetAuthRadiusUsersName Manage users allowed to authenticate.
 // name: Name of the RADIUS user.
-func (a *AuthService) GetAuthRadiusUsersName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Auth) GetAuthRadiusUsersName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -9815,7 +9817,7 @@ func (a *AuthService) GetAuthRadiusUsersName(ctx context.Context, name string) (
 
 // GetAuthTokenAccessors List token accessors, which can then be be used to iterate and discover their properties or revoke them. Because this can be used to cause a denial of service, this endpoint requires 'sudo' capability in addition to 'list'.
 // list: Must be set to &#x60;true&#x60;
-func (a *AuthService) GetAuthTokenAccessors(ctx context.Context, list string) (*http.Response, error) {
+func (a *Auth) GetAuthTokenAccessors(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -9881,7 +9883,7 @@ func (a *AuthService) GetAuthTokenAccessors(ctx context.Context, list string) (*
 }
 
 // GetAuthTokenLookup This endpoint will lookup a token and its properties.
-func (a *AuthService) GetAuthTokenLookup(ctx context.Context) (*http.Response, error) {
+func (a *Auth) GetAuthTokenLookup(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -9946,7 +9948,7 @@ func (a *AuthService) GetAuthTokenLookup(ctx context.Context) (*http.Response, e
 }
 
 // GetAuthTokenLookupSelf This endpoint will lookup a token and its properties.
-func (a *AuthService) GetAuthTokenLookupSelf(ctx context.Context) (*http.Response, error) {
+func (a *Auth) GetAuthTokenLookupSelf(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -10012,7 +10014,7 @@ func (a *AuthService) GetAuthTokenLookupSelf(ctx context.Context) (*http.Respons
 
 // GetAuthTokenRoles This endpoint lists configured roles.
 // list: Must be set to &#x60;true&#x60;
-func (a *AuthService) GetAuthTokenRoles(ctx context.Context, list string) (*http.Response, error) {
+func (a *Auth) GetAuthTokenRoles(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -10079,7 +10081,7 @@ func (a *AuthService) GetAuthTokenRoles(ctx context.Context, list string) (*http
 
 // GetAuthTokenRolesRoleName
 // roleName: Name of the role
-func (a *AuthService) GetAuthTokenRolesRoleName(ctx context.Context, roleName string) (*http.Response, error) {
+func (a *Auth) GetAuthTokenRolesRoleName(ctx context.Context, roleName string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -10146,7 +10148,7 @@ func (a *AuthService) GetAuthTokenRolesRoleName(ctx context.Context, roleName st
 
 // GetAuthUserpassUsers Manage users allowed to authenticate.
 // list: Must be set to &#x60;true&#x60;
-func (a *AuthService) GetAuthUserpassUsers(ctx context.Context, list string) (*http.Response, error) {
+func (a *Auth) GetAuthUserpassUsers(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -10213,7 +10215,7 @@ func (a *AuthService) GetAuthUserpassUsers(ctx context.Context, list string) (*h
 
 // GetAuthUserpassUsersUsername Manage users allowed to authenticate.
 // username: Username for this user.
-func (a *AuthService) GetAuthUserpassUsersUsername(ctx context.Context, username string) (*http.Response, error) {
+func (a *Auth) GetAuthUserpassUsersUsername(ctx context.Context, username string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -10279,7 +10281,7 @@ func (a *AuthService) GetAuthUserpassUsersUsername(ctx context.Context, username
 }
 
 // PostAuthAlicloudLogin Authenticates an RAM entity with Vault.
-func (a *AuthService) PostAuthAlicloudLogin(ctx context.Context, alicloudLoginRequest AlicloudLoginRequest) (*http.Response, error) {
+func (a *Auth) PostAuthAlicloudLogin(ctx context.Context, alicloudLoginRequest AlicloudLoginRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -10347,7 +10349,7 @@ func (a *AuthService) PostAuthAlicloudLogin(ctx context.Context, alicloudLoginRe
 
 // PostAuthAlicloudRoleRole Create a role and associate policies to it.
 // role: The name of the role as it should appear in Vault.
-func (a *AuthService) PostAuthAlicloudRoleRole(ctx context.Context, role string, alicloudRoleRequest AlicloudRoleRequest) (*http.Response, error) {
+func (a *Auth) PostAuthAlicloudRoleRole(ctx context.Context, role string, alicloudRoleRequest AlicloudRoleRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -10415,7 +10417,7 @@ func (a *AuthService) PostAuthAlicloudRoleRole(ctx context.Context, role string,
 }
 
 // PostAuthAppIdLogin Log in with an App ID and User ID.
-func (a *AuthService) PostAuthAppIdLogin(ctx context.Context, appIdLoginRequest AppIdLoginRequest) (*http.Response, error) {
+func (a *Auth) PostAuthAppIdLogin(ctx context.Context, appIdLoginRequest AppIdLoginRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -10483,7 +10485,7 @@ func (a *AuthService) PostAuthAppIdLogin(ctx context.Context, appIdLoginRequest 
 
 // PostAuthAppIdLoginAppId Log in with an App ID and User ID.
 // appId: The unique app ID
-func (a *AuthService) PostAuthAppIdLoginAppId(ctx context.Context, appId string, appIdLoginRequest AppIdLoginRequest) (*http.Response, error) {
+func (a *Auth) PostAuthAppIdLoginAppId(ctx context.Context, appId string, appIdLoginRequest AppIdLoginRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -10552,7 +10554,7 @@ func (a *AuthService) PostAuthAppIdLoginAppId(ctx context.Context, appId string,
 
 // PostAuthAppIdMapAppIdKey Read/write/delete a single app-id mapping
 // key: Key for the app-id mapping
-func (a *AuthService) PostAuthAppIdMapAppIdKey(ctx context.Context, key string, appIdMapAppIdRequest AppIdMapAppIdRequest) (*http.Response, error) {
+func (a *Auth) PostAuthAppIdMapAppIdKey(ctx context.Context, key string, appIdMapAppIdRequest AppIdMapAppIdRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -10621,7 +10623,7 @@ func (a *AuthService) PostAuthAppIdMapAppIdKey(ctx context.Context, key string, 
 
 // PostAuthAppIdMapUserIdKey Read/write/delete a single user-id mapping
 // key: Key for the user-id mapping
-func (a *AuthService) PostAuthAppIdMapUserIdKey(ctx context.Context, key string, appIdMapUserIdRequest AppIdMapUserIdRequest) (*http.Response, error) {
+func (a *Auth) PostAuthAppIdMapUserIdKey(ctx context.Context, key string, appIdMapUserIdRequest AppIdMapUserIdRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -10689,7 +10691,7 @@ func (a *AuthService) PostAuthAppIdMapUserIdKey(ctx context.Context, key string,
 }
 
 // PostAuthApproleLogin
-func (a *AuthService) PostAuthApproleLogin(ctx context.Context, approleLoginRequest ApproleLoginRequest) (*http.Response, error) {
+func (a *Auth) PostAuthApproleLogin(ctx context.Context, approleLoginRequest ApproleLoginRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -10757,7 +10759,7 @@ func (a *AuthService) PostAuthApproleLogin(ctx context.Context, approleLoginRequ
 
 // PostAuthApproleRoleRoleName Register an role with the backend.
 // roleName: Name of the role.
-func (a *AuthService) PostAuthApproleRoleRoleName(ctx context.Context, roleName string, approleRoleRequest ApproleRoleRequest) (*http.Response, error) {
+func (a *Auth) PostAuthApproleRoleRoleName(ctx context.Context, roleName string, approleRoleRequest ApproleRoleRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -10826,7 +10828,7 @@ func (a *AuthService) PostAuthApproleRoleRoleName(ctx context.Context, roleName 
 
 // PostAuthApproleRoleRoleNameBindSecretId Impose secret_id to be presented during login using this role.
 // roleName: Name of the role.
-func (a *AuthService) PostAuthApproleRoleRoleNameBindSecretId(ctx context.Context, roleName string, approleRoleBindSecretIdRequest ApproleRoleBindSecretIdRequest) (*http.Response, error) {
+func (a *Auth) PostAuthApproleRoleRoleNameBindSecretId(ctx context.Context, roleName string, approleRoleBindSecretIdRequest ApproleRoleBindSecretIdRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -10895,7 +10897,7 @@ func (a *AuthService) PostAuthApproleRoleRoleNameBindSecretId(ctx context.Contex
 
 // PostAuthApproleRoleRoleNameBoundCidrList Deprecated: Comma separated list of CIDR blocks, if set, specifies blocks of IP addresses which can perform the login operation
 // roleName: Name of the role.
-func (a *AuthService) PostAuthApproleRoleRoleNameBoundCidrList(ctx context.Context, roleName string, approleRoleBoundCidrListRequest ApproleRoleBoundCidrListRequest) (*http.Response, error) {
+func (a *Auth) PostAuthApproleRoleRoleNameBoundCidrList(ctx context.Context, roleName string, approleRoleBoundCidrListRequest ApproleRoleBoundCidrListRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -10964,7 +10966,7 @@ func (a *AuthService) PostAuthApproleRoleRoleNameBoundCidrList(ctx context.Conte
 
 // PostAuthApproleRoleRoleNameCustomSecretId Assign a SecretID of choice against the role.
 // roleName: Name of the role.
-func (a *AuthService) PostAuthApproleRoleRoleNameCustomSecretId(ctx context.Context, roleName string, approleRoleCustomSecretIdRequest ApproleRoleCustomSecretIdRequest) (*http.Response, error) {
+func (a *Auth) PostAuthApproleRoleRoleNameCustomSecretId(ctx context.Context, roleName string, approleRoleCustomSecretIdRequest ApproleRoleCustomSecretIdRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -11033,7 +11035,7 @@ func (a *AuthService) PostAuthApproleRoleRoleNameCustomSecretId(ctx context.Cont
 
 // PostAuthApproleRoleRoleNamePeriod Updates the value of 'period' on the role
 // roleName: Name of the role.
-func (a *AuthService) PostAuthApproleRoleRoleNamePeriod(ctx context.Context, roleName string, approleRolePeriodRequest ApproleRolePeriodRequest) (*http.Response, error) {
+func (a *Auth) PostAuthApproleRoleRoleNamePeriod(ctx context.Context, roleName string, approleRolePeriodRequest ApproleRolePeriodRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -11102,7 +11104,7 @@ func (a *AuthService) PostAuthApproleRoleRoleNamePeriod(ctx context.Context, rol
 
 // PostAuthApproleRoleRoleNamePolicies Policies of the role.
 // roleName: Name of the role.
-func (a *AuthService) PostAuthApproleRoleRoleNamePolicies(ctx context.Context, roleName string, approleRolePoliciesRequest ApproleRolePoliciesRequest) (*http.Response, error) {
+func (a *Auth) PostAuthApproleRoleRoleNamePolicies(ctx context.Context, roleName string, approleRolePoliciesRequest ApproleRolePoliciesRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -11171,7 +11173,7 @@ func (a *AuthService) PostAuthApproleRoleRoleNamePolicies(ctx context.Context, r
 
 // PostAuthApproleRoleRoleNameRoleId Returns the 'role_id' of the role.
 // roleName: Name of the role.
-func (a *AuthService) PostAuthApproleRoleRoleNameRoleId(ctx context.Context, roleName string, approleRoleRoleIdRequest ApproleRoleRoleIdRequest) (*http.Response, error) {
+func (a *Auth) PostAuthApproleRoleRoleNameRoleId(ctx context.Context, roleName string, approleRoleRoleIdRequest ApproleRoleRoleIdRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -11240,7 +11242,7 @@ func (a *AuthService) PostAuthApproleRoleRoleNameRoleId(ctx context.Context, rol
 
 // PostAuthApproleRoleRoleNameSecretId Generate a SecretID against this role.
 // roleName: Name of the role.
-func (a *AuthService) PostAuthApproleRoleRoleNameSecretId(ctx context.Context, roleName string, approleRoleSecretIdRequest ApproleRoleSecretIdRequest) (*http.Response, error) {
+func (a *Auth) PostAuthApproleRoleRoleNameSecretId(ctx context.Context, roleName string, approleRoleSecretIdRequest ApproleRoleSecretIdRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -11309,7 +11311,7 @@ func (a *AuthService) PostAuthApproleRoleRoleNameSecretId(ctx context.Context, r
 
 // PostAuthApproleRoleRoleNameSecretIdAccessorDestroy
 // roleName: Name of the role.
-func (a *AuthService) PostAuthApproleRoleRoleNameSecretIdAccessorDestroy(ctx context.Context, roleName string, approleRoleSecretIdAccessorDestroyRequest ApproleRoleSecretIdAccessorDestroyRequest) (*http.Response, error) {
+func (a *Auth) PostAuthApproleRoleRoleNameSecretIdAccessorDestroy(ctx context.Context, roleName string, approleRoleSecretIdAccessorDestroyRequest ApproleRoleSecretIdAccessorDestroyRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -11378,7 +11380,7 @@ func (a *AuthService) PostAuthApproleRoleRoleNameSecretIdAccessorDestroy(ctx con
 
 // PostAuthApproleRoleRoleNameSecretIdAccessorLookup
 // roleName: Name of the role.
-func (a *AuthService) PostAuthApproleRoleRoleNameSecretIdAccessorLookup(ctx context.Context, roleName string, approleRoleSecretIdAccessorLookupRequest ApproleRoleSecretIdAccessorLookupRequest) (*http.Response, error) {
+func (a *Auth) PostAuthApproleRoleRoleNameSecretIdAccessorLookup(ctx context.Context, roleName string, approleRoleSecretIdAccessorLookupRequest ApproleRoleSecretIdAccessorLookupRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -11447,7 +11449,7 @@ func (a *AuthService) PostAuthApproleRoleRoleNameSecretIdAccessorLookup(ctx cont
 
 // PostAuthApproleRoleRoleNameSecretIdBoundCidrs Comma separated list of CIDR blocks, if set, specifies blocks of IP addresses which can perform the login operation
 // roleName: Name of the role.
-func (a *AuthService) PostAuthApproleRoleRoleNameSecretIdBoundCidrs(ctx context.Context, roleName string, approleRoleSecretIdBoundCidrsRequest ApproleRoleSecretIdBoundCidrsRequest) (*http.Response, error) {
+func (a *Auth) PostAuthApproleRoleRoleNameSecretIdBoundCidrs(ctx context.Context, roleName string, approleRoleSecretIdBoundCidrsRequest ApproleRoleSecretIdBoundCidrsRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -11516,7 +11518,7 @@ func (a *AuthService) PostAuthApproleRoleRoleNameSecretIdBoundCidrs(ctx context.
 
 // PostAuthApproleRoleRoleNameSecretIdDestroy Invalidate an issued secret_id
 // roleName: Name of the role.
-func (a *AuthService) PostAuthApproleRoleRoleNameSecretIdDestroy(ctx context.Context, roleName string, approleRoleSecretIdDestroyRequest ApproleRoleSecretIdDestroyRequest) (*http.Response, error) {
+func (a *Auth) PostAuthApproleRoleRoleNameSecretIdDestroy(ctx context.Context, roleName string, approleRoleSecretIdDestroyRequest ApproleRoleSecretIdDestroyRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -11585,7 +11587,7 @@ func (a *AuthService) PostAuthApproleRoleRoleNameSecretIdDestroy(ctx context.Con
 
 // PostAuthApproleRoleRoleNameSecretIdLookup Read the properties of an issued secret_id
 // roleName: Name of the role.
-func (a *AuthService) PostAuthApproleRoleRoleNameSecretIdLookup(ctx context.Context, roleName string, approleRoleSecretIdLookupRequest ApproleRoleSecretIdLookupRequest) (*http.Response, error) {
+func (a *Auth) PostAuthApproleRoleRoleNameSecretIdLookup(ctx context.Context, roleName string, approleRoleSecretIdLookupRequest ApproleRoleSecretIdLookupRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -11654,7 +11656,7 @@ func (a *AuthService) PostAuthApproleRoleRoleNameSecretIdLookup(ctx context.Cont
 
 // PostAuthApproleRoleRoleNameSecretIdNumUses Use limit of the SecretID generated against the role.
 // roleName: Name of the role.
-func (a *AuthService) PostAuthApproleRoleRoleNameSecretIdNumUses(ctx context.Context, roleName string, approleRoleSecretIdNumUsesRequest ApproleRoleSecretIdNumUsesRequest) (*http.Response, error) {
+func (a *Auth) PostAuthApproleRoleRoleNameSecretIdNumUses(ctx context.Context, roleName string, approleRoleSecretIdNumUsesRequest ApproleRoleSecretIdNumUsesRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -11723,7 +11725,7 @@ func (a *AuthService) PostAuthApproleRoleRoleNameSecretIdNumUses(ctx context.Con
 
 // PostAuthApproleRoleRoleNameSecretIdTtl Duration in seconds, representing the lifetime of the SecretIDs that are generated against the role using 'role/<role_name>/secret-id' or 'role/<role_name>/custom-secret-id' endpoints.
 // roleName: Name of the role.
-func (a *AuthService) PostAuthApproleRoleRoleNameSecretIdTtl(ctx context.Context, roleName string, approleRoleSecretIdTtlRequest ApproleRoleSecretIdTtlRequest) (*http.Response, error) {
+func (a *Auth) PostAuthApproleRoleRoleNameSecretIdTtl(ctx context.Context, roleName string, approleRoleSecretIdTtlRequest ApproleRoleSecretIdTtlRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -11792,7 +11794,7 @@ func (a *AuthService) PostAuthApproleRoleRoleNameSecretIdTtl(ctx context.Context
 
 // PostAuthApproleRoleRoleNameTokenBoundCidrs Comma separated string or list of CIDR blocks. If set, specifies the blocks of IP addresses which can use the returned token.
 // roleName: Name of the role.
-func (a *AuthService) PostAuthApproleRoleRoleNameTokenBoundCidrs(ctx context.Context, roleName string, approleRoleTokenBoundCidrsRequest ApproleRoleTokenBoundCidrsRequest) (*http.Response, error) {
+func (a *Auth) PostAuthApproleRoleRoleNameTokenBoundCidrs(ctx context.Context, roleName string, approleRoleTokenBoundCidrsRequest ApproleRoleTokenBoundCidrsRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -11861,7 +11863,7 @@ func (a *AuthService) PostAuthApproleRoleRoleNameTokenBoundCidrs(ctx context.Con
 
 // PostAuthApproleRoleRoleNameTokenMaxTtl Duration in seconds, the maximum lifetime of the tokens issued by using the SecretIDs that were generated against this role, after which the tokens are not allowed to be renewed.
 // roleName: Name of the role.
-func (a *AuthService) PostAuthApproleRoleRoleNameTokenMaxTtl(ctx context.Context, roleName string, approleRoleTokenMaxTtlRequest ApproleRoleTokenMaxTtlRequest) (*http.Response, error) {
+func (a *Auth) PostAuthApproleRoleRoleNameTokenMaxTtl(ctx context.Context, roleName string, approleRoleTokenMaxTtlRequest ApproleRoleTokenMaxTtlRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -11930,7 +11932,7 @@ func (a *AuthService) PostAuthApproleRoleRoleNameTokenMaxTtl(ctx context.Context
 
 // PostAuthApproleRoleRoleNameTokenNumUses Number of times issued tokens can be used
 // roleName: Name of the role.
-func (a *AuthService) PostAuthApproleRoleRoleNameTokenNumUses(ctx context.Context, roleName string, approleRoleTokenNumUsesRequest ApproleRoleTokenNumUsesRequest) (*http.Response, error) {
+func (a *Auth) PostAuthApproleRoleRoleNameTokenNumUses(ctx context.Context, roleName string, approleRoleTokenNumUsesRequest ApproleRoleTokenNumUsesRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -11999,7 +12001,7 @@ func (a *AuthService) PostAuthApproleRoleRoleNameTokenNumUses(ctx context.Contex
 
 // PostAuthApproleRoleRoleNameTokenTtl Duration in seconds, the lifetime of the token issued by using the SecretID that is generated against this role, before which the token needs to be renewed.
 // roleName: Name of the role.
-func (a *AuthService) PostAuthApproleRoleRoleNameTokenTtl(ctx context.Context, roleName string, approleRoleTokenTtlRequest ApproleRoleTokenTtlRequest) (*http.Response, error) {
+func (a *Auth) PostAuthApproleRoleRoleNameTokenTtl(ctx context.Context, roleName string, approleRoleTokenTtlRequest ApproleRoleTokenTtlRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -12067,7 +12069,7 @@ func (a *AuthService) PostAuthApproleRoleRoleNameTokenTtl(ctx context.Context, r
 }
 
 // PostAuthApproleTidySecretId Trigger the clean-up of expired SecretID entries.
-func (a *AuthService) PostAuthApproleTidySecretId(ctx context.Context) (*http.Response, error) {
+func (a *Auth) PostAuthApproleTidySecretId(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -12133,7 +12135,7 @@ func (a *AuthService) PostAuthApproleTidySecretId(ctx context.Context) (*http.Re
 
 // PostAuthAwsConfigCertificateCertName
 // certName: Name of the certificate.
-func (a *AuthService) PostAuthAwsConfigCertificateCertName(ctx context.Context, certName string, awsConfigCertificateRequest AwsConfigCertificateRequest) (*http.Response, error) {
+func (a *Auth) PostAuthAwsConfigCertificateCertName(ctx context.Context, certName string, awsConfigCertificateRequest AwsConfigCertificateRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -12201,7 +12203,7 @@ func (a *AuthService) PostAuthAwsConfigCertificateCertName(ctx context.Context, 
 }
 
 // PostAuthAwsConfigClient
-func (a *AuthService) PostAuthAwsConfigClient(ctx context.Context, awsConfigClientRequest AwsConfigClientRequest) (*http.Response, error) {
+func (a *Auth) PostAuthAwsConfigClient(ctx context.Context, awsConfigClientRequest AwsConfigClientRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -12268,7 +12270,7 @@ func (a *AuthService) PostAuthAwsConfigClient(ctx context.Context, awsConfigClie
 }
 
 // PostAuthAwsConfigIdentity
-func (a *AuthService) PostAuthAwsConfigIdentity(ctx context.Context, awsConfigIdentityRequest AwsConfigIdentityRequest) (*http.Response, error) {
+func (a *Auth) PostAuthAwsConfigIdentity(ctx context.Context, awsConfigIdentityRequest AwsConfigIdentityRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -12335,7 +12337,7 @@ func (a *AuthService) PostAuthAwsConfigIdentity(ctx context.Context, awsConfigId
 }
 
 // PostAuthAwsConfigRotateRoot
-func (a *AuthService) PostAuthAwsConfigRotateRoot(ctx context.Context) (*http.Response, error) {
+func (a *Auth) PostAuthAwsConfigRotateRoot(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -12401,7 +12403,7 @@ func (a *AuthService) PostAuthAwsConfigRotateRoot(ctx context.Context) (*http.Re
 
 // PostAuthAwsConfigStsAccountId
 // accountId: AWS account ID to be associated with STS role. If set, Vault will use assumed credentials to verify any login attempts from EC2 instances in this account.
-func (a *AuthService) PostAuthAwsConfigStsAccountId(ctx context.Context, accountId string, awsConfigStsRequest AwsConfigStsRequest) (*http.Response, error) {
+func (a *Auth) PostAuthAwsConfigStsAccountId(ctx context.Context, accountId string, awsConfigStsRequest AwsConfigStsRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -12469,7 +12471,7 @@ func (a *AuthService) PostAuthAwsConfigStsAccountId(ctx context.Context, account
 }
 
 // PostAuthAwsConfigTidyIdentityAccesslist
-func (a *AuthService) PostAuthAwsConfigTidyIdentityAccesslist(ctx context.Context, awsConfigTidyIdentityAccesslistRequest AwsConfigTidyIdentityAccesslistRequest) (*http.Response, error) {
+func (a *Auth) PostAuthAwsConfigTidyIdentityAccesslist(ctx context.Context, awsConfigTidyIdentityAccesslistRequest AwsConfigTidyIdentityAccesslistRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -12536,7 +12538,7 @@ func (a *AuthService) PostAuthAwsConfigTidyIdentityAccesslist(ctx context.Contex
 }
 
 // PostAuthAwsConfigTidyIdentityWhitelist
-func (a *AuthService) PostAuthAwsConfigTidyIdentityWhitelist(ctx context.Context, awsConfigTidyIdentityWhitelistRequest AwsConfigTidyIdentityWhitelistRequest) (*http.Response, error) {
+func (a *Auth) PostAuthAwsConfigTidyIdentityWhitelist(ctx context.Context, awsConfigTidyIdentityWhitelistRequest AwsConfigTidyIdentityWhitelistRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -12603,7 +12605,7 @@ func (a *AuthService) PostAuthAwsConfigTidyIdentityWhitelist(ctx context.Context
 }
 
 // PostAuthAwsConfigTidyRoletagBlacklist
-func (a *AuthService) PostAuthAwsConfigTidyRoletagBlacklist(ctx context.Context, awsConfigTidyRoletagBlacklistRequest AwsConfigTidyRoletagBlacklistRequest) (*http.Response, error) {
+func (a *Auth) PostAuthAwsConfigTidyRoletagBlacklist(ctx context.Context, awsConfigTidyRoletagBlacklistRequest AwsConfigTidyRoletagBlacklistRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -12670,7 +12672,7 @@ func (a *AuthService) PostAuthAwsConfigTidyRoletagBlacklist(ctx context.Context,
 }
 
 // PostAuthAwsConfigTidyRoletagDenylist
-func (a *AuthService) PostAuthAwsConfigTidyRoletagDenylist(ctx context.Context, awsConfigTidyRoletagDenylistRequest AwsConfigTidyRoletagDenylistRequest) (*http.Response, error) {
+func (a *Auth) PostAuthAwsConfigTidyRoletagDenylist(ctx context.Context, awsConfigTidyRoletagDenylistRequest AwsConfigTidyRoletagDenylistRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -12737,7 +12739,7 @@ func (a *AuthService) PostAuthAwsConfigTidyRoletagDenylist(ctx context.Context, 
 }
 
 // PostAuthAwsLogin
-func (a *AuthService) PostAuthAwsLogin(ctx context.Context, awsLoginRequest AwsLoginRequest) (*http.Response, error) {
+func (a *Auth) PostAuthAwsLogin(ctx context.Context, awsLoginRequest AwsLoginRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -12805,7 +12807,7 @@ func (a *AuthService) PostAuthAwsLogin(ctx context.Context, awsLoginRequest AwsL
 
 // PostAuthAwsRoleRole
 // role: Name of the role.
-func (a *AuthService) PostAuthAwsRoleRole(ctx context.Context, role string, awsRoleRequest AwsRoleRequest) (*http.Response, error) {
+func (a *Auth) PostAuthAwsRoleRole(ctx context.Context, role string, awsRoleRequest AwsRoleRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -12874,7 +12876,7 @@ func (a *AuthService) PostAuthAwsRoleRole(ctx context.Context, role string, awsR
 
 // PostAuthAwsRoleRoleTag
 // role: Name of the role.
-func (a *AuthService) PostAuthAwsRoleRoleTag(ctx context.Context, role string, awsRoleTagRequest AwsRoleTagRequest) (*http.Response, error) {
+func (a *Auth) PostAuthAwsRoleRoleTag(ctx context.Context, role string, awsRoleTagRequest AwsRoleTagRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -12943,7 +12945,7 @@ func (a *AuthService) PostAuthAwsRoleRoleTag(ctx context.Context, role string, a
 
 // PostAuthAwsRoletagBlacklistRoleTag
 // roleTag: Role tag to be deny listed. The tag can be supplied as-is. In order to avoid any encoding problems, it can be base64 encoded.
-func (a *AuthService) PostAuthAwsRoletagBlacklistRoleTag(ctx context.Context, roleTag string) (*http.Response, error) {
+func (a *Auth) PostAuthAwsRoletagBlacklistRoleTag(ctx context.Context, roleTag string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -13010,7 +13012,7 @@ func (a *AuthService) PostAuthAwsRoletagBlacklistRoleTag(ctx context.Context, ro
 
 // PostAuthAwsRoletagDenylistRoleTag
 // roleTag: Role tag to be deny listed. The tag can be supplied as-is. In order to avoid any encoding problems, it can be base64 encoded.
-func (a *AuthService) PostAuthAwsRoletagDenylistRoleTag(ctx context.Context, roleTag string) (*http.Response, error) {
+func (a *Auth) PostAuthAwsRoletagDenylistRoleTag(ctx context.Context, roleTag string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -13076,7 +13078,7 @@ func (a *AuthService) PostAuthAwsRoletagDenylistRoleTag(ctx context.Context, rol
 }
 
 // PostAuthAwsTidyIdentityAccesslist
-func (a *AuthService) PostAuthAwsTidyIdentityAccesslist(ctx context.Context, awsTidyIdentityAccesslistRequest AwsTidyIdentityAccesslistRequest) (*http.Response, error) {
+func (a *Auth) PostAuthAwsTidyIdentityAccesslist(ctx context.Context, awsTidyIdentityAccesslistRequest AwsTidyIdentityAccesslistRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -13143,7 +13145,7 @@ func (a *AuthService) PostAuthAwsTidyIdentityAccesslist(ctx context.Context, aws
 }
 
 // PostAuthAwsTidyIdentityWhitelist
-func (a *AuthService) PostAuthAwsTidyIdentityWhitelist(ctx context.Context, awsTidyIdentityWhitelistRequest AwsTidyIdentityWhitelistRequest) (*http.Response, error) {
+func (a *Auth) PostAuthAwsTidyIdentityWhitelist(ctx context.Context, awsTidyIdentityWhitelistRequest AwsTidyIdentityWhitelistRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -13210,7 +13212,7 @@ func (a *AuthService) PostAuthAwsTidyIdentityWhitelist(ctx context.Context, awsT
 }
 
 // PostAuthAwsTidyRoletagBlacklist
-func (a *AuthService) PostAuthAwsTidyRoletagBlacklist(ctx context.Context, awsTidyRoletagBlacklistRequest AwsTidyRoletagBlacklistRequest) (*http.Response, error) {
+func (a *Auth) PostAuthAwsTidyRoletagBlacklist(ctx context.Context, awsTidyRoletagBlacklistRequest AwsTidyRoletagBlacklistRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -13277,7 +13279,7 @@ func (a *AuthService) PostAuthAwsTidyRoletagBlacklist(ctx context.Context, awsTi
 }
 
 // PostAuthAwsTidyRoletagDenylist
-func (a *AuthService) PostAuthAwsTidyRoletagDenylist(ctx context.Context, awsTidyRoletagDenylistRequest AwsTidyRoletagDenylistRequest) (*http.Response, error) {
+func (a *Auth) PostAuthAwsTidyRoletagDenylist(ctx context.Context, awsTidyRoletagDenylistRequest AwsTidyRoletagDenylistRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -13344,7 +13346,7 @@ func (a *AuthService) PostAuthAwsTidyRoletagDenylist(ctx context.Context, awsTid
 }
 
 // PostAuthAzureConfig
-func (a *AuthService) PostAuthAzureConfig(ctx context.Context, azureConfigRequest AzureConfigRequest) (*http.Response, error) {
+func (a *Auth) PostAuthAzureConfig(ctx context.Context, azureConfigRequest AzureConfigRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -13411,7 +13413,7 @@ func (a *AuthService) PostAuthAzureConfig(ctx context.Context, azureConfigReques
 }
 
 // PostAuthAzureLogin
-func (a *AuthService) PostAuthAzureLogin(ctx context.Context, azureLoginRequest AzureLoginRequest) (*http.Response, error) {
+func (a *Auth) PostAuthAzureLogin(ctx context.Context, azureLoginRequest AzureLoginRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -13479,7 +13481,7 @@ func (a *AuthService) PostAuthAzureLogin(ctx context.Context, azureLoginRequest 
 
 // PostAuthAzureRoleName
 // name: Name of the role.
-func (a *AuthService) PostAuthAzureRoleName(ctx context.Context, name string, azureRoleRequest AzureRoleRequest) (*http.Response, error) {
+func (a *Auth) PostAuthAzureRoleName(ctx context.Context, name string, azureRoleRequest AzureRoleRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -13547,7 +13549,7 @@ func (a *AuthService) PostAuthAzureRoleName(ctx context.Context, name string, az
 }
 
 // PostAuthCentrifyConfig This path allows you to configure the centrify auth provider to interact with the Centrify Identity Services Platform for authenticating users.
-func (a *AuthService) PostAuthCentrifyConfig(ctx context.Context, centrifyConfigRequest CentrifyConfigRequest) (*http.Response, error) {
+func (a *Auth) PostAuthCentrifyConfig(ctx context.Context, centrifyConfigRequest CentrifyConfigRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -13614,7 +13616,7 @@ func (a *AuthService) PostAuthCentrifyConfig(ctx context.Context, centrifyConfig
 }
 
 // PostAuthCentrifyLogin Log in with a username and password.
-func (a *AuthService) PostAuthCentrifyLogin(ctx context.Context, centrifyLoginRequest CentrifyLoginRequest) (*http.Response, error) {
+func (a *Auth) PostAuthCentrifyLogin(ctx context.Context, centrifyLoginRequest CentrifyLoginRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -13682,7 +13684,7 @@ func (a *AuthService) PostAuthCentrifyLogin(ctx context.Context, centrifyLoginRe
 
 // PostAuthCertCertsName Manage trusted certificates used for authentication.
 // name: The name of the certificate
-func (a *AuthService) PostAuthCertCertsName(ctx context.Context, name string, certCertsRequest CertCertsRequest) (*http.Response, error) {
+func (a *Auth) PostAuthCertCertsName(ctx context.Context, name string, certCertsRequest CertCertsRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -13750,7 +13752,7 @@ func (a *AuthService) PostAuthCertCertsName(ctx context.Context, name string, ce
 }
 
 // PostAuthCertConfig
-func (a *AuthService) PostAuthCertConfig(ctx context.Context, certConfigRequest CertConfigRequest) (*http.Response, error) {
+func (a *Auth) PostAuthCertConfig(ctx context.Context, certConfigRequest CertConfigRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -13818,7 +13820,7 @@ func (a *AuthService) PostAuthCertConfig(ctx context.Context, certConfigRequest 
 
 // PostAuthCertCrlsName Manage Certificate Revocation Lists checked during authentication.
 // name: The name of the certificate
-func (a *AuthService) PostAuthCertCrlsName(ctx context.Context, name string, certCrlsRequest CertCrlsRequest) (*http.Response, error) {
+func (a *Auth) PostAuthCertCrlsName(ctx context.Context, name string, certCrlsRequest CertCrlsRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -13886,7 +13888,7 @@ func (a *AuthService) PostAuthCertCrlsName(ctx context.Context, name string, cer
 }
 
 // PostAuthCertLogin
-func (a *AuthService) PostAuthCertLogin(ctx context.Context, certLoginRequest CertLoginRequest) (*http.Response, error) {
+func (a *Auth) PostAuthCertLogin(ctx context.Context, certLoginRequest CertLoginRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -13953,7 +13955,7 @@ func (a *AuthService) PostAuthCertLogin(ctx context.Context, certLoginRequest Ce
 }
 
 // PostAuthCfConfig
-func (a *AuthService) PostAuthCfConfig(ctx context.Context, cfConfigRequest CfConfigRequest) (*http.Response, error) {
+func (a *Auth) PostAuthCfConfig(ctx context.Context, cfConfigRequest CfConfigRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -14020,7 +14022,7 @@ func (a *AuthService) PostAuthCfConfig(ctx context.Context, cfConfigRequest CfCo
 }
 
 // PostAuthCfLogin
-func (a *AuthService) PostAuthCfLogin(ctx context.Context, cfLoginRequest CfLoginRequest) (*http.Response, error) {
+func (a *Auth) PostAuthCfLogin(ctx context.Context, cfLoginRequest CfLoginRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -14088,7 +14090,7 @@ func (a *AuthService) PostAuthCfLogin(ctx context.Context, cfLoginRequest CfLogi
 
 // PostAuthCfRolesRole
 // role: The name of the role.
-func (a *AuthService) PostAuthCfRolesRole(ctx context.Context, role string, cfRolesRequest CfRolesRequest) (*http.Response, error) {
+func (a *Auth) PostAuthCfRolesRole(ctx context.Context, role string, cfRolesRequest CfRolesRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -14156,7 +14158,7 @@ func (a *AuthService) PostAuthCfRolesRole(ctx context.Context, role string, cfRo
 }
 
 // PostAuthGcpConfig Configure credentials used to query the GCP IAM API to verify authenticating service accounts
-func (a *AuthService) PostAuthGcpConfig(ctx context.Context, gcpConfigRequest GcpConfigRequest) (*http.Response, error) {
+func (a *Auth) PostAuthGcpConfig(ctx context.Context, gcpConfigRequest GcpConfigRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -14223,7 +14225,7 @@ func (a *AuthService) PostAuthGcpConfig(ctx context.Context, gcpConfigRequest Gc
 }
 
 // PostAuthGcpLogin
-func (a *AuthService) PostAuthGcpLogin(ctx context.Context, gcpLoginRequest GcpLoginRequest) (*http.Response, error) {
+func (a *Auth) PostAuthGcpLogin(ctx context.Context, gcpLoginRequest GcpLoginRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -14291,7 +14293,7 @@ func (a *AuthService) PostAuthGcpLogin(ctx context.Context, gcpLoginRequest GcpL
 
 // PostAuthGcpRoleName Create a GCP role with associated policies and required attributes.
 // name: Name of the role.
-func (a *AuthService) PostAuthGcpRoleName(ctx context.Context, name string, gcpRoleRequest GcpRoleRequest) (*http.Response, error) {
+func (a *Auth) PostAuthGcpRoleName(ctx context.Context, name string, gcpRoleRequest GcpRoleRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -14360,7 +14362,7 @@ func (a *AuthService) PostAuthGcpRoleName(ctx context.Context, name string, gcpR
 
 // PostAuthGcpRoleNameLabels Add or remove labels for an existing 'gce' role
 // name: Name of the role.
-func (a *AuthService) PostAuthGcpRoleNameLabels(ctx context.Context, name string, gcpRoleLabelsRequest GcpRoleLabelsRequest) (*http.Response, error) {
+func (a *Auth) PostAuthGcpRoleNameLabels(ctx context.Context, name string, gcpRoleLabelsRequest GcpRoleLabelsRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -14429,7 +14431,7 @@ func (a *AuthService) PostAuthGcpRoleNameLabels(ctx context.Context, name string
 
 // PostAuthGcpRoleNameServiceAccounts Add or remove service accounts for an existing `iam` role
 // name: Name of the role.
-func (a *AuthService) PostAuthGcpRoleNameServiceAccounts(ctx context.Context, name string, gcpRoleServiceAccountsRequest GcpRoleServiceAccountsRequest) (*http.Response, error) {
+func (a *Auth) PostAuthGcpRoleNameServiceAccounts(ctx context.Context, name string, gcpRoleServiceAccountsRequest GcpRoleServiceAccountsRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -14497,7 +14499,7 @@ func (a *AuthService) PostAuthGcpRoleNameServiceAccounts(ctx context.Context, na
 }
 
 // PostAuthGithubConfig
-func (a *AuthService) PostAuthGithubConfig(ctx context.Context, githubConfigRequest GithubConfigRequest) (*http.Response, error) {
+func (a *Auth) PostAuthGithubConfig(ctx context.Context, githubConfigRequest GithubConfigRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -14564,7 +14566,7 @@ func (a *AuthService) PostAuthGithubConfig(ctx context.Context, githubConfigRequ
 }
 
 // PostAuthGithubLogin
-func (a *AuthService) PostAuthGithubLogin(ctx context.Context, githubLoginRequest GithubLoginRequest) (*http.Response, error) {
+func (a *Auth) PostAuthGithubLogin(ctx context.Context, githubLoginRequest GithubLoginRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -14632,7 +14634,7 @@ func (a *AuthService) PostAuthGithubLogin(ctx context.Context, githubLoginReques
 
 // PostAuthGithubMapTeamsKey Read/write/delete a single teams mapping
 // key: Key for the teams mapping
-func (a *AuthService) PostAuthGithubMapTeamsKey(ctx context.Context, key string, githubMapTeamsRequest GithubMapTeamsRequest) (*http.Response, error) {
+func (a *Auth) PostAuthGithubMapTeamsKey(ctx context.Context, key string, githubMapTeamsRequest GithubMapTeamsRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -14701,7 +14703,7 @@ func (a *AuthService) PostAuthGithubMapTeamsKey(ctx context.Context, key string,
 
 // PostAuthGithubMapUsersKey Read/write/delete a single users mapping
 // key: Key for the users mapping
-func (a *AuthService) PostAuthGithubMapUsersKey(ctx context.Context, key string, githubMapUsersRequest GithubMapUsersRequest) (*http.Response, error) {
+func (a *Auth) PostAuthGithubMapUsersKey(ctx context.Context, key string, githubMapUsersRequest GithubMapUsersRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -14770,7 +14772,7 @@ func (a *AuthService) PostAuthGithubMapUsersKey(ctx context.Context, key string,
 
 // PostAuthJwtConfig Configure the JWT authentication backend.
 // The JWT authentication backend validates JWTs (or OIDC) using the configured credentials. If using OIDC Discovery, the URL must be provided, along with (optionally) the CA cert to use for the connection. If performing JWT validation locally, a set of public keys must be provided.
-func (a *AuthService) PostAuthJwtConfig(ctx context.Context, jwtConfigRequest JwtConfigRequest) (*http.Response, error) {
+func (a *Auth) PostAuthJwtConfig(ctx context.Context, jwtConfigRequest JwtConfigRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -14837,7 +14839,7 @@ func (a *AuthService) PostAuthJwtConfig(ctx context.Context, jwtConfigRequest Jw
 }
 
 // PostAuthJwtLogin Authenticates to Vault using a JWT (or OIDC) token.
-func (a *AuthService) PostAuthJwtLogin(ctx context.Context, jwtLoginRequest JwtLoginRequest) (*http.Response, error) {
+func (a *Auth) PostAuthJwtLogin(ctx context.Context, jwtLoginRequest JwtLoginRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -14904,7 +14906,7 @@ func (a *AuthService) PostAuthJwtLogin(ctx context.Context, jwtLoginRequest JwtL
 }
 
 // PostAuthJwtOidcAuthUrl Request an authorization URL to start an OIDC login flow.
-func (a *AuthService) PostAuthJwtOidcAuthUrl(ctx context.Context, jwtOidcAuthUrlRequest JwtOidcAuthUrlRequest) (*http.Response, error) {
+func (a *Auth) PostAuthJwtOidcAuthUrl(ctx context.Context, jwtOidcAuthUrlRequest JwtOidcAuthUrlRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -14971,7 +14973,7 @@ func (a *AuthService) PostAuthJwtOidcAuthUrl(ctx context.Context, jwtOidcAuthUrl
 }
 
 // PostAuthJwtOidcCallback Callback endpoint to handle form_posts.
-func (a *AuthService) PostAuthJwtOidcCallback(ctx context.Context, jwtOidcCallbackRequest JwtOidcCallbackRequest) (*http.Response, error) {
+func (a *Auth) PostAuthJwtOidcCallback(ctx context.Context, jwtOidcCallbackRequest JwtOidcCallbackRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -15040,7 +15042,7 @@ func (a *AuthService) PostAuthJwtOidcCallback(ctx context.Context, jwtOidcCallba
 // PostAuthJwtRoleName Register an role with the backend.
 // A role is required to authenticate with this backend. The role binds   JWT token information with token policies and settings.   The bindings, token polices and token settings can all be configured   using this endpoint
 // name: Name of the role.
-func (a *AuthService) PostAuthJwtRoleName(ctx context.Context, name string, jwtRoleRequest JwtRoleRequest) (*http.Response, error) {
+func (a *Auth) PostAuthJwtRoleName(ctx context.Context, name string, jwtRoleRequest JwtRoleRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -15108,7 +15110,7 @@ func (a *AuthService) PostAuthJwtRoleName(ctx context.Context, name string, jwtR
 }
 
 // PostAuthKerberosConfig
-func (a *AuthService) PostAuthKerberosConfig(ctx context.Context, kerberosConfigRequest KerberosConfigRequest) (*http.Response, error) {
+func (a *Auth) PostAuthKerberosConfig(ctx context.Context, kerberosConfigRequest KerberosConfigRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -15175,7 +15177,7 @@ func (a *AuthService) PostAuthKerberosConfig(ctx context.Context, kerberosConfig
 }
 
 // PostAuthKerberosConfigLdap
-func (a *AuthService) PostAuthKerberosConfigLdap(ctx context.Context, kerberosConfigLdapRequest KerberosConfigLdapRequest) (*http.Response, error) {
+func (a *Auth) PostAuthKerberosConfigLdap(ctx context.Context, kerberosConfigLdapRequest KerberosConfigLdapRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -15243,7 +15245,7 @@ func (a *AuthService) PostAuthKerberosConfigLdap(ctx context.Context, kerberosCo
 
 // PostAuthKerberosGroupsName
 // name: Name of the LDAP group.
-func (a *AuthService) PostAuthKerberosGroupsName(ctx context.Context, name string, kerberosGroupsRequest KerberosGroupsRequest) (*http.Response, error) {
+func (a *Auth) PostAuthKerberosGroupsName(ctx context.Context, name string, kerberosGroupsRequest KerberosGroupsRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -15311,7 +15313,7 @@ func (a *AuthService) PostAuthKerberosGroupsName(ctx context.Context, name strin
 }
 
 // PostAuthKerberosLogin
-func (a *AuthService) PostAuthKerberosLogin(ctx context.Context, kerberosLoginRequest KerberosLoginRequest) (*http.Response, error) {
+func (a *Auth) PostAuthKerberosLogin(ctx context.Context, kerberosLoginRequest KerberosLoginRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -15378,7 +15380,7 @@ func (a *AuthService) PostAuthKerberosLogin(ctx context.Context, kerberosLoginRe
 }
 
 // PostAuthKubernetesConfig Configures the JWT Public Key and Kubernetes API information.
-func (a *AuthService) PostAuthKubernetesConfig(ctx context.Context, kubernetesConfigRequest KubernetesConfigRequest) (*http.Response, error) {
+func (a *Auth) PostAuthKubernetesConfig(ctx context.Context, kubernetesConfigRequest KubernetesConfigRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -15445,7 +15447,7 @@ func (a *AuthService) PostAuthKubernetesConfig(ctx context.Context, kubernetesCo
 }
 
 // PostAuthKubernetesLogin Authenticates Kubernetes service accounts with Vault.
-func (a *AuthService) PostAuthKubernetesLogin(ctx context.Context, kubernetesLoginRequest KubernetesLoginRequest) (*http.Response, error) {
+func (a *Auth) PostAuthKubernetesLogin(ctx context.Context, kubernetesLoginRequest KubernetesLoginRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -15513,7 +15515,7 @@ func (a *AuthService) PostAuthKubernetesLogin(ctx context.Context, kubernetesLog
 
 // PostAuthKubernetesRoleName Register an role with the backend.
 // name: Name of the role.
-func (a *AuthService) PostAuthKubernetesRoleName(ctx context.Context, name string, kubernetesRoleRequest KubernetesRoleRequest) (*http.Response, error) {
+func (a *Auth) PostAuthKubernetesRoleName(ctx context.Context, name string, kubernetesRoleRequest KubernetesRoleRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -15581,7 +15583,7 @@ func (a *AuthService) PostAuthKubernetesRoleName(ctx context.Context, name strin
 }
 
 // PostAuthLdapConfig Configure the LDAP server to connect to, along with its options.
-func (a *AuthService) PostAuthLdapConfig(ctx context.Context, ldapConfigRequest LdapConfigRequest) (*http.Response, error) {
+func (a *Auth) PostAuthLdapConfig(ctx context.Context, ldapConfigRequest LdapConfigRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -15649,7 +15651,7 @@ func (a *AuthService) PostAuthLdapConfig(ctx context.Context, ldapConfigRequest 
 
 // PostAuthLdapGroupsName Manage additional groups for users allowed to authenticate.
 // name: Name of the LDAP group.
-func (a *AuthService) PostAuthLdapGroupsName(ctx context.Context, name string, ldapGroupsRequest LdapGroupsRequest) (*http.Response, error) {
+func (a *Auth) PostAuthLdapGroupsName(ctx context.Context, name string, ldapGroupsRequest LdapGroupsRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -15718,7 +15720,7 @@ func (a *AuthService) PostAuthLdapGroupsName(ctx context.Context, name string, l
 
 // PostAuthLdapLoginUsername Log in with a username and password.
 // username: DN (distinguished name) to be used for login.
-func (a *AuthService) PostAuthLdapLoginUsername(ctx context.Context, username string, ldapLoginRequest LdapLoginRequest) (*http.Response, error) {
+func (a *Auth) PostAuthLdapLoginUsername(ctx context.Context, username string, ldapLoginRequest LdapLoginRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -15787,7 +15789,7 @@ func (a *AuthService) PostAuthLdapLoginUsername(ctx context.Context, username st
 
 // PostAuthLdapUsersName Manage users allowed to authenticate.
 // name: Name of the LDAP user.
-func (a *AuthService) PostAuthLdapUsersName(ctx context.Context, name string, ldapUsersRequest LdapUsersRequest) (*http.Response, error) {
+func (a *Auth) PostAuthLdapUsersName(ctx context.Context, name string, ldapUsersRequest LdapUsersRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -15855,7 +15857,7 @@ func (a *AuthService) PostAuthLdapUsersName(ctx context.Context, name string, ld
 }
 
 // PostAuthOciConfig Manages the configuration for the Vault Auth Plugin.
-func (a *AuthService) PostAuthOciConfig(ctx context.Context, ociConfigRequest OciConfigRequest) (*http.Response, error) {
+func (a *Auth) PostAuthOciConfig(ctx context.Context, ociConfigRequest OciConfigRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -15923,7 +15925,7 @@ func (a *AuthService) PostAuthOciConfig(ctx context.Context, ociConfigRequest Oc
 
 // PostAuthOciLoginRole Authenticates to Vault using OCI credentials
 // role: Name of the role.
-func (a *AuthService) PostAuthOciLoginRole(ctx context.Context, role string, ociLoginRequest OciLoginRequest) (*http.Response, error) {
+func (a *Auth) PostAuthOciLoginRole(ctx context.Context, role string, ociLoginRequest OciLoginRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -15992,7 +15994,7 @@ func (a *AuthService) PostAuthOciLoginRole(ctx context.Context, role string, oci
 
 // PostAuthOciRoleRole Create a role and associate policies to it.
 // role: Name of the role.
-func (a *AuthService) PostAuthOciRoleRole(ctx context.Context, role string, ociRoleRequest OciRoleRequest) (*http.Response, error) {
+func (a *Auth) PostAuthOciRoleRole(ctx context.Context, role string, ociRoleRequest OciRoleRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -16061,7 +16063,7 @@ func (a *AuthService) PostAuthOciRoleRole(ctx context.Context, role string, ociR
 
 // PostAuthOidcConfig Configure the JWT authentication backend.
 // The JWT authentication backend validates JWTs (or OIDC) using the configured credentials. If using OIDC Discovery, the URL must be provided, along with (optionally) the CA cert to use for the connection. If performing JWT validation locally, a set of public keys must be provided.
-func (a *AuthService) PostAuthOidcConfig(ctx context.Context, oidcConfigRequest OidcConfigRequest) (*http.Response, error) {
+func (a *Auth) PostAuthOidcConfig(ctx context.Context, oidcConfigRequest OidcConfigRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -16128,7 +16130,7 @@ func (a *AuthService) PostAuthOidcConfig(ctx context.Context, oidcConfigRequest 
 }
 
 // PostAuthOidcLogin Authenticates to Vault using a JWT (or OIDC) token.
-func (a *AuthService) PostAuthOidcLogin(ctx context.Context, oidcLoginRequest OidcLoginRequest) (*http.Response, error) {
+func (a *Auth) PostAuthOidcLogin(ctx context.Context, oidcLoginRequest OidcLoginRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -16195,7 +16197,7 @@ func (a *AuthService) PostAuthOidcLogin(ctx context.Context, oidcLoginRequest Oi
 }
 
 // PostAuthOidcOidcAuthUrl Request an authorization URL to start an OIDC login flow.
-func (a *AuthService) PostAuthOidcOidcAuthUrl(ctx context.Context, oidcOidcAuthUrlRequest OidcOidcAuthUrlRequest) (*http.Response, error) {
+func (a *Auth) PostAuthOidcOidcAuthUrl(ctx context.Context, oidcOidcAuthUrlRequest OidcOidcAuthUrlRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -16262,7 +16264,7 @@ func (a *AuthService) PostAuthOidcOidcAuthUrl(ctx context.Context, oidcOidcAuthU
 }
 
 // PostAuthOidcOidcCallback Callback endpoint to handle form_posts.
-func (a *AuthService) PostAuthOidcOidcCallback(ctx context.Context, oidcOidcCallbackRequest OidcOidcCallbackRequest) (*http.Response, error) {
+func (a *Auth) PostAuthOidcOidcCallback(ctx context.Context, oidcOidcCallbackRequest OidcOidcCallbackRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -16331,7 +16333,7 @@ func (a *AuthService) PostAuthOidcOidcCallback(ctx context.Context, oidcOidcCall
 // PostAuthOidcRoleName Register an role with the backend.
 // A role is required to authenticate with this backend. The role binds   JWT token information with token policies and settings.   The bindings, token polices and token settings can all be configured   using this endpoint
 // name: Name of the role.
-func (a *AuthService) PostAuthOidcRoleName(ctx context.Context, name string, oidcRoleRequest OidcRoleRequest) (*http.Response, error) {
+func (a *Auth) PostAuthOidcRoleName(ctx context.Context, name string, oidcRoleRequest OidcRoleRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -16399,7 +16401,7 @@ func (a *AuthService) PostAuthOidcRoleName(ctx context.Context, name string, oid
 }
 
 // PostAuthOktaConfig This endpoint allows you to configure the Okta and its configuration options.  The Okta organization are the characters at the front of the URL for Okta. Example https://ORG.okta.com
-func (a *AuthService) PostAuthOktaConfig(ctx context.Context, oktaConfigRequest OktaConfigRequest) (*http.Response, error) {
+func (a *Auth) PostAuthOktaConfig(ctx context.Context, oktaConfigRequest OktaConfigRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -16467,7 +16469,7 @@ func (a *AuthService) PostAuthOktaConfig(ctx context.Context, oktaConfigRequest 
 
 // PostAuthOktaGroupsName Manage users allowed to authenticate.
 // name: Name of the Okta group.
-func (a *AuthService) PostAuthOktaGroupsName(ctx context.Context, name string, oktaGroupsRequest OktaGroupsRequest) (*http.Response, error) {
+func (a *Auth) PostAuthOktaGroupsName(ctx context.Context, name string, oktaGroupsRequest OktaGroupsRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -16536,7 +16538,7 @@ func (a *AuthService) PostAuthOktaGroupsName(ctx context.Context, name string, o
 
 // PostAuthOktaLoginUsername Log in with a username and password.
 // username: Username to be used for login.
-func (a *AuthService) PostAuthOktaLoginUsername(ctx context.Context, username string, oktaLoginRequest OktaLoginRequest) (*http.Response, error) {
+func (a *Auth) PostAuthOktaLoginUsername(ctx context.Context, username string, oktaLoginRequest OktaLoginRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -16605,7 +16607,7 @@ func (a *AuthService) PostAuthOktaLoginUsername(ctx context.Context, username st
 
 // PostAuthOktaUsersName Manage additional groups for users allowed to authenticate.
 // name: Name of the user.
-func (a *AuthService) PostAuthOktaUsersName(ctx context.Context, name string, oktaUsersRequest OktaUsersRequest) (*http.Response, error) {
+func (a *Auth) PostAuthOktaUsersName(ctx context.Context, name string, oktaUsersRequest OktaUsersRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -16673,7 +16675,7 @@ func (a *AuthService) PostAuthOktaUsersName(ctx context.Context, name string, ok
 }
 
 // PostAuthRadiusConfig Configure the RADIUS server to connect to, along with its options.
-func (a *AuthService) PostAuthRadiusConfig(ctx context.Context, radiusConfigRequest RadiusConfigRequest) (*http.Response, error) {
+func (a *Auth) PostAuthRadiusConfig(ctx context.Context, radiusConfigRequest RadiusConfigRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -16740,7 +16742,7 @@ func (a *AuthService) PostAuthRadiusConfig(ctx context.Context, radiusConfigRequ
 }
 
 // PostAuthRadiusLogin Log in with a username and password.
-func (a *AuthService) PostAuthRadiusLogin(ctx context.Context, radiusLoginRequest RadiusLoginRequest) (*http.Response, error) {
+func (a *Auth) PostAuthRadiusLogin(ctx context.Context, radiusLoginRequest RadiusLoginRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -16808,7 +16810,7 @@ func (a *AuthService) PostAuthRadiusLogin(ctx context.Context, radiusLoginReques
 
 // PostAuthRadiusLoginUrlusername Log in with a username and password.
 // urlusername: Username to be used for login. (URL parameter)
-func (a *AuthService) PostAuthRadiusLoginUrlusername(ctx context.Context, urlusername string, radiusLoginRequest RadiusLoginRequest) (*http.Response, error) {
+func (a *Auth) PostAuthRadiusLoginUrlusername(ctx context.Context, urlusername string, radiusLoginRequest RadiusLoginRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -16877,7 +16879,7 @@ func (a *AuthService) PostAuthRadiusLoginUrlusername(ctx context.Context, urluse
 
 // PostAuthRadiusUsersName Manage users allowed to authenticate.
 // name: Name of the RADIUS user.
-func (a *AuthService) PostAuthRadiusUsersName(ctx context.Context, name string, radiusUsersRequest RadiusUsersRequest) (*http.Response, error) {
+func (a *Auth) PostAuthRadiusUsersName(ctx context.Context, name string, radiusUsersRequest RadiusUsersRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -16945,7 +16947,7 @@ func (a *AuthService) PostAuthRadiusUsersName(ctx context.Context, name string, 
 }
 
 // PostAuthTokenCreate The token create path is used to create new tokens.
-func (a *AuthService) PostAuthTokenCreate(ctx context.Context) (*http.Response, error) {
+func (a *Auth) PostAuthTokenCreate(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -17010,7 +17012,7 @@ func (a *AuthService) PostAuthTokenCreate(ctx context.Context) (*http.Response, 
 }
 
 // PostAuthTokenCreateOrphan The token create path is used to create new orphan tokens.
-func (a *AuthService) PostAuthTokenCreateOrphan(ctx context.Context) (*http.Response, error) {
+func (a *Auth) PostAuthTokenCreateOrphan(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -17076,7 +17078,7 @@ func (a *AuthService) PostAuthTokenCreateOrphan(ctx context.Context) (*http.Resp
 
 // PostAuthTokenCreateRoleName This token create path is used to create new tokens adhering to the given role.
 // roleName: Name of the role
-func (a *AuthService) PostAuthTokenCreateRoleName(ctx context.Context, roleName string) (*http.Response, error) {
+func (a *Auth) PostAuthTokenCreateRoleName(ctx context.Context, roleName string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -17142,7 +17144,7 @@ func (a *AuthService) PostAuthTokenCreateRoleName(ctx context.Context, roleName 
 }
 
 // PostAuthTokenLookup This endpoint will lookup a token and its properties.
-func (a *AuthService) PostAuthTokenLookup(ctx context.Context, tokenLookupRequest TokenLookupRequest) (*http.Response, error) {
+func (a *Auth) PostAuthTokenLookup(ctx context.Context, tokenLookupRequest TokenLookupRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -17209,7 +17211,7 @@ func (a *AuthService) PostAuthTokenLookup(ctx context.Context, tokenLookupReques
 }
 
 // PostAuthTokenLookupAccessor This endpoint will lookup a token associated with the given accessor and its properties. Response will not contain the token ID.
-func (a *AuthService) PostAuthTokenLookupAccessor(ctx context.Context, tokenLookupAccessorRequest TokenLookupAccessorRequest) (*http.Response, error) {
+func (a *Auth) PostAuthTokenLookupAccessor(ctx context.Context, tokenLookupAccessorRequest TokenLookupAccessorRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -17276,7 +17278,7 @@ func (a *AuthService) PostAuthTokenLookupAccessor(ctx context.Context, tokenLook
 }
 
 // PostAuthTokenLookupSelf This endpoint will lookup a token and its properties.
-func (a *AuthService) PostAuthTokenLookupSelf(ctx context.Context, tokenLookupSelfRequest TokenLookupSelfRequest) (*http.Response, error) {
+func (a *Auth) PostAuthTokenLookupSelf(ctx context.Context, tokenLookupSelfRequest TokenLookupSelfRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -17343,7 +17345,7 @@ func (a *AuthService) PostAuthTokenLookupSelf(ctx context.Context, tokenLookupSe
 }
 
 // PostAuthTokenRenew This endpoint will renew the given token and prevent expiration.
-func (a *AuthService) PostAuthTokenRenew(ctx context.Context, tokenRenewRequest TokenRenewRequest) (*http.Response, error) {
+func (a *Auth) PostAuthTokenRenew(ctx context.Context, tokenRenewRequest TokenRenewRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -17410,7 +17412,7 @@ func (a *AuthService) PostAuthTokenRenew(ctx context.Context, tokenRenewRequest 
 }
 
 // PostAuthTokenRenewAccessor This endpoint will renew a token associated with the given accessor and its properties. Response will not contain the token ID.
-func (a *AuthService) PostAuthTokenRenewAccessor(ctx context.Context, tokenRenewAccessorRequest TokenRenewAccessorRequest) (*http.Response, error) {
+func (a *Auth) PostAuthTokenRenewAccessor(ctx context.Context, tokenRenewAccessorRequest TokenRenewAccessorRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -17477,7 +17479,7 @@ func (a *AuthService) PostAuthTokenRenewAccessor(ctx context.Context, tokenRenew
 }
 
 // PostAuthTokenRenewSelf This endpoint will renew the token used to call it and prevent expiration.
-func (a *AuthService) PostAuthTokenRenewSelf(ctx context.Context, tokenRenewSelfRequest TokenRenewSelfRequest) (*http.Response, error) {
+func (a *Auth) PostAuthTokenRenewSelf(ctx context.Context, tokenRenewSelfRequest TokenRenewSelfRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -17544,7 +17546,7 @@ func (a *AuthService) PostAuthTokenRenewSelf(ctx context.Context, tokenRenewSelf
 }
 
 // PostAuthTokenRevoke This endpoint will delete the given token and all of its child tokens.
-func (a *AuthService) PostAuthTokenRevoke(ctx context.Context, tokenRevokeRequest TokenRevokeRequest) (*http.Response, error) {
+func (a *Auth) PostAuthTokenRevoke(ctx context.Context, tokenRevokeRequest TokenRevokeRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -17611,7 +17613,7 @@ func (a *AuthService) PostAuthTokenRevoke(ctx context.Context, tokenRevokeReques
 }
 
 // PostAuthTokenRevokeAccessor This endpoint will delete the token associated with the accessor and all of its child tokens.
-func (a *AuthService) PostAuthTokenRevokeAccessor(ctx context.Context, tokenRevokeAccessorRequest TokenRevokeAccessorRequest) (*http.Response, error) {
+func (a *Auth) PostAuthTokenRevokeAccessor(ctx context.Context, tokenRevokeAccessorRequest TokenRevokeAccessorRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -17678,7 +17680,7 @@ func (a *AuthService) PostAuthTokenRevokeAccessor(ctx context.Context, tokenRevo
 }
 
 // PostAuthTokenRevokeOrphan This endpoint will delete the token and orphan its child tokens.
-func (a *AuthService) PostAuthTokenRevokeOrphan(ctx context.Context, tokenRevokeOrphanRequest TokenRevokeOrphanRequest) (*http.Response, error) {
+func (a *Auth) PostAuthTokenRevokeOrphan(ctx context.Context, tokenRevokeOrphanRequest TokenRevokeOrphanRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -17745,7 +17747,7 @@ func (a *AuthService) PostAuthTokenRevokeOrphan(ctx context.Context, tokenRevoke
 }
 
 // PostAuthTokenRevokeSelf This endpoint will delete the token used to call it and all of its child tokens.
-func (a *AuthService) PostAuthTokenRevokeSelf(ctx context.Context) (*http.Response, error) {
+func (a *Auth) PostAuthTokenRevokeSelf(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -17811,7 +17813,7 @@ func (a *AuthService) PostAuthTokenRevokeSelf(ctx context.Context) (*http.Respon
 
 // PostAuthTokenRolesRoleName
 // roleName: Name of the role
-func (a *AuthService) PostAuthTokenRolesRoleName(ctx context.Context, roleName string, tokenRolesRequest TokenRolesRequest) (*http.Response, error) {
+func (a *Auth) PostAuthTokenRolesRoleName(ctx context.Context, roleName string, tokenRolesRequest TokenRolesRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -17879,7 +17881,7 @@ func (a *AuthService) PostAuthTokenRolesRoleName(ctx context.Context, roleName s
 }
 
 // PostAuthTokenTidy This endpoint performs cleanup tasks that can be run if certain error conditions have occurred.
-func (a *AuthService) PostAuthTokenTidy(ctx context.Context) (*http.Response, error) {
+func (a *Auth) PostAuthTokenTidy(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -17945,7 +17947,7 @@ func (a *AuthService) PostAuthTokenTidy(ctx context.Context) (*http.Response, er
 
 // PostAuthUserpassLoginUsername Log in with a username and password.
 // username: Username of the user.
-func (a *AuthService) PostAuthUserpassLoginUsername(ctx context.Context, username string, userpassLoginRequest UserpassLoginRequest) (*http.Response, error) {
+func (a *Auth) PostAuthUserpassLoginUsername(ctx context.Context, username string, userpassLoginRequest UserpassLoginRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -18014,7 +18016,7 @@ func (a *AuthService) PostAuthUserpassLoginUsername(ctx context.Context, usernam
 
 // PostAuthUserpassUsersUsername Manage users allowed to authenticate.
 // username: Username for this user.
-func (a *AuthService) PostAuthUserpassUsersUsername(ctx context.Context, username string, userpassUsersRequest UserpassUsersRequest) (*http.Response, error) {
+func (a *Auth) PostAuthUserpassUsersUsername(ctx context.Context, username string, userpassUsersRequest UserpassUsersRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -18083,7 +18085,7 @@ func (a *AuthService) PostAuthUserpassUsersUsername(ctx context.Context, usernam
 
 // PostAuthUserpassUsersUsernamePassword Reset user's password.
 // username: Username for this user.
-func (a *AuthService) PostAuthUserpassUsersUsernamePassword(ctx context.Context, username string, userpassUsersPasswordRequest UserpassUsersPasswordRequest) (*http.Response, error) {
+func (a *Auth) PostAuthUserpassUsersUsernamePassword(ctx context.Context, username string, userpassUsersPasswordRequest UserpassUsersPasswordRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -18152,7 +18154,7 @@ func (a *AuthService) PostAuthUserpassUsersUsernamePassword(ctx context.Context,
 
 // PostAuthUserpassUsersUsernamePolicies Update the policies associated with the username.
 // username: Username for this user.
-func (a *AuthService) PostAuthUserpassUsersUsernamePolicies(ctx context.Context, username string, userpassUsersPoliciesRequest UserpassUsersPoliciesRequest) (*http.Response, error) {
+func (a *Auth) PostAuthUserpassUsersUsernamePolicies(ctx context.Context, username string, userpassUsersPoliciesRequest UserpassUsersPoliciesRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}

--- a/api_identity.go
+++ b/api_identity.go
@@ -19,12 +19,14 @@ import (
 	"strings"
 )
 
-// IdentityService Identity service
-type IdentityService service
+// Identity is a simple wrapper around the client for Identity requests
+type Identity struct {
+	client *Client
+}
 
 // DeleteIdentityAliasIdId Update, read or delete an alias ID.
 // id: ID of the alias
-func (a *IdentityService) DeleteIdentityAliasIdId(ctx context.Context, id string) (*http.Response, error) {
+func (a *Identity) DeleteIdentityAliasIdId(ctx context.Context, id string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -91,7 +93,7 @@ func (a *IdentityService) DeleteIdentityAliasIdId(ctx context.Context, id string
 
 // DeleteIdentityEntityAliasIdId Update, read or delete an alias ID.
 // id: ID of the alias
-func (a *IdentityService) DeleteIdentityEntityAliasIdId(ctx context.Context, id string) (*http.Response, error) {
+func (a *Identity) DeleteIdentityEntityAliasIdId(ctx context.Context, id string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -158,7 +160,7 @@ func (a *IdentityService) DeleteIdentityEntityAliasIdId(ctx context.Context, id 
 
 // DeleteIdentityEntityIdId Update, read or delete an entity using entity ID
 // id: ID of the entity. If set, updates the corresponding existing entity.
-func (a *IdentityService) DeleteIdentityEntityIdId(ctx context.Context, id string) (*http.Response, error) {
+func (a *Identity) DeleteIdentityEntityIdId(ctx context.Context, id string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -225,7 +227,7 @@ func (a *IdentityService) DeleteIdentityEntityIdId(ctx context.Context, id strin
 
 // DeleteIdentityEntityNameName Update, read or delete an entity using entity name
 // name: Name of the entity
-func (a *IdentityService) DeleteIdentityEntityNameName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Identity) DeleteIdentityEntityNameName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -292,7 +294,7 @@ func (a *IdentityService) DeleteIdentityEntityNameName(ctx context.Context, name
 
 // DeleteIdentityGroupAliasIdId
 // id: ID of the group alias.
-func (a *IdentityService) DeleteIdentityGroupAliasIdId(ctx context.Context, id string) (*http.Response, error) {
+func (a *Identity) DeleteIdentityGroupAliasIdId(ctx context.Context, id string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -359,7 +361,7 @@ func (a *IdentityService) DeleteIdentityGroupAliasIdId(ctx context.Context, id s
 
 // DeleteIdentityGroupIdId Update or delete an existing group using its ID.
 // id: ID of the group. If set, updates the corresponding existing group.
-func (a *IdentityService) DeleteIdentityGroupIdId(ctx context.Context, id string) (*http.Response, error) {
+func (a *Identity) DeleteIdentityGroupIdId(ctx context.Context, id string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -426,7 +428,7 @@ func (a *IdentityService) DeleteIdentityGroupIdId(ctx context.Context, id string
 
 // DeleteIdentityGroupNameName
 // name: Name of the group.
-func (a *IdentityService) DeleteIdentityGroupNameName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Identity) DeleteIdentityGroupNameName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -493,7 +495,7 @@ func (a *IdentityService) DeleteIdentityGroupNameName(ctx context.Context, name 
 
 // DeleteIdentityMfaLoginEnforcementName Delete a login enforcement
 // name: Name for this login enforcement configuration
-func (a *IdentityService) DeleteIdentityMfaLoginEnforcementName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Identity) DeleteIdentityMfaLoginEnforcementName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -560,7 +562,7 @@ func (a *IdentityService) DeleteIdentityMfaLoginEnforcementName(ctx context.Cont
 
 // DeleteIdentityMfaMethodDuoMethodId Delete a configuration for the given MFA method
 // methodId: The unique identifier for this MFA method.
-func (a *IdentityService) DeleteIdentityMfaMethodDuoMethodId(ctx context.Context, methodId string) (*http.Response, error) {
+func (a *Identity) DeleteIdentityMfaMethodDuoMethodId(ctx context.Context, methodId string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -627,7 +629,7 @@ func (a *IdentityService) DeleteIdentityMfaMethodDuoMethodId(ctx context.Context
 
 // DeleteIdentityMfaMethodOktaMethodId Delete a configuration for the given MFA method
 // methodId: The unique identifier for this MFA method.
-func (a *IdentityService) DeleteIdentityMfaMethodOktaMethodId(ctx context.Context, methodId string) (*http.Response, error) {
+func (a *Identity) DeleteIdentityMfaMethodOktaMethodId(ctx context.Context, methodId string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -694,7 +696,7 @@ func (a *IdentityService) DeleteIdentityMfaMethodOktaMethodId(ctx context.Contex
 
 // DeleteIdentityMfaMethodPingidMethodId Delete a configuration for the given MFA method
 // methodId: The unique identifier for this MFA method.
-func (a *IdentityService) DeleteIdentityMfaMethodPingidMethodId(ctx context.Context, methodId string) (*http.Response, error) {
+func (a *Identity) DeleteIdentityMfaMethodPingidMethodId(ctx context.Context, methodId string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -761,7 +763,7 @@ func (a *IdentityService) DeleteIdentityMfaMethodPingidMethodId(ctx context.Cont
 
 // DeleteIdentityMfaMethodTotpMethodId Delete a configuration for the given MFA method
 // methodId: The unique identifier for this MFA method.
-func (a *IdentityService) DeleteIdentityMfaMethodTotpMethodId(ctx context.Context, methodId string) (*http.Response, error) {
+func (a *Identity) DeleteIdentityMfaMethodTotpMethodId(ctx context.Context, methodId string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -828,7 +830,7 @@ func (a *IdentityService) DeleteIdentityMfaMethodTotpMethodId(ctx context.Contex
 
 // DeleteIdentityOidcAssignmentName
 // name: Name of the assignment
-func (a *IdentityService) DeleteIdentityOidcAssignmentName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Identity) DeleteIdentityOidcAssignmentName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -895,7 +897,7 @@ func (a *IdentityService) DeleteIdentityOidcAssignmentName(ctx context.Context, 
 
 // DeleteIdentityOidcClientName
 // name: Name of the client.
-func (a *IdentityService) DeleteIdentityOidcClientName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Identity) DeleteIdentityOidcClientName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -962,7 +964,7 @@ func (a *IdentityService) DeleteIdentityOidcClientName(ctx context.Context, name
 
 // DeleteIdentityOidcKeyName CRUD operations for OIDC keys.
 // name: Name of the key
-func (a *IdentityService) DeleteIdentityOidcKeyName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Identity) DeleteIdentityOidcKeyName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -1029,7 +1031,7 @@ func (a *IdentityService) DeleteIdentityOidcKeyName(ctx context.Context, name st
 
 // DeleteIdentityOidcProviderName
 // name: Name of the provider
-func (a *IdentityService) DeleteIdentityOidcProviderName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Identity) DeleteIdentityOidcProviderName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -1096,7 +1098,7 @@ func (a *IdentityService) DeleteIdentityOidcProviderName(ctx context.Context, na
 
 // DeleteIdentityOidcRoleName CRUD operations on OIDC Roles
 // name: Name of the role
-func (a *IdentityService) DeleteIdentityOidcRoleName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Identity) DeleteIdentityOidcRoleName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -1163,7 +1165,7 @@ func (a *IdentityService) DeleteIdentityOidcRoleName(ctx context.Context, name s
 
 // DeleteIdentityOidcScopeName
 // name: Name of the scope
-func (a *IdentityService) DeleteIdentityOidcScopeName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Identity) DeleteIdentityOidcScopeName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -1230,7 +1232,7 @@ func (a *IdentityService) DeleteIdentityOidcScopeName(ctx context.Context, name 
 
 // DeleteIdentityPersonaIdId Update, read or delete an alias ID.
 // id: ID of the persona
-func (a *IdentityService) DeleteIdentityPersonaIdId(ctx context.Context, id string) (*http.Response, error) {
+func (a *Identity) DeleteIdentityPersonaIdId(ctx context.Context, id string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -1297,7 +1299,7 @@ func (a *IdentityService) DeleteIdentityPersonaIdId(ctx context.Context, id stri
 
 // GetIdentityAliasId List all the alias IDs.
 // list: Must be set to &#x60;true&#x60;
-func (a *IdentityService) GetIdentityAliasId(ctx context.Context, list string) (*http.Response, error) {
+func (a *Identity) GetIdentityAliasId(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -1364,7 +1366,7 @@ func (a *IdentityService) GetIdentityAliasId(ctx context.Context, list string) (
 
 // GetIdentityAliasIdId Update, read or delete an alias ID.
 // id: ID of the alias
-func (a *IdentityService) GetIdentityAliasIdId(ctx context.Context, id string) (*http.Response, error) {
+func (a *Identity) GetIdentityAliasIdId(ctx context.Context, id string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -1431,7 +1433,7 @@ func (a *IdentityService) GetIdentityAliasIdId(ctx context.Context, id string) (
 
 // GetIdentityEntityAliasId List all the alias IDs.
 // list: Must be set to &#x60;true&#x60;
-func (a *IdentityService) GetIdentityEntityAliasId(ctx context.Context, list string) (*http.Response, error) {
+func (a *Identity) GetIdentityEntityAliasId(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -1498,7 +1500,7 @@ func (a *IdentityService) GetIdentityEntityAliasId(ctx context.Context, list str
 
 // GetIdentityEntityAliasIdId Update, read or delete an alias ID.
 // id: ID of the alias
-func (a *IdentityService) GetIdentityEntityAliasIdId(ctx context.Context, id string) (*http.Response, error) {
+func (a *Identity) GetIdentityEntityAliasIdId(ctx context.Context, id string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -1565,7 +1567,7 @@ func (a *IdentityService) GetIdentityEntityAliasIdId(ctx context.Context, id str
 
 // GetIdentityEntityId List all the entity IDs
 // list: Must be set to &#x60;true&#x60;
-func (a *IdentityService) GetIdentityEntityId(ctx context.Context, list string) (*http.Response, error) {
+func (a *Identity) GetIdentityEntityId(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -1632,7 +1634,7 @@ func (a *IdentityService) GetIdentityEntityId(ctx context.Context, list string) 
 
 // GetIdentityEntityIdId Update, read or delete an entity using entity ID
 // id: ID of the entity. If set, updates the corresponding existing entity.
-func (a *IdentityService) GetIdentityEntityIdId(ctx context.Context, id string) (*http.Response, error) {
+func (a *Identity) GetIdentityEntityIdId(ctx context.Context, id string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -1699,7 +1701,7 @@ func (a *IdentityService) GetIdentityEntityIdId(ctx context.Context, id string) 
 
 // GetIdentityEntityName List all the entity names
 // list: Must be set to &#x60;true&#x60;
-func (a *IdentityService) GetIdentityEntityName(ctx context.Context, list string) (*http.Response, error) {
+func (a *Identity) GetIdentityEntityName(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -1766,7 +1768,7 @@ func (a *IdentityService) GetIdentityEntityName(ctx context.Context, list string
 
 // GetIdentityEntityNameName Update, read or delete an entity using entity name
 // name: Name of the entity
-func (a *IdentityService) GetIdentityEntityNameName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Identity) GetIdentityEntityNameName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -1833,7 +1835,7 @@ func (a *IdentityService) GetIdentityEntityNameName(ctx context.Context, name st
 
 // GetIdentityGroupAliasId List all the group alias IDs.
 // list: Must be set to &#x60;true&#x60;
-func (a *IdentityService) GetIdentityGroupAliasId(ctx context.Context, list string) (*http.Response, error) {
+func (a *Identity) GetIdentityGroupAliasId(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -1900,7 +1902,7 @@ func (a *IdentityService) GetIdentityGroupAliasId(ctx context.Context, list stri
 
 // GetIdentityGroupAliasIdId
 // id: ID of the group alias.
-func (a *IdentityService) GetIdentityGroupAliasIdId(ctx context.Context, id string) (*http.Response, error) {
+func (a *Identity) GetIdentityGroupAliasIdId(ctx context.Context, id string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -1967,7 +1969,7 @@ func (a *IdentityService) GetIdentityGroupAliasIdId(ctx context.Context, id stri
 
 // GetIdentityGroupId List all the group IDs.
 // list: Must be set to &#x60;true&#x60;
-func (a *IdentityService) GetIdentityGroupId(ctx context.Context, list string) (*http.Response, error) {
+func (a *Identity) GetIdentityGroupId(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -2034,7 +2036,7 @@ func (a *IdentityService) GetIdentityGroupId(ctx context.Context, list string) (
 
 // GetIdentityGroupIdId Update or delete an existing group using its ID.
 // id: ID of the group. If set, updates the corresponding existing group.
-func (a *IdentityService) GetIdentityGroupIdId(ctx context.Context, id string) (*http.Response, error) {
+func (a *Identity) GetIdentityGroupIdId(ctx context.Context, id string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -2101,7 +2103,7 @@ func (a *IdentityService) GetIdentityGroupIdId(ctx context.Context, id string) (
 
 // GetIdentityGroupName
 // list: Must be set to &#x60;true&#x60;
-func (a *IdentityService) GetIdentityGroupName(ctx context.Context, list string) (*http.Response, error) {
+func (a *Identity) GetIdentityGroupName(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -2168,7 +2170,7 @@ func (a *IdentityService) GetIdentityGroupName(ctx context.Context, list string)
 
 // GetIdentityGroupNameName
 // name: Name of the group.
-func (a *IdentityService) GetIdentityGroupNameName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Identity) GetIdentityGroupNameName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -2235,7 +2237,7 @@ func (a *IdentityService) GetIdentityGroupNameName(ctx context.Context, name str
 
 // GetIdentityMfaLoginEnforcement List login enforcements
 // list: Must be set to &#x60;true&#x60;
-func (a *IdentityService) GetIdentityMfaLoginEnforcement(ctx context.Context, list string) (*http.Response, error) {
+func (a *Identity) GetIdentityMfaLoginEnforcement(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -2302,7 +2304,7 @@ func (a *IdentityService) GetIdentityMfaLoginEnforcement(ctx context.Context, li
 
 // GetIdentityMfaLoginEnforcementName Read the current login enforcement
 // name: Name for this login enforcement configuration
-func (a *IdentityService) GetIdentityMfaLoginEnforcementName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Identity) GetIdentityMfaLoginEnforcementName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -2369,7 +2371,7 @@ func (a *IdentityService) GetIdentityMfaLoginEnforcementName(ctx context.Context
 
 // GetIdentityMfaMethod List MFA method configurations for all MFA methods
 // list: Must be set to &#x60;true&#x60;
-func (a *IdentityService) GetIdentityMfaMethod(ctx context.Context, list string) (*http.Response, error) {
+func (a *Identity) GetIdentityMfaMethod(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -2436,7 +2438,7 @@ func (a *IdentityService) GetIdentityMfaMethod(ctx context.Context, list string)
 
 // GetIdentityMfaMethodDuo List MFA method configurations for the given MFA method
 // list: Must be set to &#x60;true&#x60;
-func (a *IdentityService) GetIdentityMfaMethodDuo(ctx context.Context, list string) (*http.Response, error) {
+func (a *Identity) GetIdentityMfaMethodDuo(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -2503,7 +2505,7 @@ func (a *IdentityService) GetIdentityMfaMethodDuo(ctx context.Context, list stri
 
 // GetIdentityMfaMethodDuoMethodId Read the current configuration for the given MFA method
 // methodId: The unique identifier for this MFA method.
-func (a *IdentityService) GetIdentityMfaMethodDuoMethodId(ctx context.Context, methodId string) (*http.Response, error) {
+func (a *Identity) GetIdentityMfaMethodDuoMethodId(ctx context.Context, methodId string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -2570,7 +2572,7 @@ func (a *IdentityService) GetIdentityMfaMethodDuoMethodId(ctx context.Context, m
 
 // GetIdentityMfaMethodMethodId Read the current configuration for the given ID regardless of the MFA method type
 // methodId: The unique identifier for this MFA method.
-func (a *IdentityService) GetIdentityMfaMethodMethodId(ctx context.Context, methodId string) (*http.Response, error) {
+func (a *Identity) GetIdentityMfaMethodMethodId(ctx context.Context, methodId string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -2637,7 +2639,7 @@ func (a *IdentityService) GetIdentityMfaMethodMethodId(ctx context.Context, meth
 
 // GetIdentityMfaMethodOkta List MFA method configurations for the given MFA method
 // list: Must be set to &#x60;true&#x60;
-func (a *IdentityService) GetIdentityMfaMethodOkta(ctx context.Context, list string) (*http.Response, error) {
+func (a *Identity) GetIdentityMfaMethodOkta(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -2704,7 +2706,7 @@ func (a *IdentityService) GetIdentityMfaMethodOkta(ctx context.Context, list str
 
 // GetIdentityMfaMethodOktaMethodId Read the current configuration for the given MFA method
 // methodId: The unique identifier for this MFA method.
-func (a *IdentityService) GetIdentityMfaMethodOktaMethodId(ctx context.Context, methodId string) (*http.Response, error) {
+func (a *Identity) GetIdentityMfaMethodOktaMethodId(ctx context.Context, methodId string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -2771,7 +2773,7 @@ func (a *IdentityService) GetIdentityMfaMethodOktaMethodId(ctx context.Context, 
 
 // GetIdentityMfaMethodPingid List MFA method configurations for the given MFA method
 // list: Must be set to &#x60;true&#x60;
-func (a *IdentityService) GetIdentityMfaMethodPingid(ctx context.Context, list string) (*http.Response, error) {
+func (a *Identity) GetIdentityMfaMethodPingid(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -2838,7 +2840,7 @@ func (a *IdentityService) GetIdentityMfaMethodPingid(ctx context.Context, list s
 
 // GetIdentityMfaMethodPingidMethodId Read the current configuration for the given MFA method
 // methodId: The unique identifier for this MFA method.
-func (a *IdentityService) GetIdentityMfaMethodPingidMethodId(ctx context.Context, methodId string) (*http.Response, error) {
+func (a *Identity) GetIdentityMfaMethodPingidMethodId(ctx context.Context, methodId string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -2905,7 +2907,7 @@ func (a *IdentityService) GetIdentityMfaMethodPingidMethodId(ctx context.Context
 
 // GetIdentityMfaMethodTotp List MFA method configurations for the given MFA method
 // list: Must be set to &#x60;true&#x60;
-func (a *IdentityService) GetIdentityMfaMethodTotp(ctx context.Context, list string) (*http.Response, error) {
+func (a *Identity) GetIdentityMfaMethodTotp(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -2972,7 +2974,7 @@ func (a *IdentityService) GetIdentityMfaMethodTotp(ctx context.Context, list str
 
 // GetIdentityMfaMethodTotpMethodId Read the current configuration for the given MFA method
 // methodId: The unique identifier for this MFA method.
-func (a *IdentityService) GetIdentityMfaMethodTotpMethodId(ctx context.Context, methodId string) (*http.Response, error) {
+func (a *Identity) GetIdentityMfaMethodTotpMethodId(ctx context.Context, methodId string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -3039,7 +3041,7 @@ func (a *IdentityService) GetIdentityMfaMethodTotpMethodId(ctx context.Context, 
 
 // GetIdentityOidcAssignment
 // list: Must be set to &#x60;true&#x60;
-func (a *IdentityService) GetIdentityOidcAssignment(ctx context.Context, list string) (*http.Response, error) {
+func (a *Identity) GetIdentityOidcAssignment(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -3106,7 +3108,7 @@ func (a *IdentityService) GetIdentityOidcAssignment(ctx context.Context, list st
 
 // GetIdentityOidcAssignmentName
 // name: Name of the assignment
-func (a *IdentityService) GetIdentityOidcAssignmentName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Identity) GetIdentityOidcAssignmentName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -3173,7 +3175,7 @@ func (a *IdentityService) GetIdentityOidcAssignmentName(ctx context.Context, nam
 
 // GetIdentityOidcClient
 // list: Must be set to &#x60;true&#x60;
-func (a *IdentityService) GetIdentityOidcClient(ctx context.Context, list string) (*http.Response, error) {
+func (a *Identity) GetIdentityOidcClient(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -3240,7 +3242,7 @@ func (a *IdentityService) GetIdentityOidcClient(ctx context.Context, list string
 
 // GetIdentityOidcClientName
 // name: Name of the client.
-func (a *IdentityService) GetIdentityOidcClientName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Identity) GetIdentityOidcClientName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -3306,7 +3308,7 @@ func (a *IdentityService) GetIdentityOidcClientName(ctx context.Context, name st
 }
 
 // GetIdentityOidcConfig OIDC configuration
-func (a *IdentityService) GetIdentityOidcConfig(ctx context.Context) (*http.Response, error) {
+func (a *Identity) GetIdentityOidcConfig(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -3372,7 +3374,7 @@ func (a *IdentityService) GetIdentityOidcConfig(ctx context.Context) (*http.Resp
 
 // GetIdentityOidcKey List OIDC keys
 // list: Must be set to &#x60;true&#x60;
-func (a *IdentityService) GetIdentityOidcKey(ctx context.Context, list string) (*http.Response, error) {
+func (a *Identity) GetIdentityOidcKey(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -3439,7 +3441,7 @@ func (a *IdentityService) GetIdentityOidcKey(ctx context.Context, list string) (
 
 // GetIdentityOidcKeyName CRUD operations for OIDC keys.
 // name: Name of the key
-func (a *IdentityService) GetIdentityOidcKeyName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Identity) GetIdentityOidcKeyName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -3506,7 +3508,7 @@ func (a *IdentityService) GetIdentityOidcKeyName(ctx context.Context, name strin
 
 // GetIdentityOidcProvider
 // list: Must be set to &#x60;true&#x60;
-func (a *IdentityService) GetIdentityOidcProvider(ctx context.Context, list string) (*http.Response, error) {
+func (a *Identity) GetIdentityOidcProvider(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -3573,7 +3575,7 @@ func (a *IdentityService) GetIdentityOidcProvider(ctx context.Context, list stri
 
 // GetIdentityOidcProviderName
 // name: Name of the provider
-func (a *IdentityService) GetIdentityOidcProviderName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Identity) GetIdentityOidcProviderName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -3640,7 +3642,7 @@ func (a *IdentityService) GetIdentityOidcProviderName(ctx context.Context, name 
 
 // GetIdentityOidcProviderNameAuthorize
 // name: Name of the provider
-func (a *IdentityService) GetIdentityOidcProviderNameAuthorize(ctx context.Context, name string) (*http.Response, error) {
+func (a *Identity) GetIdentityOidcProviderNameAuthorize(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -3707,7 +3709,7 @@ func (a *IdentityService) GetIdentityOidcProviderNameAuthorize(ctx context.Conte
 
 // GetIdentityOidcProviderNameUserinfo
 // name: Name of the provider
-func (a *IdentityService) GetIdentityOidcProviderNameUserinfo(ctx context.Context, name string) (*http.Response, error) {
+func (a *Identity) GetIdentityOidcProviderNameUserinfo(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -3774,7 +3776,7 @@ func (a *IdentityService) GetIdentityOidcProviderNameUserinfo(ctx context.Contex
 
 // GetIdentityOidcProviderNameWellKnownKeys
 // name: Name of the provider
-func (a *IdentityService) GetIdentityOidcProviderNameWellKnownKeys(ctx context.Context, name string) (*http.Response, error) {
+func (a *Identity) GetIdentityOidcProviderNameWellKnownKeys(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -3841,7 +3843,7 @@ func (a *IdentityService) GetIdentityOidcProviderNameWellKnownKeys(ctx context.C
 
 // GetIdentityOidcProviderNameWellKnownOpenidConfiguration
 // name: Name of the provider
-func (a *IdentityService) GetIdentityOidcProviderNameWellKnownOpenidConfiguration(ctx context.Context, name string) (*http.Response, error) {
+func (a *Identity) GetIdentityOidcProviderNameWellKnownOpenidConfiguration(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -3908,7 +3910,7 @@ func (a *IdentityService) GetIdentityOidcProviderNameWellKnownOpenidConfiguratio
 
 // GetIdentityOidcRole List configured OIDC roles
 // list: Must be set to &#x60;true&#x60;
-func (a *IdentityService) GetIdentityOidcRole(ctx context.Context, list string) (*http.Response, error) {
+func (a *Identity) GetIdentityOidcRole(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -3975,7 +3977,7 @@ func (a *IdentityService) GetIdentityOidcRole(ctx context.Context, list string) 
 
 // GetIdentityOidcRoleName CRUD operations on OIDC Roles
 // name: Name of the role
-func (a *IdentityService) GetIdentityOidcRoleName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Identity) GetIdentityOidcRoleName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -4042,7 +4044,7 @@ func (a *IdentityService) GetIdentityOidcRoleName(ctx context.Context, name stri
 
 // GetIdentityOidcScope
 // list: Must be set to &#x60;true&#x60;
-func (a *IdentityService) GetIdentityOidcScope(ctx context.Context, list string) (*http.Response, error) {
+func (a *Identity) GetIdentityOidcScope(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -4109,7 +4111,7 @@ func (a *IdentityService) GetIdentityOidcScope(ctx context.Context, list string)
 
 // GetIdentityOidcScopeName
 // name: Name of the scope
-func (a *IdentityService) GetIdentityOidcScopeName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Identity) GetIdentityOidcScopeName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -4176,7 +4178,7 @@ func (a *IdentityService) GetIdentityOidcScopeName(ctx context.Context, name str
 
 // GetIdentityOidcTokenName Generate an OIDC token
 // name: Name of the role
-func (a *IdentityService) GetIdentityOidcTokenName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Identity) GetIdentityOidcTokenName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -4242,7 +4244,7 @@ func (a *IdentityService) GetIdentityOidcTokenName(ctx context.Context, name str
 }
 
 // GetIdentityOidcWellKnownKeys Retrieve public keys
-func (a *IdentityService) GetIdentityOidcWellKnownKeys(ctx context.Context) (*http.Response, error) {
+func (a *Identity) GetIdentityOidcWellKnownKeys(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -4307,7 +4309,7 @@ func (a *IdentityService) GetIdentityOidcWellKnownKeys(ctx context.Context) (*ht
 }
 
 // GetIdentityOidcWellKnownOpenidConfiguration Query OIDC configurations
-func (a *IdentityService) GetIdentityOidcWellKnownOpenidConfiguration(ctx context.Context) (*http.Response, error) {
+func (a *Identity) GetIdentityOidcWellKnownOpenidConfiguration(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -4373,7 +4375,7 @@ func (a *IdentityService) GetIdentityOidcWellKnownOpenidConfiguration(ctx contex
 
 // GetIdentityPersonaId List all the alias IDs.
 // list: Must be set to &#x60;true&#x60;
-func (a *IdentityService) GetIdentityPersonaId(ctx context.Context, list string) (*http.Response, error) {
+func (a *Identity) GetIdentityPersonaId(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -4440,7 +4442,7 @@ func (a *IdentityService) GetIdentityPersonaId(ctx context.Context, list string)
 
 // GetIdentityPersonaIdId Update, read or delete an alias ID.
 // id: ID of the persona
-func (a *IdentityService) GetIdentityPersonaIdId(ctx context.Context, id string) (*http.Response, error) {
+func (a *Identity) GetIdentityPersonaIdId(ctx context.Context, id string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -4506,7 +4508,7 @@ func (a *IdentityService) GetIdentityPersonaIdId(ctx context.Context, id string)
 }
 
 // PostIdentityAlias Create a new alias.
-func (a *IdentityService) PostIdentityAlias(ctx context.Context, identityAliasRequest IdentityAliasRequest) (*http.Response, error) {
+func (a *Identity) PostIdentityAlias(ctx context.Context, identityAliasRequest IdentityAliasRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -4574,7 +4576,7 @@ func (a *IdentityService) PostIdentityAlias(ctx context.Context, identityAliasRe
 
 // PostIdentityAliasIdId Update, read or delete an alias ID.
 // id: ID of the alias
-func (a *IdentityService) PostIdentityAliasIdId(ctx context.Context, id string, identityAliasIdRequest IdentityAliasIdRequest) (*http.Response, error) {
+func (a *Identity) PostIdentityAliasIdId(ctx context.Context, id string, identityAliasIdRequest IdentityAliasIdRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -4642,7 +4644,7 @@ func (a *IdentityService) PostIdentityAliasIdId(ctx context.Context, id string, 
 }
 
 // PostIdentityEntity Create a new entity
-func (a *IdentityService) PostIdentityEntity(ctx context.Context, identityEntityRequest IdentityEntityRequest) (*http.Response, error) {
+func (a *Identity) PostIdentityEntity(ctx context.Context, identityEntityRequest IdentityEntityRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -4709,7 +4711,7 @@ func (a *IdentityService) PostIdentityEntity(ctx context.Context, identityEntity
 }
 
 // PostIdentityEntityAlias Create a new alias.
-func (a *IdentityService) PostIdentityEntityAlias(ctx context.Context, identityEntityAliasRequest IdentityEntityAliasRequest) (*http.Response, error) {
+func (a *Identity) PostIdentityEntityAlias(ctx context.Context, identityEntityAliasRequest IdentityEntityAliasRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -4777,7 +4779,7 @@ func (a *IdentityService) PostIdentityEntityAlias(ctx context.Context, identityE
 
 // PostIdentityEntityAliasIdId Update, read or delete an alias ID.
 // id: ID of the alias
-func (a *IdentityService) PostIdentityEntityAliasIdId(ctx context.Context, id string, identityEntityAliasIdRequest IdentityEntityAliasIdRequest) (*http.Response, error) {
+func (a *Identity) PostIdentityEntityAliasIdId(ctx context.Context, id string, identityEntityAliasIdRequest IdentityEntityAliasIdRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -4845,7 +4847,7 @@ func (a *IdentityService) PostIdentityEntityAliasIdId(ctx context.Context, id st
 }
 
 // PostIdentityEntityBatchDelete Delete all of the entities provided
-func (a *IdentityService) PostIdentityEntityBatchDelete(ctx context.Context, identityEntityBatchDeleteRequest IdentityEntityBatchDeleteRequest) (*http.Response, error) {
+func (a *Identity) PostIdentityEntityBatchDelete(ctx context.Context, identityEntityBatchDeleteRequest IdentityEntityBatchDeleteRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -4913,7 +4915,7 @@ func (a *IdentityService) PostIdentityEntityBatchDelete(ctx context.Context, ide
 
 // PostIdentityEntityIdId Update, read or delete an entity using entity ID
 // id: ID of the entity. If set, updates the corresponding existing entity.
-func (a *IdentityService) PostIdentityEntityIdId(ctx context.Context, id string, identityEntityIdRequest IdentityEntityIdRequest) (*http.Response, error) {
+func (a *Identity) PostIdentityEntityIdId(ctx context.Context, id string, identityEntityIdRequest IdentityEntityIdRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -4981,7 +4983,7 @@ func (a *IdentityService) PostIdentityEntityIdId(ctx context.Context, id string,
 }
 
 // PostIdentityEntityMerge Merge two or more entities together
-func (a *IdentityService) PostIdentityEntityMerge(ctx context.Context, identityEntityMergeRequest IdentityEntityMergeRequest) (*http.Response, error) {
+func (a *Identity) PostIdentityEntityMerge(ctx context.Context, identityEntityMergeRequest IdentityEntityMergeRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -5049,7 +5051,7 @@ func (a *IdentityService) PostIdentityEntityMerge(ctx context.Context, identityE
 
 // PostIdentityEntityNameName Update, read or delete an entity using entity name
 // name: Name of the entity
-func (a *IdentityService) PostIdentityEntityNameName(ctx context.Context, name string, identityEntityNameRequest IdentityEntityNameRequest) (*http.Response, error) {
+func (a *Identity) PostIdentityEntityNameName(ctx context.Context, name string, identityEntityNameRequest IdentityEntityNameRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -5117,7 +5119,7 @@ func (a *IdentityService) PostIdentityEntityNameName(ctx context.Context, name s
 }
 
 // PostIdentityGroup Create a new group.
-func (a *IdentityService) PostIdentityGroup(ctx context.Context, identityGroupRequest IdentityGroupRequest) (*http.Response, error) {
+func (a *Identity) PostIdentityGroup(ctx context.Context, identityGroupRequest IdentityGroupRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -5184,7 +5186,7 @@ func (a *IdentityService) PostIdentityGroup(ctx context.Context, identityGroupRe
 }
 
 // PostIdentityGroupAlias Creates a new group alias, or updates an existing one.
-func (a *IdentityService) PostIdentityGroupAlias(ctx context.Context, identityGroupAliasRequest IdentityGroupAliasRequest) (*http.Response, error) {
+func (a *Identity) PostIdentityGroupAlias(ctx context.Context, identityGroupAliasRequest IdentityGroupAliasRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -5252,7 +5254,7 @@ func (a *IdentityService) PostIdentityGroupAlias(ctx context.Context, identityGr
 
 // PostIdentityGroupAliasIdId
 // id: ID of the group alias.
-func (a *IdentityService) PostIdentityGroupAliasIdId(ctx context.Context, id string, identityGroupAliasIdRequest IdentityGroupAliasIdRequest) (*http.Response, error) {
+func (a *Identity) PostIdentityGroupAliasIdId(ctx context.Context, id string, identityGroupAliasIdRequest IdentityGroupAliasIdRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -5321,7 +5323,7 @@ func (a *IdentityService) PostIdentityGroupAliasIdId(ctx context.Context, id str
 
 // PostIdentityGroupIdId Update or delete an existing group using its ID.
 // id: ID of the group. If set, updates the corresponding existing group.
-func (a *IdentityService) PostIdentityGroupIdId(ctx context.Context, id string, identityGroupIdRequest IdentityGroupIdRequest) (*http.Response, error) {
+func (a *Identity) PostIdentityGroupIdId(ctx context.Context, id string, identityGroupIdRequest IdentityGroupIdRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -5390,7 +5392,7 @@ func (a *IdentityService) PostIdentityGroupIdId(ctx context.Context, id string, 
 
 // PostIdentityGroupNameName
 // name: Name of the group.
-func (a *IdentityService) PostIdentityGroupNameName(ctx context.Context, name string, identityGroupNameRequest IdentityGroupNameRequest) (*http.Response, error) {
+func (a *Identity) PostIdentityGroupNameName(ctx context.Context, name string, identityGroupNameRequest IdentityGroupNameRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -5458,7 +5460,7 @@ func (a *IdentityService) PostIdentityGroupNameName(ctx context.Context, name st
 }
 
 // PostIdentityLookupEntity Query entities based on various properties.
-func (a *IdentityService) PostIdentityLookupEntity(ctx context.Context, identityLookupEntityRequest IdentityLookupEntityRequest) (*http.Response, error) {
+func (a *Identity) PostIdentityLookupEntity(ctx context.Context, identityLookupEntityRequest IdentityLookupEntityRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -5525,7 +5527,7 @@ func (a *IdentityService) PostIdentityLookupEntity(ctx context.Context, identity
 }
 
 // PostIdentityLookupGroup Query groups based on various properties.
-func (a *IdentityService) PostIdentityLookupGroup(ctx context.Context, identityLookupGroupRequest IdentityLookupGroupRequest) (*http.Response, error) {
+func (a *Identity) PostIdentityLookupGroup(ctx context.Context, identityLookupGroupRequest IdentityLookupGroupRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -5593,7 +5595,7 @@ func (a *IdentityService) PostIdentityLookupGroup(ctx context.Context, identityL
 
 // PostIdentityMfaLoginEnforcementName Create or update a login enforcement
 // name: Name for this login enforcement configuration
-func (a *IdentityService) PostIdentityMfaLoginEnforcementName(ctx context.Context, name string, identityMfaLoginEnforcementRequest IdentityMfaLoginEnforcementRequest) (*http.Response, error) {
+func (a *Identity) PostIdentityMfaLoginEnforcementName(ctx context.Context, name string, identityMfaLoginEnforcementRequest IdentityMfaLoginEnforcementRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -5662,7 +5664,7 @@ func (a *IdentityService) PostIdentityMfaLoginEnforcementName(ctx context.Contex
 
 // PostIdentityMfaMethodDuoMethodId Update or create a configuration for the given MFA method
 // methodId: The unique identifier for this MFA method.
-func (a *IdentityService) PostIdentityMfaMethodDuoMethodId(ctx context.Context, methodId string, identityMfaMethodDuoRequest IdentityMfaMethodDuoRequest) (*http.Response, error) {
+func (a *Identity) PostIdentityMfaMethodDuoMethodId(ctx context.Context, methodId string, identityMfaMethodDuoRequest IdentityMfaMethodDuoRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -5731,7 +5733,7 @@ func (a *IdentityService) PostIdentityMfaMethodDuoMethodId(ctx context.Context, 
 
 // PostIdentityMfaMethodOktaMethodId Update or create a configuration for the given MFA method
 // methodId: The unique identifier for this MFA method.
-func (a *IdentityService) PostIdentityMfaMethodOktaMethodId(ctx context.Context, methodId string, identityMfaMethodOktaRequest IdentityMfaMethodOktaRequest) (*http.Response, error) {
+func (a *Identity) PostIdentityMfaMethodOktaMethodId(ctx context.Context, methodId string, identityMfaMethodOktaRequest IdentityMfaMethodOktaRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -5800,7 +5802,7 @@ func (a *IdentityService) PostIdentityMfaMethodOktaMethodId(ctx context.Context,
 
 // PostIdentityMfaMethodPingidMethodId Update or create a configuration for the given MFA method
 // methodId: The unique identifier for this MFA method.
-func (a *IdentityService) PostIdentityMfaMethodPingidMethodId(ctx context.Context, methodId string, identityMfaMethodPingidRequest IdentityMfaMethodPingidRequest) (*http.Response, error) {
+func (a *Identity) PostIdentityMfaMethodPingidMethodId(ctx context.Context, methodId string, identityMfaMethodPingidRequest IdentityMfaMethodPingidRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -5868,7 +5870,7 @@ func (a *IdentityService) PostIdentityMfaMethodPingidMethodId(ctx context.Contex
 }
 
 // PostIdentityMfaMethodTotpAdminDestroy Destroys a TOTP secret for the given MFA method ID on the given entity
-func (a *IdentityService) PostIdentityMfaMethodTotpAdminDestroy(ctx context.Context, identityMfaMethodTotpAdminDestroyRequest IdentityMfaMethodTotpAdminDestroyRequest) (*http.Response, error) {
+func (a *Identity) PostIdentityMfaMethodTotpAdminDestroy(ctx context.Context, identityMfaMethodTotpAdminDestroyRequest IdentityMfaMethodTotpAdminDestroyRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -5935,7 +5937,7 @@ func (a *IdentityService) PostIdentityMfaMethodTotpAdminDestroy(ctx context.Cont
 }
 
 // PostIdentityMfaMethodTotpAdminGenerate Update or create TOTP secret for the given method ID on the given entity.
-func (a *IdentityService) PostIdentityMfaMethodTotpAdminGenerate(ctx context.Context, identityMfaMethodTotpAdminGenerateRequest IdentityMfaMethodTotpAdminGenerateRequest) (*http.Response, error) {
+func (a *Identity) PostIdentityMfaMethodTotpAdminGenerate(ctx context.Context, identityMfaMethodTotpAdminGenerateRequest IdentityMfaMethodTotpAdminGenerateRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -6002,7 +6004,7 @@ func (a *IdentityService) PostIdentityMfaMethodTotpAdminGenerate(ctx context.Con
 }
 
 // PostIdentityMfaMethodTotpGenerate Update or create TOTP secret for the given method ID on the given entity.
-func (a *IdentityService) PostIdentityMfaMethodTotpGenerate(ctx context.Context, identityMfaMethodTotpGenerateRequest IdentityMfaMethodTotpGenerateRequest) (*http.Response, error) {
+func (a *Identity) PostIdentityMfaMethodTotpGenerate(ctx context.Context, identityMfaMethodTotpGenerateRequest IdentityMfaMethodTotpGenerateRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -6070,7 +6072,7 @@ func (a *IdentityService) PostIdentityMfaMethodTotpGenerate(ctx context.Context,
 
 // PostIdentityMfaMethodTotpMethodId Update or create a configuration for the given MFA method
 // methodId: The unique identifier for this MFA method.
-func (a *IdentityService) PostIdentityMfaMethodTotpMethodId(ctx context.Context, methodId string, identityMfaMethodTotpRequest IdentityMfaMethodTotpRequest) (*http.Response, error) {
+func (a *Identity) PostIdentityMfaMethodTotpMethodId(ctx context.Context, methodId string, identityMfaMethodTotpRequest IdentityMfaMethodTotpRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -6139,7 +6141,7 @@ func (a *IdentityService) PostIdentityMfaMethodTotpMethodId(ctx context.Context,
 
 // PostIdentityOidcAssignmentName
 // name: Name of the assignment
-func (a *IdentityService) PostIdentityOidcAssignmentName(ctx context.Context, name string, identityOidcAssignmentRequest IdentityOidcAssignmentRequest) (*http.Response, error) {
+func (a *Identity) PostIdentityOidcAssignmentName(ctx context.Context, name string, identityOidcAssignmentRequest IdentityOidcAssignmentRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -6208,7 +6210,7 @@ func (a *IdentityService) PostIdentityOidcAssignmentName(ctx context.Context, na
 
 // PostIdentityOidcClientName
 // name: Name of the client.
-func (a *IdentityService) PostIdentityOidcClientName(ctx context.Context, name string, identityOidcClientRequest IdentityOidcClientRequest) (*http.Response, error) {
+func (a *Identity) PostIdentityOidcClientName(ctx context.Context, name string, identityOidcClientRequest IdentityOidcClientRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -6276,7 +6278,7 @@ func (a *IdentityService) PostIdentityOidcClientName(ctx context.Context, name s
 }
 
 // PostIdentityOidcConfig OIDC configuration
-func (a *IdentityService) PostIdentityOidcConfig(ctx context.Context, identityOidcConfigRequest IdentityOidcConfigRequest) (*http.Response, error) {
+func (a *Identity) PostIdentityOidcConfig(ctx context.Context, identityOidcConfigRequest IdentityOidcConfigRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -6343,7 +6345,7 @@ func (a *IdentityService) PostIdentityOidcConfig(ctx context.Context, identityOi
 }
 
 // PostIdentityOidcIntrospect Verify the authenticity of an OIDC token
-func (a *IdentityService) PostIdentityOidcIntrospect(ctx context.Context, identityOidcIntrospectRequest IdentityOidcIntrospectRequest) (*http.Response, error) {
+func (a *Identity) PostIdentityOidcIntrospect(ctx context.Context, identityOidcIntrospectRequest IdentityOidcIntrospectRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -6411,7 +6413,7 @@ func (a *IdentityService) PostIdentityOidcIntrospect(ctx context.Context, identi
 
 // PostIdentityOidcKeyName CRUD operations for OIDC keys.
 // name: Name of the key
-func (a *IdentityService) PostIdentityOidcKeyName(ctx context.Context, name string, identityOidcKeyRequest IdentityOidcKeyRequest) (*http.Response, error) {
+func (a *Identity) PostIdentityOidcKeyName(ctx context.Context, name string, identityOidcKeyRequest IdentityOidcKeyRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -6480,7 +6482,7 @@ func (a *IdentityService) PostIdentityOidcKeyName(ctx context.Context, name stri
 
 // PostIdentityOidcKeyNameRotate Rotate a named OIDC key.
 // name: Name of the key
-func (a *IdentityService) PostIdentityOidcKeyNameRotate(ctx context.Context, name string, identityOidcKeyRotateRequest IdentityOidcKeyRotateRequest) (*http.Response, error) {
+func (a *Identity) PostIdentityOidcKeyNameRotate(ctx context.Context, name string, identityOidcKeyRotateRequest IdentityOidcKeyRotateRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -6549,7 +6551,7 @@ func (a *IdentityService) PostIdentityOidcKeyNameRotate(ctx context.Context, nam
 
 // PostIdentityOidcProviderName
 // name: Name of the provider
-func (a *IdentityService) PostIdentityOidcProviderName(ctx context.Context, name string, identityOidcProviderRequest IdentityOidcProviderRequest) (*http.Response, error) {
+func (a *Identity) PostIdentityOidcProviderName(ctx context.Context, name string, identityOidcProviderRequest IdentityOidcProviderRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -6618,7 +6620,7 @@ func (a *IdentityService) PostIdentityOidcProviderName(ctx context.Context, name
 
 // PostIdentityOidcProviderNameAuthorize
 // name: Name of the provider
-func (a *IdentityService) PostIdentityOidcProviderNameAuthorize(ctx context.Context, name string, identityOidcProviderAuthorizeRequest IdentityOidcProviderAuthorizeRequest) (*http.Response, error) {
+func (a *Identity) PostIdentityOidcProviderNameAuthorize(ctx context.Context, name string, identityOidcProviderAuthorizeRequest IdentityOidcProviderAuthorizeRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -6687,7 +6689,7 @@ func (a *IdentityService) PostIdentityOidcProviderNameAuthorize(ctx context.Cont
 
 // PostIdentityOidcProviderNameToken
 // name: Name of the provider
-func (a *IdentityService) PostIdentityOidcProviderNameToken(ctx context.Context, name string, identityOidcProviderTokenRequest IdentityOidcProviderTokenRequest) (*http.Response, error) {
+func (a *Identity) PostIdentityOidcProviderNameToken(ctx context.Context, name string, identityOidcProviderTokenRequest IdentityOidcProviderTokenRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -6756,7 +6758,7 @@ func (a *IdentityService) PostIdentityOidcProviderNameToken(ctx context.Context,
 
 // PostIdentityOidcProviderNameUserinfo
 // name: Name of the provider
-func (a *IdentityService) PostIdentityOidcProviderNameUserinfo(ctx context.Context, name string) (*http.Response, error) {
+func (a *Identity) PostIdentityOidcProviderNameUserinfo(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -6823,7 +6825,7 @@ func (a *IdentityService) PostIdentityOidcProviderNameUserinfo(ctx context.Conte
 
 // PostIdentityOidcRoleName CRUD operations on OIDC Roles
 // name: Name of the role
-func (a *IdentityService) PostIdentityOidcRoleName(ctx context.Context, name string, identityOidcRoleRequest IdentityOidcRoleRequest) (*http.Response, error) {
+func (a *Identity) PostIdentityOidcRoleName(ctx context.Context, name string, identityOidcRoleRequest IdentityOidcRoleRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -6892,7 +6894,7 @@ func (a *IdentityService) PostIdentityOidcRoleName(ctx context.Context, name str
 
 // PostIdentityOidcScopeName
 // name: Name of the scope
-func (a *IdentityService) PostIdentityOidcScopeName(ctx context.Context, name string, identityOidcScopeRequest IdentityOidcScopeRequest) (*http.Response, error) {
+func (a *Identity) PostIdentityOidcScopeName(ctx context.Context, name string, identityOidcScopeRequest IdentityOidcScopeRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -6960,7 +6962,7 @@ func (a *IdentityService) PostIdentityOidcScopeName(ctx context.Context, name st
 }
 
 // PostIdentityPersona Create a new alias.
-func (a *IdentityService) PostIdentityPersona(ctx context.Context, identityPersonaRequest IdentityPersonaRequest) (*http.Response, error) {
+func (a *Identity) PostIdentityPersona(ctx context.Context, identityPersonaRequest IdentityPersonaRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -7028,7 +7030,7 @@ func (a *IdentityService) PostIdentityPersona(ctx context.Context, identityPerso
 
 // PostIdentityPersonaIdId Update, read or delete an alias ID.
 // id: ID of the persona
-func (a *IdentityService) PostIdentityPersonaIdId(ctx context.Context, id string, identityPersonaIdRequest IdentityPersonaIdRequest) (*http.Response, error) {
+func (a *Identity) PostIdentityPersonaIdId(ctx context.Context, id string, identityPersonaIdRequest IdentityPersonaIdRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}

--- a/api_secrets.go
+++ b/api_secrets.go
@@ -19,11 +19,13 @@ import (
 	"strings"
 )
 
-// SecretsService Secrets service
-type SecretsService service
+// Secrets is a simple wrapper around the client for Secrets requests
+type Secrets struct {
+	client *Client
+}
 
 // DeleteAdConfig Configure the AD server to connect to, along with password options.
-func (a *SecretsService) DeleteAdConfig(ctx context.Context) (*http.Response, error) {
+func (a *Secrets) DeleteAdConfig(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -89,7 +91,7 @@ func (a *SecretsService) DeleteAdConfig(ctx context.Context) (*http.Response, er
 
 // DeleteAdLibraryName Delete a library set.
 // name: Name of the set.
-func (a *SecretsService) DeleteAdLibraryName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Secrets) DeleteAdLibraryName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -156,7 +158,7 @@ func (a *SecretsService) DeleteAdLibraryName(ctx context.Context, name string) (
 
 // DeleteAdRolesName Manage roles to build links between Vault and Active Directory service accounts.
 // name: Name of the role
-func (a *SecretsService) DeleteAdRolesName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Secrets) DeleteAdRolesName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -222,7 +224,7 @@ func (a *SecretsService) DeleteAdRolesName(ctx context.Context, name string) (*h
 }
 
 // DeleteAlicloudConfig Configure the access key and secret to use for RAM and STS calls.
-func (a *SecretsService) DeleteAlicloudConfig(ctx context.Context) (*http.Response, error) {
+func (a *Secrets) DeleteAlicloudConfig(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -288,7 +290,7 @@ func (a *SecretsService) DeleteAlicloudConfig(ctx context.Context) (*http.Respon
 
 // DeleteAlicloudRoleName Read, write and reference policies and roles that API keys or STS credentials can be made for.
 // name: The name of the role.
-func (a *SecretsService) DeleteAlicloudRoleName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Secrets) DeleteAlicloudRoleName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -355,7 +357,7 @@ func (a *SecretsService) DeleteAlicloudRoleName(ctx context.Context, name string
 
 // DeleteAwsRolesName Read, write and reference IAM policies that access keys can be made for.
 // name: Name of the policy
-func (a *SecretsService) DeleteAwsRolesName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Secrets) DeleteAwsRolesName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -421,7 +423,7 @@ func (a *SecretsService) DeleteAwsRolesName(ctx context.Context, name string) (*
 }
 
 // DeleteAzureConfig
-func (a *SecretsService) DeleteAzureConfig(ctx context.Context) (*http.Response, error) {
+func (a *Secrets) DeleteAzureConfig(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -487,7 +489,7 @@ func (a *SecretsService) DeleteAzureConfig(ctx context.Context) (*http.Response,
 
 // DeleteAzureRolesName Manage the Vault roles used to generate Azure credentials.
 // name: Name of the role.
-func (a *SecretsService) DeleteAzureRolesName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Secrets) DeleteAzureRolesName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -554,7 +556,7 @@ func (a *SecretsService) DeleteAzureRolesName(ctx context.Context, name string) 
 
 // DeleteConsulRolesName
 // name: Name of the role.
-func (a *SecretsService) DeleteConsulRolesName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Secrets) DeleteConsulRolesName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -621,7 +623,7 @@ func (a *SecretsService) DeleteConsulRolesName(ctx context.Context, name string)
 
 // DeleteCubbyholePath Deletes the secret at the specified location.
 // path: Specifies the path of the secret.
-func (a *SecretsService) DeleteCubbyholePath(ctx context.Context, path string) (*http.Response, error) {
+func (a *Secrets) DeleteCubbyholePath(ctx context.Context, path string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -688,7 +690,7 @@ func (a *SecretsService) DeleteCubbyholePath(ctx context.Context, path string) (
 
 // DeleteGcpRolesetName
 // name: Required. Name of the role.
-func (a *SecretsService) DeleteGcpRolesetName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Secrets) DeleteGcpRolesetName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -755,7 +757,7 @@ func (a *SecretsService) DeleteGcpRolesetName(ctx context.Context, name string) 
 
 // DeleteGcpStaticAccountName
 // name: Required. Name to refer to this static account in Vault. Cannot be updated.
-func (a *SecretsService) DeleteGcpStaticAccountName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Secrets) DeleteGcpStaticAccountName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -821,7 +823,7 @@ func (a *SecretsService) DeleteGcpStaticAccountName(ctx context.Context, name st
 }
 
 // DeleteGcpkmsConfig Configure the GCP KMS secrets engine
-func (a *SecretsService) DeleteGcpkmsConfig(ctx context.Context) (*http.Response, error) {
+func (a *Secrets) DeleteGcpkmsConfig(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -887,7 +889,7 @@ func (a *SecretsService) DeleteGcpkmsConfig(ctx context.Context) (*http.Response
 
 // DeleteGcpkmsKeysDeregisterKey Deregister an existing key in Vault
 // key: Name of the key to deregister in Vault. If the key exists in Google Cloud KMS, it will be left untouched.
-func (a *SecretsService) DeleteGcpkmsKeysDeregisterKey(ctx context.Context, key string) (*http.Response, error) {
+func (a *Secrets) DeleteGcpkmsKeysDeregisterKey(ctx context.Context, key string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -954,7 +956,7 @@ func (a *SecretsService) DeleteGcpkmsKeysDeregisterKey(ctx context.Context, key 
 
 // DeleteGcpkmsKeysKey Interact with crypto keys in Vault and Google Cloud KMS
 // key: Name of the key in Vault.
-func (a *SecretsService) DeleteGcpkmsKeysKey(ctx context.Context, key string) (*http.Response, error) {
+func (a *Secrets) DeleteGcpkmsKeysKey(ctx context.Context, key string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -1021,7 +1023,7 @@ func (a *SecretsService) DeleteGcpkmsKeysKey(ctx context.Context, key string) (*
 
 // DeleteGcpkmsKeysTrimKey Delete old crypto key versions from Google Cloud KMS
 // key: Name of the key in Vault.
-func (a *SecretsService) DeleteGcpkmsKeysTrimKey(ctx context.Context, key string) (*http.Response, error) {
+func (a *Secrets) DeleteGcpkmsKeysTrimKey(ctx context.Context, key string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -1087,7 +1089,7 @@ func (a *SecretsService) DeleteGcpkmsKeysTrimKey(ctx context.Context, key string
 }
 
 // DeleteKubernetesConfig
-func (a *SecretsService) DeleteKubernetesConfig(ctx context.Context) (*http.Response, error) {
+func (a *Secrets) DeleteKubernetesConfig(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -1153,7 +1155,7 @@ func (a *SecretsService) DeleteKubernetesConfig(ctx context.Context) (*http.Resp
 
 // DeleteKubernetesRolesName
 // name: Name of the role
-func (a *SecretsService) DeleteKubernetesRolesName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Secrets) DeleteKubernetesRolesName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -1220,7 +1222,7 @@ func (a *SecretsService) DeleteKubernetesRolesName(ctx context.Context, name str
 
 // DeleteKvPath Pass-through secret storage to the storage backend, allowing you to read/write arbitrary data into secret storage.
 // path: Location of the secret.
-func (a *SecretsService) DeleteKvPath(ctx context.Context, path string) (*http.Response, error) {
+func (a *Secrets) DeleteKvPath(ctx context.Context, path string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -1287,7 +1289,7 @@ func (a *SecretsService) DeleteKvPath(ctx context.Context, path string) (*http.R
 
 // DeleteMongodbatlasRolesName Manage the roles used to generate MongoDB Atlas Programmatic API Keys.
 // name: Name of the Roles
-func (a *SecretsService) DeleteMongodbatlasRolesName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Secrets) DeleteMongodbatlasRolesName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -1353,7 +1355,7 @@ func (a *SecretsService) DeleteMongodbatlasRolesName(ctx context.Context, name s
 }
 
 // DeleteNomadConfigAccess
-func (a *SecretsService) DeleteNomadConfigAccess(ctx context.Context) (*http.Response, error) {
+func (a *Secrets) DeleteNomadConfigAccess(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -1418,7 +1420,7 @@ func (a *SecretsService) DeleteNomadConfigAccess(ctx context.Context) (*http.Res
 }
 
 // DeleteNomadConfigLease Configure the lease parameters for generated tokens
-func (a *SecretsService) DeleteNomadConfigLease(ctx context.Context) (*http.Response, error) {
+func (a *Secrets) DeleteNomadConfigLease(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -1484,7 +1486,7 @@ func (a *SecretsService) DeleteNomadConfigLease(ctx context.Context) (*http.Resp
 
 // DeleteNomadRoleName
 // name: Name of the role
-func (a *SecretsService) DeleteNomadRoleName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Secrets) DeleteNomadRoleName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -1550,7 +1552,7 @@ func (a *SecretsService) DeleteNomadRoleName(ctx context.Context, name string) (
 }
 
 // DeleteOpenldapConfig
-func (a *SecretsService) DeleteOpenldapConfig(ctx context.Context) (*http.Response, error) {
+func (a *Secrets) DeleteOpenldapConfig(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -1616,7 +1618,7 @@ func (a *SecretsService) DeleteOpenldapConfig(ctx context.Context) (*http.Respon
 
 // DeleteOpenldapRoleName
 // name: Name of the role (lowercase)
-func (a *SecretsService) DeleteOpenldapRoleName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Secrets) DeleteOpenldapRoleName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -1683,7 +1685,7 @@ func (a *SecretsService) DeleteOpenldapRoleName(ctx context.Context, name string
 
 // DeleteOpenldapStaticRoleName
 // name: Name of the role
-func (a *SecretsService) DeleteOpenldapStaticRoleName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Secrets) DeleteOpenldapStaticRoleName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -1750,7 +1752,7 @@ func (a *SecretsService) DeleteOpenldapStaticRoleName(ctx context.Context, name 
 
 // DeletePkiIssuerRefDerPem
 // issuerRef: Reference to a existing issuer; either \&quot;default\&quot; for the configured default issuer, an identifier or the name assigned to the issuer.
-func (a *SecretsService) DeletePkiIssuerRefDerPem(ctx context.Context, issuerRef string) (*http.Response, error) {
+func (a *Secrets) DeletePkiIssuerRefDerPem(ctx context.Context, issuerRef string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -1816,7 +1818,7 @@ func (a *SecretsService) DeletePkiIssuerRefDerPem(ctx context.Context, issuerRef
 }
 
 // DeletePkiJson
-func (a *SecretsService) DeletePkiJson(ctx context.Context) (*http.Response, error) {
+func (a *Secrets) DeletePkiJson(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -1882,7 +1884,7 @@ func (a *SecretsService) DeletePkiJson(ctx context.Context) (*http.Response, err
 
 // DeletePkiKeyKeyRef
 // keyRef: Reference to key; either \&quot;default\&quot; for the configured default key, an identifier of a key, or the name assigned to the key.
-func (a *SecretsService) DeletePkiKeyKeyRef(ctx context.Context, keyRef string) (*http.Response, error) {
+func (a *Secrets) DeletePkiKeyKeyRef(ctx context.Context, keyRef string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -1949,7 +1951,7 @@ func (a *SecretsService) DeletePkiKeyKeyRef(ctx context.Context, keyRef string) 
 
 // DeletePkiRolesName
 // name: Name of the role
-func (a *SecretsService) DeletePkiRolesName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Secrets) DeletePkiRolesName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -2015,7 +2017,7 @@ func (a *SecretsService) DeletePkiRolesName(ctx context.Context, name string) (*
 }
 
 // DeletePkiRoot
-func (a *SecretsService) DeletePkiRoot(ctx context.Context) (*http.Response, error) {
+func (a *Secrets) DeletePkiRoot(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -2081,7 +2083,7 @@ func (a *SecretsService) DeletePkiRoot(ctx context.Context) (*http.Response, err
 
 // DeleteRabbitmqRolesName Manage the roles that can be created with this backend.
 // name: Name of the role.
-func (a *SecretsService) DeleteRabbitmqRolesName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Secrets) DeleteRabbitmqRolesName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -2148,7 +2150,7 @@ func (a *SecretsService) DeleteRabbitmqRolesName(ctx context.Context, name strin
 
 // DeleteSecretDataPath Write, Patch, Read, and Delete data in the Key-Value Store.
 // path: Location of the secret.
-func (a *SecretsService) DeleteSecretDataPath(ctx context.Context, path string) (*http.Response, error) {
+func (a *Secrets) DeleteSecretDataPath(ctx context.Context, path string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -2215,7 +2217,7 @@ func (a *SecretsService) DeleteSecretDataPath(ctx context.Context, path string) 
 
 // DeleteSecretMetadataPath Configures settings for the KV store
 // path: Location of the secret.
-func (a *SecretsService) DeleteSecretMetadataPath(ctx context.Context, path string) (*http.Response, error) {
+func (a *Secrets) DeleteSecretMetadataPath(ctx context.Context, path string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -2281,7 +2283,7 @@ func (a *SecretsService) DeleteSecretMetadataPath(ctx context.Context, path stri
 }
 
 // DeleteSshConfigCa Set the SSH private key used for signing certificates.
-func (a *SecretsService) DeleteSshConfigCa(ctx context.Context) (*http.Response, error) {
+func (a *Secrets) DeleteSshConfigCa(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -2346,7 +2348,7 @@ func (a *SecretsService) DeleteSshConfigCa(ctx context.Context) (*http.Response,
 }
 
 // DeleteSshConfigZeroaddress Assign zero address as default CIDR block for select roles.
-func (a *SecretsService) DeleteSshConfigZeroaddress(ctx context.Context) (*http.Response, error) {
+func (a *Secrets) DeleteSshConfigZeroaddress(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -2412,7 +2414,7 @@ func (a *SecretsService) DeleteSshConfigZeroaddress(ctx context.Context) (*http.
 
 // DeleteSshKeysKeyName Register a shared private key with Vault.
 // keyName: [Required] Name of the key
-func (a *SecretsService) DeleteSshKeysKeyName(ctx context.Context, keyName string) (*http.Response, error) {
+func (a *Secrets) DeleteSshKeysKeyName(ctx context.Context, keyName string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -2479,7 +2481,7 @@ func (a *SecretsService) DeleteSshKeysKeyName(ctx context.Context, keyName strin
 
 // DeleteSshRolesRole Manage the 'roles' that can be created with this backend.
 // role: [Required for all types] Name of the role being created.
-func (a *SecretsService) DeleteSshRolesRole(ctx context.Context, role string) (*http.Response, error) {
+func (a *Secrets) DeleteSshRolesRole(ctx context.Context, role string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -2545,7 +2547,7 @@ func (a *SecretsService) DeleteSshRolesRole(ctx context.Context, role string) (*
 }
 
 // DeleteTerraformConfig
-func (a *SecretsService) DeleteTerraformConfig(ctx context.Context) (*http.Response, error) {
+func (a *Secrets) DeleteTerraformConfig(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -2611,7 +2613,7 @@ func (a *SecretsService) DeleteTerraformConfig(ctx context.Context) (*http.Respo
 
 // DeleteTerraformRoleName
 // name: Name of the role
-func (a *SecretsService) DeleteTerraformRoleName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Secrets) DeleteTerraformRoleName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -2678,7 +2680,7 @@ func (a *SecretsService) DeleteTerraformRoleName(ctx context.Context, name strin
 
 // DeleteTotpKeysName Manage the keys that can be created with this backend.
 // name: Name of the key.
-func (a *SecretsService) DeleteTotpKeysName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Secrets) DeleteTotpKeysName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -2745,7 +2747,7 @@ func (a *SecretsService) DeleteTotpKeysName(ctx context.Context, name string) (*
 
 // DeleteTransitKeysName Managed named encryption keys
 // name: Name of the key
-func (a *SecretsService) DeleteTransitKeysName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Secrets) DeleteTransitKeysName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -2811,7 +2813,7 @@ func (a *SecretsService) DeleteTransitKeysName(ctx context.Context, name string)
 }
 
 // GetAdConfig Configure the AD server to connect to, along with password options.
-func (a *SecretsService) GetAdConfig(ctx context.Context) (*http.Response, error) {
+func (a *Secrets) GetAdConfig(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -2877,7 +2879,7 @@ func (a *SecretsService) GetAdConfig(ctx context.Context) (*http.Response, error
 
 // GetAdCredsName
 // name: Name of the role
-func (a *SecretsService) GetAdCredsName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Secrets) GetAdCredsName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -2944,7 +2946,7 @@ func (a *SecretsService) GetAdCredsName(ctx context.Context, name string) (*http
 
 // GetAdLibrary
 // list: Must be set to &#x60;true&#x60;
-func (a *SecretsService) GetAdLibrary(ctx context.Context, list string) (*http.Response, error) {
+func (a *Secrets) GetAdLibrary(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -3011,7 +3013,7 @@ func (a *SecretsService) GetAdLibrary(ctx context.Context, list string) (*http.R
 
 // GetAdLibraryName Read a library set.
 // name: Name of the set.
-func (a *SecretsService) GetAdLibraryName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Secrets) GetAdLibraryName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -3078,7 +3080,7 @@ func (a *SecretsService) GetAdLibraryName(ctx context.Context, name string) (*ht
 
 // GetAdLibraryNameStatus Check the status of the service accounts in a library set.
 // name: Name of the set.
-func (a *SecretsService) GetAdLibraryNameStatus(ctx context.Context, name string) (*http.Response, error) {
+func (a *Secrets) GetAdLibraryNameStatus(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -3145,7 +3147,7 @@ func (a *SecretsService) GetAdLibraryNameStatus(ctx context.Context, name string
 
 // GetAdRoles List the name of each role currently stored.
 // list: Must be set to &#x60;true&#x60;
-func (a *SecretsService) GetAdRoles(ctx context.Context, list string) (*http.Response, error) {
+func (a *Secrets) GetAdRoles(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -3212,7 +3214,7 @@ func (a *SecretsService) GetAdRoles(ctx context.Context, list string) (*http.Res
 
 // GetAdRolesName Manage roles to build links between Vault and Active Directory service accounts.
 // name: Name of the role
-func (a *SecretsService) GetAdRolesName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Secrets) GetAdRolesName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -3278,7 +3280,7 @@ func (a *SecretsService) GetAdRolesName(ctx context.Context, name string) (*http
 }
 
 // GetAdRotateRoot
-func (a *SecretsService) GetAdRotateRoot(ctx context.Context) (*http.Response, error) {
+func (a *Secrets) GetAdRotateRoot(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -3343,7 +3345,7 @@ func (a *SecretsService) GetAdRotateRoot(ctx context.Context) (*http.Response, e
 }
 
 // GetAlicloudConfig Configure the access key and secret to use for RAM and STS calls.
-func (a *SecretsService) GetAlicloudConfig(ctx context.Context) (*http.Response, error) {
+func (a *Secrets) GetAlicloudConfig(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -3409,7 +3411,7 @@ func (a *SecretsService) GetAlicloudConfig(ctx context.Context) (*http.Response,
 
 // GetAlicloudCredsName Generate an API key or STS credential using the given role's configuration.'
 // name: The name of the role.
-func (a *SecretsService) GetAlicloudCredsName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Secrets) GetAlicloudCredsName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -3476,7 +3478,7 @@ func (a *SecretsService) GetAlicloudCredsName(ctx context.Context, name string) 
 
 // GetAlicloudRole List the existing roles in this backend.
 // list: Must be set to &#x60;true&#x60;
-func (a *SecretsService) GetAlicloudRole(ctx context.Context, list string) (*http.Response, error) {
+func (a *Secrets) GetAlicloudRole(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -3543,7 +3545,7 @@ func (a *SecretsService) GetAlicloudRole(ctx context.Context, list string) (*htt
 
 // GetAlicloudRoleName Read, write and reference policies and roles that API keys or STS credentials can be made for.
 // name: The name of the role.
-func (a *SecretsService) GetAlicloudRoleName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Secrets) GetAlicloudRoleName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -3609,7 +3611,7 @@ func (a *SecretsService) GetAlicloudRoleName(ctx context.Context, name string) (
 }
 
 // GetAwsConfigLease Configure the default lease information for generated credentials.
-func (a *SecretsService) GetAwsConfigLease(ctx context.Context) (*http.Response, error) {
+func (a *Secrets) GetAwsConfigLease(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -3674,7 +3676,7 @@ func (a *SecretsService) GetAwsConfigLease(ctx context.Context) (*http.Response,
 }
 
 // GetAwsConfigRoot Configure the root credentials that are used to manage IAM.
-func (a *SecretsService) GetAwsConfigRoot(ctx context.Context) (*http.Response, error) {
+func (a *Secrets) GetAwsConfigRoot(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -3739,7 +3741,7 @@ func (a *SecretsService) GetAwsConfigRoot(ctx context.Context) (*http.Response, 
 }
 
 // GetAwsCreds Generate AWS credentials from a specific Vault role.
-func (a *SecretsService) GetAwsCreds(ctx context.Context) (*http.Response, error) {
+func (a *Secrets) GetAwsCreds(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -3805,7 +3807,7 @@ func (a *SecretsService) GetAwsCreds(ctx context.Context) (*http.Response, error
 
 // GetAwsRoles List the existing roles in this backend
 // list: Must be set to &#x60;true&#x60;
-func (a *SecretsService) GetAwsRoles(ctx context.Context, list string) (*http.Response, error) {
+func (a *Secrets) GetAwsRoles(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -3872,7 +3874,7 @@ func (a *SecretsService) GetAwsRoles(ctx context.Context, list string) (*http.Re
 
 // GetAwsRolesName Read, write and reference IAM policies that access keys can be made for.
 // name: Name of the policy
-func (a *SecretsService) GetAwsRolesName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Secrets) GetAwsRolesName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -3939,7 +3941,7 @@ func (a *SecretsService) GetAwsRolesName(ctx context.Context, name string) (*htt
 
 // GetAwsStsName Generate AWS credentials from a specific Vault role.
 // name: Name of the role
-func (a *SecretsService) GetAwsStsName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Secrets) GetAwsStsName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -4005,7 +4007,7 @@ func (a *SecretsService) GetAwsStsName(ctx context.Context, name string) (*http.
 }
 
 // GetAzureConfig
-func (a *SecretsService) GetAzureConfig(ctx context.Context) (*http.Response, error) {
+func (a *Secrets) GetAzureConfig(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -4071,7 +4073,7 @@ func (a *SecretsService) GetAzureConfig(ctx context.Context) (*http.Response, er
 
 // GetAzureCredsRole
 // role: Name of the Vault role
-func (a *SecretsService) GetAzureCredsRole(ctx context.Context, role string) (*http.Response, error) {
+func (a *Secrets) GetAzureCredsRole(ctx context.Context, role string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -4138,7 +4140,7 @@ func (a *SecretsService) GetAzureCredsRole(ctx context.Context, role string) (*h
 
 // GetAzureRoles List existing roles.
 // list: Must be set to &#x60;true&#x60;
-func (a *SecretsService) GetAzureRoles(ctx context.Context, list string) (*http.Response, error) {
+func (a *Secrets) GetAzureRoles(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -4205,7 +4207,7 @@ func (a *SecretsService) GetAzureRoles(ctx context.Context, list string) (*http.
 
 // GetAzureRolesName Manage the Vault roles used to generate Azure credentials.
 // name: Name of the role.
-func (a *SecretsService) GetAzureRolesName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Secrets) GetAzureRolesName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -4271,7 +4273,7 @@ func (a *SecretsService) GetAzureRolesName(ctx context.Context, name string) (*h
 }
 
 // GetConsulConfigAccess
-func (a *SecretsService) GetConsulConfigAccess(ctx context.Context) (*http.Response, error) {
+func (a *Secrets) GetConsulConfigAccess(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -4337,7 +4339,7 @@ func (a *SecretsService) GetConsulConfigAccess(ctx context.Context) (*http.Respo
 
 // GetConsulCredsRole
 // role: Name of the role.
-func (a *SecretsService) GetConsulCredsRole(ctx context.Context, role string) (*http.Response, error) {
+func (a *Secrets) GetConsulCredsRole(ctx context.Context, role string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -4404,7 +4406,7 @@ func (a *SecretsService) GetConsulCredsRole(ctx context.Context, role string) (*
 
 // GetConsulRoles
 // list: Must be set to &#x60;true&#x60;
-func (a *SecretsService) GetConsulRoles(ctx context.Context, list string) (*http.Response, error) {
+func (a *Secrets) GetConsulRoles(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -4471,7 +4473,7 @@ func (a *SecretsService) GetConsulRoles(ctx context.Context, list string) (*http
 
 // GetConsulRolesName
 // name: Name of the role.
-func (a *SecretsService) GetConsulRolesName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Secrets) GetConsulRolesName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -4539,7 +4541,7 @@ func (a *SecretsService) GetConsulRolesName(ctx context.Context, name string) (*
 // GetCubbyholePath Retrieve the secret at the specified location.
 // path: Specifies the path of the secret.
 // list: Return a list if &#x60;true&#x60;
-func (a *SecretsService) GetCubbyholePath(ctx context.Context, path string, list string) (*http.Response, error) {
+func (a *Secrets) GetCubbyholePath(ctx context.Context, path string, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -4606,7 +4608,7 @@ func (a *SecretsService) GetCubbyholePath(ctx context.Context, path string, list
 }
 
 // GetGcpConfig
-func (a *SecretsService) GetGcpConfig(ctx context.Context) (*http.Response, error) {
+func (a *Secrets) GetGcpConfig(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -4672,7 +4674,7 @@ func (a *SecretsService) GetGcpConfig(ctx context.Context) (*http.Response, erro
 
 // GetGcpKeyRoleset
 // roleset: Required. Name of the role set.
-func (a *SecretsService) GetGcpKeyRoleset(ctx context.Context, roleset string) (*http.Response, error) {
+func (a *Secrets) GetGcpKeyRoleset(ctx context.Context, roleset string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -4739,7 +4741,7 @@ func (a *SecretsService) GetGcpKeyRoleset(ctx context.Context, roleset string) (
 
 // GetGcpRolesetName
 // name: Required. Name of the role.
-func (a *SecretsService) GetGcpRolesetName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Secrets) GetGcpRolesetName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -4806,7 +4808,7 @@ func (a *SecretsService) GetGcpRolesetName(ctx context.Context, name string) (*h
 
 // GetGcpRolesetRolesetKey
 // roleset: Required. Name of the role set.
-func (a *SecretsService) GetGcpRolesetRolesetKey(ctx context.Context, roleset string) (*http.Response, error) {
+func (a *Secrets) GetGcpRolesetRolesetKey(ctx context.Context, roleset string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -4873,7 +4875,7 @@ func (a *SecretsService) GetGcpRolesetRolesetKey(ctx context.Context, roleset st
 
 // GetGcpRolesetRolesetToken
 // roleset: Required. Name of the role set.
-func (a *SecretsService) GetGcpRolesetRolesetToken(ctx context.Context, roleset string) (*http.Response, error) {
+func (a *Secrets) GetGcpRolesetRolesetToken(ctx context.Context, roleset string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -4940,7 +4942,7 @@ func (a *SecretsService) GetGcpRolesetRolesetToken(ctx context.Context, roleset 
 
 // GetGcpRolesets
 // list: Must be set to &#x60;true&#x60;
-func (a *SecretsService) GetGcpRolesets(ctx context.Context, list string) (*http.Response, error) {
+func (a *Secrets) GetGcpRolesets(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -5007,7 +5009,7 @@ func (a *SecretsService) GetGcpRolesets(ctx context.Context, list string) (*http
 
 // GetGcpStaticAccountName
 // name: Required. Name to refer to this static account in Vault. Cannot be updated.
-func (a *SecretsService) GetGcpStaticAccountName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Secrets) GetGcpStaticAccountName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -5074,7 +5076,7 @@ func (a *SecretsService) GetGcpStaticAccountName(ctx context.Context, name strin
 
 // GetGcpStaticAccountNameKey
 // name: Required. Name of the static account.
-func (a *SecretsService) GetGcpStaticAccountNameKey(ctx context.Context, name string) (*http.Response, error) {
+func (a *Secrets) GetGcpStaticAccountNameKey(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -5141,7 +5143,7 @@ func (a *SecretsService) GetGcpStaticAccountNameKey(ctx context.Context, name st
 
 // GetGcpStaticAccountNameToken
 // name: Required. Name of the static account.
-func (a *SecretsService) GetGcpStaticAccountNameToken(ctx context.Context, name string) (*http.Response, error) {
+func (a *Secrets) GetGcpStaticAccountNameToken(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -5208,7 +5210,7 @@ func (a *SecretsService) GetGcpStaticAccountNameToken(ctx context.Context, name 
 
 // GetGcpStaticAccounts
 // list: Must be set to &#x60;true&#x60;
-func (a *SecretsService) GetGcpStaticAccounts(ctx context.Context, list string) (*http.Response, error) {
+func (a *Secrets) GetGcpStaticAccounts(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -5275,7 +5277,7 @@ func (a *SecretsService) GetGcpStaticAccounts(ctx context.Context, list string) 
 
 // GetGcpTokenRoleset
 // roleset: Required. Name of the role set.
-func (a *SecretsService) GetGcpTokenRoleset(ctx context.Context, roleset string) (*http.Response, error) {
+func (a *Secrets) GetGcpTokenRoleset(ctx context.Context, roleset string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -5341,7 +5343,7 @@ func (a *SecretsService) GetGcpTokenRoleset(ctx context.Context, roleset string)
 }
 
 // GetGcpkmsConfig Configure the GCP KMS secrets engine
-func (a *SecretsService) GetGcpkmsConfig(ctx context.Context) (*http.Response, error) {
+func (a *Secrets) GetGcpkmsConfig(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -5407,7 +5409,7 @@ func (a *SecretsService) GetGcpkmsConfig(ctx context.Context) (*http.Response, e
 
 // GetGcpkmsKeys List named keys
 // list: Must be set to &#x60;true&#x60;
-func (a *SecretsService) GetGcpkmsKeys(ctx context.Context, list string) (*http.Response, error) {
+func (a *Secrets) GetGcpkmsKeys(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -5474,7 +5476,7 @@ func (a *SecretsService) GetGcpkmsKeys(ctx context.Context, list string) (*http.
 
 // GetGcpkmsKeysConfigKey Configure the key in Vault
 // key: Name of the key in Vault.
-func (a *SecretsService) GetGcpkmsKeysConfigKey(ctx context.Context, key string) (*http.Response, error) {
+func (a *Secrets) GetGcpkmsKeysConfigKey(ctx context.Context, key string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -5541,7 +5543,7 @@ func (a *SecretsService) GetGcpkmsKeysConfigKey(ctx context.Context, key string)
 
 // GetGcpkmsKeysKey Interact with crypto keys in Vault and Google Cloud KMS
 // key: Name of the key in Vault.
-func (a *SecretsService) GetGcpkmsKeysKey(ctx context.Context, key string) (*http.Response, error) {
+func (a *Secrets) GetGcpkmsKeysKey(ctx context.Context, key string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -5608,7 +5610,7 @@ func (a *SecretsService) GetGcpkmsKeysKey(ctx context.Context, key string) (*htt
 
 // GetGcpkmsPubkeyKey Retrieve the public key associated with the named key
 // key: Name of the key for which to get the public key. This key must already exist in Vault and Google Cloud KMS.
-func (a *SecretsService) GetGcpkmsPubkeyKey(ctx context.Context, key string) (*http.Response, error) {
+func (a *Secrets) GetGcpkmsPubkeyKey(ctx context.Context, key string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -5674,7 +5676,7 @@ func (a *SecretsService) GetGcpkmsPubkeyKey(ctx context.Context, key string) (*h
 }
 
 // GetKubernetesConfig
-func (a *SecretsService) GetKubernetesConfig(ctx context.Context) (*http.Response, error) {
+func (a *Secrets) GetKubernetesConfig(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -5740,7 +5742,7 @@ func (a *SecretsService) GetKubernetesConfig(ctx context.Context) (*http.Respons
 
 // GetKubernetesRoles
 // list: Must be set to &#x60;true&#x60;
-func (a *SecretsService) GetKubernetesRoles(ctx context.Context, list string) (*http.Response, error) {
+func (a *Secrets) GetKubernetesRoles(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -5807,7 +5809,7 @@ func (a *SecretsService) GetKubernetesRoles(ctx context.Context, list string) (*
 
 // GetKubernetesRolesName
 // name: Name of the role
-func (a *SecretsService) GetKubernetesRolesName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Secrets) GetKubernetesRolesName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -5875,7 +5877,7 @@ func (a *SecretsService) GetKubernetesRolesName(ctx context.Context, name string
 // GetKvPath Pass-through secret storage to the storage backend, allowing you to read/write arbitrary data into secret storage.
 // path: Location of the secret.
 // list: Return a list if &#x60;true&#x60;
-func (a *SecretsService) GetKvPath(ctx context.Context, path string, list string) (*http.Response, error) {
+func (a *Secrets) GetKvPath(ctx context.Context, path string, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -5942,7 +5944,7 @@ func (a *SecretsService) GetKvPath(ctx context.Context, path string, list string
 }
 
 // GetMongodbatlasConfig Configure the  credentials that are used to manage Database Users.
-func (a *SecretsService) GetMongodbatlasConfig(ctx context.Context) (*http.Response, error) {
+func (a *Secrets) GetMongodbatlasConfig(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -6008,7 +6010,7 @@ func (a *SecretsService) GetMongodbatlasConfig(ctx context.Context) (*http.Respo
 
 // GetMongodbatlasCredsName Generate MongoDB Atlas Programmatic API from a specific Vault role.
 // name: Name of the role
-func (a *SecretsService) GetMongodbatlasCredsName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Secrets) GetMongodbatlasCredsName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -6075,7 +6077,7 @@ func (a *SecretsService) GetMongodbatlasCredsName(ctx context.Context, name stri
 
 // GetMongodbatlasRoles List the existing roles in this backend
 // list: Must be set to &#x60;true&#x60;
-func (a *SecretsService) GetMongodbatlasRoles(ctx context.Context, list string) (*http.Response, error) {
+func (a *Secrets) GetMongodbatlasRoles(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -6142,7 +6144,7 @@ func (a *SecretsService) GetMongodbatlasRoles(ctx context.Context, list string) 
 
 // GetMongodbatlasRolesName Manage the roles used to generate MongoDB Atlas Programmatic API Keys.
 // name: Name of the Roles
-func (a *SecretsService) GetMongodbatlasRolesName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Secrets) GetMongodbatlasRolesName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -6208,7 +6210,7 @@ func (a *SecretsService) GetMongodbatlasRolesName(ctx context.Context, name stri
 }
 
 // GetNomadConfigAccess
-func (a *SecretsService) GetNomadConfigAccess(ctx context.Context) (*http.Response, error) {
+func (a *Secrets) GetNomadConfigAccess(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -6273,7 +6275,7 @@ func (a *SecretsService) GetNomadConfigAccess(ctx context.Context) (*http.Respon
 }
 
 // GetNomadConfigLease Configure the lease parameters for generated tokens
-func (a *SecretsService) GetNomadConfigLease(ctx context.Context) (*http.Response, error) {
+func (a *Secrets) GetNomadConfigLease(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -6339,7 +6341,7 @@ func (a *SecretsService) GetNomadConfigLease(ctx context.Context) (*http.Respons
 
 // GetNomadCredsName
 // name: Name of the role
-func (a *SecretsService) GetNomadCredsName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Secrets) GetNomadCredsName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -6406,7 +6408,7 @@ func (a *SecretsService) GetNomadCredsName(ctx context.Context, name string) (*h
 
 // GetNomadRole
 // list: Must be set to &#x60;true&#x60;
-func (a *SecretsService) GetNomadRole(ctx context.Context, list string) (*http.Response, error) {
+func (a *Secrets) GetNomadRole(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -6473,7 +6475,7 @@ func (a *SecretsService) GetNomadRole(ctx context.Context, list string) (*http.R
 
 // GetNomadRoleName
 // name: Name of the role
-func (a *SecretsService) GetNomadRoleName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Secrets) GetNomadRoleName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -6539,7 +6541,7 @@ func (a *SecretsService) GetNomadRoleName(ctx context.Context, name string) (*ht
 }
 
 // GetOpenldapConfig
-func (a *SecretsService) GetOpenldapConfig(ctx context.Context) (*http.Response, error) {
+func (a *Secrets) GetOpenldapConfig(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -6605,7 +6607,7 @@ func (a *SecretsService) GetOpenldapConfig(ctx context.Context) (*http.Response,
 
 // GetOpenldapCredsName
 // name: Name of the dynamic role.
-func (a *SecretsService) GetOpenldapCredsName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Secrets) GetOpenldapCredsName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -6672,7 +6674,7 @@ func (a *SecretsService) GetOpenldapCredsName(ctx context.Context, name string) 
 
 // GetOpenldapRole
 // list: Must be set to &#x60;true&#x60;
-func (a *SecretsService) GetOpenldapRole(ctx context.Context, list string) (*http.Response, error) {
+func (a *Secrets) GetOpenldapRole(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -6739,7 +6741,7 @@ func (a *SecretsService) GetOpenldapRole(ctx context.Context, list string) (*htt
 
 // GetOpenldapRoleName
 // name: Name of the role (lowercase)
-func (a *SecretsService) GetOpenldapRoleName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Secrets) GetOpenldapRoleName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -6806,7 +6808,7 @@ func (a *SecretsService) GetOpenldapRoleName(ctx context.Context, name string) (
 
 // GetOpenldapStaticCredName
 // name: Name of the static role.
-func (a *SecretsService) GetOpenldapStaticCredName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Secrets) GetOpenldapStaticCredName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -6873,7 +6875,7 @@ func (a *SecretsService) GetOpenldapStaticCredName(ctx context.Context, name str
 
 // GetOpenldapStaticRole
 // list: Must be set to &#x60;true&#x60;
-func (a *SecretsService) GetOpenldapStaticRole(ctx context.Context, list string) (*http.Response, error) {
+func (a *Secrets) GetOpenldapStaticRole(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -6940,7 +6942,7 @@ func (a *SecretsService) GetOpenldapStaticRole(ctx context.Context, list string)
 
 // GetOpenldapStaticRoleName
 // name: Name of the role
-func (a *SecretsService) GetOpenldapStaticRoleName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Secrets) GetOpenldapStaticRoleName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -7006,7 +7008,7 @@ func (a *SecretsService) GetOpenldapStaticRoleName(ctx context.Context, name str
 }
 
 // GetPkiCa
-func (a *SecretsService) GetPkiCa(ctx context.Context) (*http.Response, error) {
+func (a *Secrets) GetPkiCa(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -7071,7 +7073,7 @@ func (a *SecretsService) GetPkiCa(ctx context.Context) (*http.Response, error) {
 }
 
 // GetPkiCaChain
-func (a *SecretsService) GetPkiCaChain(ctx context.Context) (*http.Response, error) {
+func (a *Secrets) GetPkiCaChain(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -7136,7 +7138,7 @@ func (a *SecretsService) GetPkiCaChain(ctx context.Context) (*http.Response, err
 }
 
 // GetPkiCaPem
-func (a *SecretsService) GetPkiCaPem(ctx context.Context) (*http.Response, error) {
+func (a *Secrets) GetPkiCaPem(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -7201,7 +7203,7 @@ func (a *SecretsService) GetPkiCaPem(ctx context.Context) (*http.Response, error
 }
 
 // GetPkiCertCaChain
-func (a *SecretsService) GetPkiCertCaChain(ctx context.Context) (*http.Response, error) {
+func (a *Secrets) GetPkiCertCaChain(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -7266,7 +7268,7 @@ func (a *SecretsService) GetPkiCertCaChain(ctx context.Context) (*http.Response,
 }
 
 // GetPkiCertCrl
-func (a *SecretsService) GetPkiCertCrl(ctx context.Context) (*http.Response, error) {
+func (a *Secrets) GetPkiCertCrl(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -7332,7 +7334,7 @@ func (a *SecretsService) GetPkiCertCrl(ctx context.Context) (*http.Response, err
 
 // GetPkiCertSerial
 // serial: Certificate serial number, in colon- or hyphen-separated octal
-func (a *SecretsService) GetPkiCertSerial(ctx context.Context, serial string) (*http.Response, error) {
+func (a *Secrets) GetPkiCertSerial(ctx context.Context, serial string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -7399,7 +7401,7 @@ func (a *SecretsService) GetPkiCertSerial(ctx context.Context, serial string) (*
 
 // GetPkiCertSerialRaw
 // serial: Certificate serial number, in colon- or hyphen-separated octal
-func (a *SecretsService) GetPkiCertSerialRaw(ctx context.Context, serial string) (*http.Response, error) {
+func (a *Secrets) GetPkiCertSerialRaw(ctx context.Context, serial string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -7466,7 +7468,7 @@ func (a *SecretsService) GetPkiCertSerialRaw(ctx context.Context, serial string)
 
 // GetPkiCertSerialRawPem
 // serial: Certificate serial number, in colon- or hyphen-separated octal
-func (a *SecretsService) GetPkiCertSerialRawPem(ctx context.Context, serial string) (*http.Response, error) {
+func (a *Secrets) GetPkiCertSerialRawPem(ctx context.Context, serial string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -7533,7 +7535,7 @@ func (a *SecretsService) GetPkiCertSerialRawPem(ctx context.Context, serial stri
 
 // GetPkiCerts
 // list: Must be set to &#x60;true&#x60;
-func (a *SecretsService) GetPkiCerts(ctx context.Context, list string) (*http.Response, error) {
+func (a *Secrets) GetPkiCerts(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -7599,7 +7601,7 @@ func (a *SecretsService) GetPkiCerts(ctx context.Context, list string) (*http.Re
 }
 
 // GetPkiConfigCrl
-func (a *SecretsService) GetPkiConfigCrl(ctx context.Context) (*http.Response, error) {
+func (a *Secrets) GetPkiConfigCrl(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -7664,7 +7666,7 @@ func (a *SecretsService) GetPkiConfigCrl(ctx context.Context) (*http.Response, e
 }
 
 // GetPkiConfigIssuers
-func (a *SecretsService) GetPkiConfigIssuers(ctx context.Context) (*http.Response, error) {
+func (a *Secrets) GetPkiConfigIssuers(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -7729,7 +7731,7 @@ func (a *SecretsService) GetPkiConfigIssuers(ctx context.Context) (*http.Respons
 }
 
 // GetPkiConfigKeys
-func (a *SecretsService) GetPkiConfigKeys(ctx context.Context) (*http.Response, error) {
+func (a *Secrets) GetPkiConfigKeys(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -7794,7 +7796,7 @@ func (a *SecretsService) GetPkiConfigKeys(ctx context.Context) (*http.Response, 
 }
 
 // GetPkiConfigUrls
-func (a *SecretsService) GetPkiConfigUrls(ctx context.Context) (*http.Response, error) {
+func (a *Secrets) GetPkiConfigUrls(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -7859,7 +7861,7 @@ func (a *SecretsService) GetPkiConfigUrls(ctx context.Context) (*http.Response, 
 }
 
 // GetPkiCrl
-func (a *SecretsService) GetPkiCrl(ctx context.Context) (*http.Response, error) {
+func (a *Secrets) GetPkiCrl(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -7924,7 +7926,7 @@ func (a *SecretsService) GetPkiCrl(ctx context.Context) (*http.Response, error) 
 }
 
 // GetPkiCrlPem
-func (a *SecretsService) GetPkiCrlPem(ctx context.Context) (*http.Response, error) {
+func (a *Secrets) GetPkiCrlPem(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -7989,7 +7991,7 @@ func (a *SecretsService) GetPkiCrlPem(ctx context.Context) (*http.Response, erro
 }
 
 // GetPkiCrlRotate
-func (a *SecretsService) GetPkiCrlRotate(ctx context.Context) (*http.Response, error) {
+func (a *Secrets) GetPkiCrlRotate(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -8054,7 +8056,7 @@ func (a *SecretsService) GetPkiCrlRotate(ctx context.Context) (*http.Response, e
 }
 
 // GetPkiDer
-func (a *SecretsService) GetPkiDer(ctx context.Context) (*http.Response, error) {
+func (a *Secrets) GetPkiDer(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -8120,7 +8122,7 @@ func (a *SecretsService) GetPkiDer(ctx context.Context) (*http.Response, error) 
 
 // GetPkiIssuerRefCrlPem
 // issuerRef: Reference to a existing issuer; either \&quot;default\&quot; for the configured default issuer, an identifier or the name assigned to the issuer.
-func (a *SecretsService) GetPkiIssuerRefCrlPem(ctx context.Context, issuerRef string) (*http.Response, error) {
+func (a *Secrets) GetPkiIssuerRefCrlPem(ctx context.Context, issuerRef string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -8187,7 +8189,7 @@ func (a *SecretsService) GetPkiIssuerRefCrlPem(ctx context.Context, issuerRef st
 
 // GetPkiIssuerRefDerPem
 // issuerRef: Reference to a existing issuer; either \&quot;default\&quot; for the configured default issuer, an identifier or the name assigned to the issuer.
-func (a *SecretsService) GetPkiIssuerRefDerPem(ctx context.Context, issuerRef string) (*http.Response, error) {
+func (a *Secrets) GetPkiIssuerRefDerPem(ctx context.Context, issuerRef string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -8254,7 +8256,7 @@ func (a *SecretsService) GetPkiIssuerRefDerPem(ctx context.Context, issuerRef st
 
 // GetPkiIssuers
 // list: Must be set to &#x60;true&#x60;
-func (a *SecretsService) GetPkiIssuers(ctx context.Context, list string) (*http.Response, error) {
+func (a *Secrets) GetPkiIssuers(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -8320,7 +8322,7 @@ func (a *SecretsService) GetPkiIssuers(ctx context.Context, list string) (*http.
 }
 
 // GetPkiJson
-func (a *SecretsService) GetPkiJson(ctx context.Context) (*http.Response, error) {
+func (a *Secrets) GetPkiJson(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -8386,7 +8388,7 @@ func (a *SecretsService) GetPkiJson(ctx context.Context) (*http.Response, error)
 
 // GetPkiKeyKeyRef
 // keyRef: Reference to key; either \&quot;default\&quot; for the configured default key, an identifier of a key, or the name assigned to the key.
-func (a *SecretsService) GetPkiKeyKeyRef(ctx context.Context, keyRef string) (*http.Response, error) {
+func (a *Secrets) GetPkiKeyKeyRef(ctx context.Context, keyRef string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -8453,7 +8455,7 @@ func (a *SecretsService) GetPkiKeyKeyRef(ctx context.Context, keyRef string) (*h
 
 // GetPkiKeys
 // list: Must be set to &#x60;true&#x60;
-func (a *SecretsService) GetPkiKeys(ctx context.Context, list string) (*http.Response, error) {
+func (a *Secrets) GetPkiKeys(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -8520,7 +8522,7 @@ func (a *SecretsService) GetPkiKeys(ctx context.Context, list string) (*http.Res
 
 // GetPkiRoles
 // list: Must be set to &#x60;true&#x60;
-func (a *SecretsService) GetPkiRoles(ctx context.Context, list string) (*http.Response, error) {
+func (a *Secrets) GetPkiRoles(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -8587,7 +8589,7 @@ func (a *SecretsService) GetPkiRoles(ctx context.Context, list string) (*http.Re
 
 // GetPkiRolesName
 // name: Name of the role
-func (a *SecretsService) GetPkiRolesName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Secrets) GetPkiRolesName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -8653,7 +8655,7 @@ func (a *SecretsService) GetPkiRolesName(ctx context.Context, name string) (*htt
 }
 
 // GetPkiTidyStatus
-func (a *SecretsService) GetPkiTidyStatus(ctx context.Context) (*http.Response, error) {
+func (a *Secrets) GetPkiTidyStatus(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -8718,7 +8720,7 @@ func (a *SecretsService) GetPkiTidyStatus(ctx context.Context) (*http.Response, 
 }
 
 // GetRabbitmqConfigLease Configure the lease parameters for generated credentials
-func (a *SecretsService) GetRabbitmqConfigLease(ctx context.Context) (*http.Response, error) {
+func (a *Secrets) GetRabbitmqConfigLease(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -8784,7 +8786,7 @@ func (a *SecretsService) GetRabbitmqConfigLease(ctx context.Context) (*http.Resp
 
 // GetRabbitmqCredsName Request RabbitMQ credentials for a certain role.
 // name: Name of the role.
-func (a *SecretsService) GetRabbitmqCredsName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Secrets) GetRabbitmqCredsName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -8851,7 +8853,7 @@ func (a *SecretsService) GetRabbitmqCredsName(ctx context.Context, name string) 
 
 // GetRabbitmqRoles Manage the roles that can be created with this backend.
 // list: Must be set to &#x60;true&#x60;
-func (a *SecretsService) GetRabbitmqRoles(ctx context.Context, list string) (*http.Response, error) {
+func (a *Secrets) GetRabbitmqRoles(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -8918,7 +8920,7 @@ func (a *SecretsService) GetRabbitmqRoles(ctx context.Context, list string) (*ht
 
 // GetRabbitmqRolesName Manage the roles that can be created with this backend.
 // name: Name of the role.
-func (a *SecretsService) GetRabbitmqRolesName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Secrets) GetRabbitmqRolesName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -8984,7 +8986,7 @@ func (a *SecretsService) GetRabbitmqRolesName(ctx context.Context, name string) 
 }
 
 // GetSecretConfig Read the backend level settings.
-func (a *SecretsService) GetSecretConfig(ctx context.Context) (*http.Response, error) {
+func (a *Secrets) GetSecretConfig(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -9050,7 +9052,7 @@ func (a *SecretsService) GetSecretConfig(ctx context.Context) (*http.Response, e
 
 // GetSecretDataPath Write, Patch, Read, and Delete data in the Key-Value Store.
 // path: Location of the secret.
-func (a *SecretsService) GetSecretDataPath(ctx context.Context, path string) (*http.Response, error) {
+func (a *Secrets) GetSecretDataPath(ctx context.Context, path string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -9118,7 +9120,7 @@ func (a *SecretsService) GetSecretDataPath(ctx context.Context, path string) (*h
 // GetSecretMetadataPath Configures settings for the KV store
 // path: Location of the secret.
 // list: Return a list if &#x60;true&#x60;
-func (a *SecretsService) GetSecretMetadataPath(ctx context.Context, path string, list string) (*http.Response, error) {
+func (a *Secrets) GetSecretMetadataPath(ctx context.Context, path string, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -9186,7 +9188,7 @@ func (a *SecretsService) GetSecretMetadataPath(ctx context.Context, path string,
 
 // GetSecretSubkeysPath Read the structure of a secret entry from the Key-Value store with the values removed.
 // path: Location of the secret.
-func (a *SecretsService) GetSecretSubkeysPath(ctx context.Context, path string) (*http.Response, error) {
+func (a *Secrets) GetSecretSubkeysPath(ctx context.Context, path string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -9252,7 +9254,7 @@ func (a *SecretsService) GetSecretSubkeysPath(ctx context.Context, path string) 
 }
 
 // GetSshConfigCa Set the SSH private key used for signing certificates.
-func (a *SecretsService) GetSshConfigCa(ctx context.Context) (*http.Response, error) {
+func (a *Secrets) GetSshConfigCa(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -9317,7 +9319,7 @@ func (a *SecretsService) GetSshConfigCa(ctx context.Context) (*http.Response, er
 }
 
 // GetSshConfigZeroaddress Assign zero address as default CIDR block for select roles.
-func (a *SecretsService) GetSshConfigZeroaddress(ctx context.Context) (*http.Response, error) {
+func (a *Secrets) GetSshConfigZeroaddress(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -9382,7 +9384,7 @@ func (a *SecretsService) GetSshConfigZeroaddress(ctx context.Context) (*http.Res
 }
 
 // GetSshPublicKey Retrieve the public key.
-func (a *SecretsService) GetSshPublicKey(ctx context.Context) (*http.Response, error) {
+func (a *Secrets) GetSshPublicKey(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -9448,7 +9450,7 @@ func (a *SecretsService) GetSshPublicKey(ctx context.Context) (*http.Response, e
 
 // GetSshRoles Manage the 'roles' that can be created with this backend.
 // list: Must be set to &#x60;true&#x60;
-func (a *SecretsService) GetSshRoles(ctx context.Context, list string) (*http.Response, error) {
+func (a *Secrets) GetSshRoles(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -9515,7 +9517,7 @@ func (a *SecretsService) GetSshRoles(ctx context.Context, list string) (*http.Re
 
 // GetSshRolesRole Manage the 'roles' that can be created with this backend.
 // role: [Required for all types] Name of the role being created.
-func (a *SecretsService) GetSshRolesRole(ctx context.Context, role string) (*http.Response, error) {
+func (a *Secrets) GetSshRolesRole(ctx context.Context, role string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -9581,7 +9583,7 @@ func (a *SecretsService) GetSshRolesRole(ctx context.Context, role string) (*htt
 }
 
 // GetTerraformConfig
-func (a *SecretsService) GetTerraformConfig(ctx context.Context) (*http.Response, error) {
+func (a *Secrets) GetTerraformConfig(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -9647,7 +9649,7 @@ func (a *SecretsService) GetTerraformConfig(ctx context.Context) (*http.Response
 
 // GetTerraformCredsName Generate a Terraform Cloud or Enterprise API token from a specific Vault role.
 // name: Name of the role
-func (a *SecretsService) GetTerraformCredsName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Secrets) GetTerraformCredsName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -9714,7 +9716,7 @@ func (a *SecretsService) GetTerraformCredsName(ctx context.Context, name string)
 
 // GetTerraformRole
 // list: Must be set to &#x60;true&#x60;
-func (a *SecretsService) GetTerraformRole(ctx context.Context, list string) (*http.Response, error) {
+func (a *Secrets) GetTerraformRole(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -9781,7 +9783,7 @@ func (a *SecretsService) GetTerraformRole(ctx context.Context, list string) (*ht
 
 // GetTerraformRoleName
 // name: Name of the role
-func (a *SecretsService) GetTerraformRoleName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Secrets) GetTerraformRoleName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -9848,7 +9850,7 @@ func (a *SecretsService) GetTerraformRoleName(ctx context.Context, name string) 
 
 // GetTotpCodeName Request time-based one-time use password or validate a password for a certain key .
 // name: Name of the key.
-func (a *SecretsService) GetTotpCodeName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Secrets) GetTotpCodeName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -9915,7 +9917,7 @@ func (a *SecretsService) GetTotpCodeName(ctx context.Context, name string) (*htt
 
 // GetTotpKeys Manage the keys that can be created with this backend.
 // list: Must be set to &#x60;true&#x60;
-func (a *SecretsService) GetTotpKeys(ctx context.Context, list string) (*http.Response, error) {
+func (a *Secrets) GetTotpKeys(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -9982,7 +9984,7 @@ func (a *SecretsService) GetTotpKeys(ctx context.Context, list string) (*http.Re
 
 // GetTotpKeysName Manage the keys that can be created with this backend.
 // name: Name of the key.
-func (a *SecretsService) GetTotpKeysName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Secrets) GetTotpKeysName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -10049,7 +10051,7 @@ func (a *SecretsService) GetTotpKeysName(ctx context.Context, name string) (*htt
 
 // GetTransitBackupName Backup the named key
 // name: Name of the key
-func (a *SecretsService) GetTransitBackupName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Secrets) GetTransitBackupName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -10115,7 +10117,7 @@ func (a *SecretsService) GetTransitBackupName(ctx context.Context, name string) 
 }
 
 // GetTransitCacheConfig Returns the size of the active cache
-func (a *SecretsService) GetTransitCacheConfig(ctx context.Context) (*http.Response, error) {
+func (a *Secrets) GetTransitCacheConfig(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -10182,7 +10184,7 @@ func (a *SecretsService) GetTransitCacheConfig(ctx context.Context) (*http.Respo
 // GetTransitExportTypeName Export named encryption or signing key
 // name: Name of the key
 // type_: Type of key to export (encryption-key, signing-key, hmac-key)
-func (a *SecretsService) GetTransitExportTypeName(ctx context.Context, name string, type_ string) (*http.Response, error) {
+func (a *Secrets) GetTransitExportTypeName(ctx context.Context, name string, type_ string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -10252,7 +10254,7 @@ func (a *SecretsService) GetTransitExportTypeName(ctx context.Context, name stri
 // name: Name of the key
 // type_: Type of key to export (encryption-key, signing-key, hmac-key)
 // version: Version of the key
-func (a *SecretsService) GetTransitExportTypeNameVersion(ctx context.Context, name string, type_ string, version string) (*http.Response, error) {
+func (a *Secrets) GetTransitExportTypeNameVersion(ctx context.Context, name string, type_ string, version string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -10321,7 +10323,7 @@ func (a *SecretsService) GetTransitExportTypeNameVersion(ctx context.Context, na
 
 // GetTransitKeys Managed named encryption keys
 // list: Must be set to &#x60;true&#x60;
-func (a *SecretsService) GetTransitKeys(ctx context.Context, list string) (*http.Response, error) {
+func (a *Secrets) GetTransitKeys(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -10388,7 +10390,7 @@ func (a *SecretsService) GetTransitKeys(ctx context.Context, list string) (*http
 
 // GetTransitKeysName Managed named encryption keys
 // name: Name of the key
-func (a *SecretsService) GetTransitKeysName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Secrets) GetTransitKeysName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -10454,7 +10456,7 @@ func (a *SecretsService) GetTransitKeysName(ctx context.Context, name string) (*
 }
 
 // GetTransitWrappingKey Returns the public key to use for wrapping imported keys
-func (a *SecretsService) GetTransitWrappingKey(ctx context.Context) (*http.Response, error) {
+func (a *Secrets) GetTransitWrappingKey(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -10519,7 +10521,7 @@ func (a *SecretsService) GetTransitWrappingKey(ctx context.Context) (*http.Respo
 }
 
 // PostAdConfig Configure the AD server to connect to, along with password options.
-func (a *SecretsService) PostAdConfig(ctx context.Context, adConfigRequest AdConfigRequest) (*http.Response, error) {
+func (a *Secrets) PostAdConfig(ctx context.Context, adConfigRequest AdConfigRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -10587,7 +10589,7 @@ func (a *SecretsService) PostAdConfig(ctx context.Context, adConfigRequest AdCon
 
 // PostAdLibraryManageNameCheckIn Check service accounts in to the library.
 // name: Name of the set.
-func (a *SecretsService) PostAdLibraryManageNameCheckIn(ctx context.Context, name string, adLibraryManageCheckInRequest AdLibraryManageCheckInRequest) (*http.Response, error) {
+func (a *Secrets) PostAdLibraryManageNameCheckIn(ctx context.Context, name string, adLibraryManageCheckInRequest AdLibraryManageCheckInRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -10656,7 +10658,7 @@ func (a *SecretsService) PostAdLibraryManageNameCheckIn(ctx context.Context, nam
 
 // PostAdLibraryName Update a library set.
 // name: Name of the set.
-func (a *SecretsService) PostAdLibraryName(ctx context.Context, name string, adLibraryRequest AdLibraryRequest) (*http.Response, error) {
+func (a *Secrets) PostAdLibraryName(ctx context.Context, name string, adLibraryRequest AdLibraryRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -10725,7 +10727,7 @@ func (a *SecretsService) PostAdLibraryName(ctx context.Context, name string, adL
 
 // PostAdLibraryNameCheckIn Check service accounts in to the library.
 // name: Name of the set.
-func (a *SecretsService) PostAdLibraryNameCheckIn(ctx context.Context, name string, adLibraryCheckInRequest AdLibraryCheckInRequest) (*http.Response, error) {
+func (a *Secrets) PostAdLibraryNameCheckIn(ctx context.Context, name string, adLibraryCheckInRequest AdLibraryCheckInRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -10794,7 +10796,7 @@ func (a *SecretsService) PostAdLibraryNameCheckIn(ctx context.Context, name stri
 
 // PostAdLibraryNameCheckOut Check a service account out from the library.
 // name: Name of the set
-func (a *SecretsService) PostAdLibraryNameCheckOut(ctx context.Context, name string, adLibraryCheckOutRequest AdLibraryCheckOutRequest) (*http.Response, error) {
+func (a *Secrets) PostAdLibraryNameCheckOut(ctx context.Context, name string, adLibraryCheckOutRequest AdLibraryCheckOutRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -10863,7 +10865,7 @@ func (a *SecretsService) PostAdLibraryNameCheckOut(ctx context.Context, name str
 
 // PostAdRolesName Manage roles to build links between Vault and Active Directory service accounts.
 // name: Name of the role
-func (a *SecretsService) PostAdRolesName(ctx context.Context, name string, adRolesRequest AdRolesRequest) (*http.Response, error) {
+func (a *Secrets) PostAdRolesName(ctx context.Context, name string, adRolesRequest AdRolesRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -10932,7 +10934,7 @@ func (a *SecretsService) PostAdRolesName(ctx context.Context, name string, adRol
 
 // PostAdRotateRoleName
 // name: Name of the static role
-func (a *SecretsService) PostAdRotateRoleName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Secrets) PostAdRotateRoleName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -10998,7 +11000,7 @@ func (a *SecretsService) PostAdRotateRoleName(ctx context.Context, name string) 
 }
 
 // PostAdRotateRoot
-func (a *SecretsService) PostAdRotateRoot(ctx context.Context) (*http.Response, error) {
+func (a *Secrets) PostAdRotateRoot(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -11063,7 +11065,7 @@ func (a *SecretsService) PostAdRotateRoot(ctx context.Context) (*http.Response, 
 }
 
 // PostAlicloudConfig Configure the access key and secret to use for RAM and STS calls.
-func (a *SecretsService) PostAlicloudConfig(ctx context.Context, alicloudConfigRequest AlicloudConfigRequest) (*http.Response, error) {
+func (a *Secrets) PostAlicloudConfig(ctx context.Context, alicloudConfigRequest AlicloudConfigRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -11131,7 +11133,7 @@ func (a *SecretsService) PostAlicloudConfig(ctx context.Context, alicloudConfigR
 
 // PostAlicloudRoleName Read, write and reference policies and roles that API keys or STS credentials can be made for.
 // name: The name of the role.
-func (a *SecretsService) PostAlicloudRoleName(ctx context.Context, name string, alicloudRoleRequest AlicloudRoleRequest) (*http.Response, error) {
+func (a *Secrets) PostAlicloudRoleName(ctx context.Context, name string, alicloudRoleRequest AlicloudRoleRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -11199,7 +11201,7 @@ func (a *SecretsService) PostAlicloudRoleName(ctx context.Context, name string, 
 }
 
 // PostAwsConfigLease Configure the default lease information for generated credentials.
-func (a *SecretsService) PostAwsConfigLease(ctx context.Context, awsConfigLeaseRequest AwsConfigLeaseRequest) (*http.Response, error) {
+func (a *Secrets) PostAwsConfigLease(ctx context.Context, awsConfigLeaseRequest AwsConfigLeaseRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -11266,7 +11268,7 @@ func (a *SecretsService) PostAwsConfigLease(ctx context.Context, awsConfigLeaseR
 }
 
 // PostAwsConfigRoot Configure the root credentials that are used to manage IAM.
-func (a *SecretsService) PostAwsConfigRoot(ctx context.Context, awsConfigRootRequest AwsConfigRootRequest) (*http.Response, error) {
+func (a *Secrets) PostAwsConfigRoot(ctx context.Context, awsConfigRootRequest AwsConfigRootRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -11333,7 +11335,7 @@ func (a *SecretsService) PostAwsConfigRoot(ctx context.Context, awsConfigRootReq
 }
 
 // PostAwsConfigRotateRoot
-func (a *SecretsService) PostAwsConfigRotateRoot(ctx context.Context) (*http.Response, error) {
+func (a *Secrets) PostAwsConfigRotateRoot(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -11398,7 +11400,7 @@ func (a *SecretsService) PostAwsConfigRotateRoot(ctx context.Context) (*http.Res
 }
 
 // PostAwsCreds Generate AWS credentials from a specific Vault role.
-func (a *SecretsService) PostAwsCreds(ctx context.Context, awsCredsRequest AwsCredsRequest) (*http.Response, error) {
+func (a *Secrets) PostAwsCreds(ctx context.Context, awsCredsRequest AwsCredsRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -11466,7 +11468,7 @@ func (a *SecretsService) PostAwsCreds(ctx context.Context, awsCredsRequest AwsCr
 
 // PostAwsRolesName Read, write and reference IAM policies that access keys can be made for.
 // name: Name of the policy
-func (a *SecretsService) PostAwsRolesName(ctx context.Context, name string, awsRolesRequest AwsRolesRequest) (*http.Response, error) {
+func (a *Secrets) PostAwsRolesName(ctx context.Context, name string, awsRolesRequest AwsRolesRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -11535,7 +11537,7 @@ func (a *SecretsService) PostAwsRolesName(ctx context.Context, name string, awsR
 
 // PostAwsStsName Generate AWS credentials from a specific Vault role.
 // name: Name of the role
-func (a *SecretsService) PostAwsStsName(ctx context.Context, name string, awsStsRequest AwsStsRequest) (*http.Response, error) {
+func (a *Secrets) PostAwsStsName(ctx context.Context, name string, awsStsRequest AwsStsRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -11603,7 +11605,7 @@ func (a *SecretsService) PostAwsStsName(ctx context.Context, name string, awsSts
 }
 
 // PostAzureConfig
-func (a *SecretsService) PostAzureConfig(ctx context.Context, azureConfigRequest AzureConfigRequest) (*http.Response, error) {
+func (a *Secrets) PostAzureConfig(ctx context.Context, azureConfigRequest AzureConfigRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -11671,7 +11673,7 @@ func (a *SecretsService) PostAzureConfig(ctx context.Context, azureConfigRequest
 
 // PostAzureRolesName Manage the Vault roles used to generate Azure credentials.
 // name: Name of the role.
-func (a *SecretsService) PostAzureRolesName(ctx context.Context, name string, azureRolesRequest AzureRolesRequest) (*http.Response, error) {
+func (a *Secrets) PostAzureRolesName(ctx context.Context, name string, azureRolesRequest AzureRolesRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -11739,7 +11741,7 @@ func (a *SecretsService) PostAzureRolesName(ctx context.Context, name string, az
 }
 
 // PostAzureRotateRoot
-func (a *SecretsService) PostAzureRotateRoot(ctx context.Context) (*http.Response, error) {
+func (a *Secrets) PostAzureRotateRoot(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -11804,7 +11806,7 @@ func (a *SecretsService) PostAzureRotateRoot(ctx context.Context) (*http.Respons
 }
 
 // PostConsulConfigAccess
-func (a *SecretsService) PostConsulConfigAccess(ctx context.Context, consulConfigAccessRequest ConsulConfigAccessRequest) (*http.Response, error) {
+func (a *Secrets) PostConsulConfigAccess(ctx context.Context, consulConfigAccessRequest ConsulConfigAccessRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -11872,7 +11874,7 @@ func (a *SecretsService) PostConsulConfigAccess(ctx context.Context, consulConfi
 
 // PostConsulRolesName
 // name: Name of the role.
-func (a *SecretsService) PostConsulRolesName(ctx context.Context, name string, consulRolesRequest ConsulRolesRequest) (*http.Response, error) {
+func (a *Secrets) PostConsulRolesName(ctx context.Context, name string, consulRolesRequest ConsulRolesRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -11941,7 +11943,7 @@ func (a *SecretsService) PostConsulRolesName(ctx context.Context, name string, c
 
 // PostCubbyholePath Store a secret at the specified location.
 // path: Specifies the path of the secret.
-func (a *SecretsService) PostCubbyholePath(ctx context.Context, path string) (*http.Response, error) {
+func (a *Secrets) PostCubbyholePath(ctx context.Context, path string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -12007,7 +12009,7 @@ func (a *SecretsService) PostCubbyholePath(ctx context.Context, path string) (*h
 }
 
 // PostGcpConfig
-func (a *SecretsService) PostGcpConfig(ctx context.Context, gcpConfigRequest GcpConfigRequest) (*http.Response, error) {
+func (a *Secrets) PostGcpConfig(ctx context.Context, gcpConfigRequest GcpConfigRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -12074,7 +12076,7 @@ func (a *SecretsService) PostGcpConfig(ctx context.Context, gcpConfigRequest Gcp
 }
 
 // PostGcpConfigRotateRoot
-func (a *SecretsService) PostGcpConfigRotateRoot(ctx context.Context) (*http.Response, error) {
+func (a *Secrets) PostGcpConfigRotateRoot(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -12140,7 +12142,7 @@ func (a *SecretsService) PostGcpConfigRotateRoot(ctx context.Context) (*http.Res
 
 // PostGcpKeyRoleset
 // roleset: Required. Name of the role set.
-func (a *SecretsService) PostGcpKeyRoleset(ctx context.Context, roleset string, gcpKeyRequest GcpKeyRequest) (*http.Response, error) {
+func (a *Secrets) PostGcpKeyRoleset(ctx context.Context, roleset string, gcpKeyRequest GcpKeyRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -12209,7 +12211,7 @@ func (a *SecretsService) PostGcpKeyRoleset(ctx context.Context, roleset string, 
 
 // PostGcpRolesetName
 // name: Required. Name of the role.
-func (a *SecretsService) PostGcpRolesetName(ctx context.Context, name string, gcpRolesetRequest GcpRolesetRequest) (*http.Response, error) {
+func (a *Secrets) PostGcpRolesetName(ctx context.Context, name string, gcpRolesetRequest GcpRolesetRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -12278,7 +12280,7 @@ func (a *SecretsService) PostGcpRolesetName(ctx context.Context, name string, gc
 
 // PostGcpRolesetNameRotate
 // name: Name of the role.
-func (a *SecretsService) PostGcpRolesetNameRotate(ctx context.Context, name string) (*http.Response, error) {
+func (a *Secrets) PostGcpRolesetNameRotate(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -12345,7 +12347,7 @@ func (a *SecretsService) PostGcpRolesetNameRotate(ctx context.Context, name stri
 
 // PostGcpRolesetNameRotateKey
 // name: Name of the role.
-func (a *SecretsService) PostGcpRolesetNameRotateKey(ctx context.Context, name string) (*http.Response, error) {
+func (a *Secrets) PostGcpRolesetNameRotateKey(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -12412,7 +12414,7 @@ func (a *SecretsService) PostGcpRolesetNameRotateKey(ctx context.Context, name s
 
 // PostGcpRolesetRolesetKey
 // roleset: Required. Name of the role set.
-func (a *SecretsService) PostGcpRolesetRolesetKey(ctx context.Context, roleset string, gcpRolesetKeyRequest GcpRolesetKeyRequest) (*http.Response, error) {
+func (a *Secrets) PostGcpRolesetRolesetKey(ctx context.Context, roleset string, gcpRolesetKeyRequest GcpRolesetKeyRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -12481,7 +12483,7 @@ func (a *SecretsService) PostGcpRolesetRolesetKey(ctx context.Context, roleset s
 
 // PostGcpRolesetRolesetToken
 // roleset: Required. Name of the role set.
-func (a *SecretsService) PostGcpRolesetRolesetToken(ctx context.Context, roleset string) (*http.Response, error) {
+func (a *Secrets) PostGcpRolesetRolesetToken(ctx context.Context, roleset string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -12548,7 +12550,7 @@ func (a *SecretsService) PostGcpRolesetRolesetToken(ctx context.Context, roleset
 
 // PostGcpStaticAccountName
 // name: Required. Name to refer to this static account in Vault. Cannot be updated.
-func (a *SecretsService) PostGcpStaticAccountName(ctx context.Context, name string, gcpStaticAccountRequest GcpStaticAccountRequest) (*http.Response, error) {
+func (a *Secrets) PostGcpStaticAccountName(ctx context.Context, name string, gcpStaticAccountRequest GcpStaticAccountRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -12617,7 +12619,7 @@ func (a *SecretsService) PostGcpStaticAccountName(ctx context.Context, name stri
 
 // PostGcpStaticAccountNameKey
 // name: Required. Name of the static account.
-func (a *SecretsService) PostGcpStaticAccountNameKey(ctx context.Context, name string, gcpStaticAccountKeyRequest GcpStaticAccountKeyRequest) (*http.Response, error) {
+func (a *Secrets) PostGcpStaticAccountNameKey(ctx context.Context, name string, gcpStaticAccountKeyRequest GcpStaticAccountKeyRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -12686,7 +12688,7 @@ func (a *SecretsService) PostGcpStaticAccountNameKey(ctx context.Context, name s
 
 // PostGcpStaticAccountNameRotateKey
 // name: Name of the account.
-func (a *SecretsService) PostGcpStaticAccountNameRotateKey(ctx context.Context, name string) (*http.Response, error) {
+func (a *Secrets) PostGcpStaticAccountNameRotateKey(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -12753,7 +12755,7 @@ func (a *SecretsService) PostGcpStaticAccountNameRotateKey(ctx context.Context, 
 
 // PostGcpStaticAccountNameToken
 // name: Required. Name of the static account.
-func (a *SecretsService) PostGcpStaticAccountNameToken(ctx context.Context, name string) (*http.Response, error) {
+func (a *Secrets) PostGcpStaticAccountNameToken(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -12820,7 +12822,7 @@ func (a *SecretsService) PostGcpStaticAccountNameToken(ctx context.Context, name
 
 // PostGcpTokenRoleset
 // roleset: Required. Name of the role set.
-func (a *SecretsService) PostGcpTokenRoleset(ctx context.Context, roleset string) (*http.Response, error) {
+func (a *Secrets) PostGcpTokenRoleset(ctx context.Context, roleset string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -12886,7 +12888,7 @@ func (a *SecretsService) PostGcpTokenRoleset(ctx context.Context, roleset string
 }
 
 // PostGcpkmsConfig Configure the GCP KMS secrets engine
-func (a *SecretsService) PostGcpkmsConfig(ctx context.Context, gcpkmsConfigRequest GcpkmsConfigRequest) (*http.Response, error) {
+func (a *Secrets) PostGcpkmsConfig(ctx context.Context, gcpkmsConfigRequest GcpkmsConfigRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -12954,7 +12956,7 @@ func (a *SecretsService) PostGcpkmsConfig(ctx context.Context, gcpkmsConfigReque
 
 // PostGcpkmsDecryptKey Decrypt a ciphertext value using a named key
 // key: Name of the key in Vault to use for decryption. This key must already exist in Vault and must map back to a Google Cloud KMS key.
-func (a *SecretsService) PostGcpkmsDecryptKey(ctx context.Context, key string, gcpkmsDecryptRequest GcpkmsDecryptRequest) (*http.Response, error) {
+func (a *Secrets) PostGcpkmsDecryptKey(ctx context.Context, key string, gcpkmsDecryptRequest GcpkmsDecryptRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -13023,7 +13025,7 @@ func (a *SecretsService) PostGcpkmsDecryptKey(ctx context.Context, key string, g
 
 // PostGcpkmsEncryptKey Encrypt a plaintext value using a named key
 // key: Name of the key in Vault to use for encryption. This key must already exist in Vault and must map back to a Google Cloud KMS key.
-func (a *SecretsService) PostGcpkmsEncryptKey(ctx context.Context, key string, gcpkmsEncryptRequest GcpkmsEncryptRequest) (*http.Response, error) {
+func (a *Secrets) PostGcpkmsEncryptKey(ctx context.Context, key string, gcpkmsEncryptRequest GcpkmsEncryptRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -13092,7 +13094,7 @@ func (a *SecretsService) PostGcpkmsEncryptKey(ctx context.Context, key string, g
 
 // PostGcpkmsKeysConfigKey Configure the key in Vault
 // key: Name of the key in Vault.
-func (a *SecretsService) PostGcpkmsKeysConfigKey(ctx context.Context, key string, gcpkmsKeysConfigRequest GcpkmsKeysConfigRequest) (*http.Response, error) {
+func (a *Secrets) PostGcpkmsKeysConfigKey(ctx context.Context, key string, gcpkmsKeysConfigRequest GcpkmsKeysConfigRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -13161,7 +13163,7 @@ func (a *SecretsService) PostGcpkmsKeysConfigKey(ctx context.Context, key string
 
 // PostGcpkmsKeysDeregisterKey Deregister an existing key in Vault
 // key: Name of the key to deregister in Vault. If the key exists in Google Cloud KMS, it will be left untouched.
-func (a *SecretsService) PostGcpkmsKeysDeregisterKey(ctx context.Context, key string) (*http.Response, error) {
+func (a *Secrets) PostGcpkmsKeysDeregisterKey(ctx context.Context, key string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -13228,7 +13230,7 @@ func (a *SecretsService) PostGcpkmsKeysDeregisterKey(ctx context.Context, key st
 
 // PostGcpkmsKeysKey Interact with crypto keys in Vault and Google Cloud KMS
 // key: Name of the key in Vault.
-func (a *SecretsService) PostGcpkmsKeysKey(ctx context.Context, key string, gcpkmsKeysRequest GcpkmsKeysRequest) (*http.Response, error) {
+func (a *Secrets) PostGcpkmsKeysKey(ctx context.Context, key string, gcpkmsKeysRequest GcpkmsKeysRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -13297,7 +13299,7 @@ func (a *SecretsService) PostGcpkmsKeysKey(ctx context.Context, key string, gcpk
 
 // PostGcpkmsKeysRegisterKey Register an existing crypto key in Google Cloud KMS
 // key: Name of the key to register in Vault. This will be the named used to refer to the underlying crypto key when encrypting or decrypting data.
-func (a *SecretsService) PostGcpkmsKeysRegisterKey(ctx context.Context, key string, gcpkmsKeysRegisterRequest GcpkmsKeysRegisterRequest) (*http.Response, error) {
+func (a *Secrets) PostGcpkmsKeysRegisterKey(ctx context.Context, key string, gcpkmsKeysRegisterRequest GcpkmsKeysRegisterRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -13366,7 +13368,7 @@ func (a *SecretsService) PostGcpkmsKeysRegisterKey(ctx context.Context, key stri
 
 // PostGcpkmsKeysRotateKey Rotate a crypto key to a new primary version
 // key: Name of the key to rotate. This key must already be registered with Vault and point to a valid Google Cloud KMS crypto key.
-func (a *SecretsService) PostGcpkmsKeysRotateKey(ctx context.Context, key string) (*http.Response, error) {
+func (a *Secrets) PostGcpkmsKeysRotateKey(ctx context.Context, key string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -13433,7 +13435,7 @@ func (a *SecretsService) PostGcpkmsKeysRotateKey(ctx context.Context, key string
 
 // PostGcpkmsKeysTrimKey Delete old crypto key versions from Google Cloud KMS
 // key: Name of the key in Vault.
-func (a *SecretsService) PostGcpkmsKeysTrimKey(ctx context.Context, key string) (*http.Response, error) {
+func (a *Secrets) PostGcpkmsKeysTrimKey(ctx context.Context, key string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -13500,7 +13502,7 @@ func (a *SecretsService) PostGcpkmsKeysTrimKey(ctx context.Context, key string) 
 
 // PostGcpkmsReencryptKey Re-encrypt existing ciphertext data to a new version
 // key: Name of the key to use for encryption. This key must already exist in Vault and Google Cloud KMS.
-func (a *SecretsService) PostGcpkmsReencryptKey(ctx context.Context, key string, gcpkmsReencryptRequest GcpkmsReencryptRequest) (*http.Response, error) {
+func (a *Secrets) PostGcpkmsReencryptKey(ctx context.Context, key string, gcpkmsReencryptRequest GcpkmsReencryptRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -13569,7 +13571,7 @@ func (a *SecretsService) PostGcpkmsReencryptKey(ctx context.Context, key string,
 
 // PostGcpkmsSignKey Signs a message or digest using a named key
 // key: Name of the key in Vault to use for signing. This key must already exist in Vault and must map back to a Google Cloud KMS key.
-func (a *SecretsService) PostGcpkmsSignKey(ctx context.Context, key string, gcpkmsSignRequest GcpkmsSignRequest) (*http.Response, error) {
+func (a *Secrets) PostGcpkmsSignKey(ctx context.Context, key string, gcpkmsSignRequest GcpkmsSignRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -13638,7 +13640,7 @@ func (a *SecretsService) PostGcpkmsSignKey(ctx context.Context, key string, gcpk
 
 // PostGcpkmsVerifyKey Verify a signature using a named key
 // key: Name of the key in Vault to use for verification. This key must already exist in Vault and must map back to a Google Cloud KMS key.
-func (a *SecretsService) PostGcpkmsVerifyKey(ctx context.Context, key string, gcpkmsVerifyRequest GcpkmsVerifyRequest) (*http.Response, error) {
+func (a *Secrets) PostGcpkmsVerifyKey(ctx context.Context, key string, gcpkmsVerifyRequest GcpkmsVerifyRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -13706,7 +13708,7 @@ func (a *SecretsService) PostGcpkmsVerifyKey(ctx context.Context, key string, gc
 }
 
 // PostKubernetesConfig
-func (a *SecretsService) PostKubernetesConfig(ctx context.Context, kubernetesConfigRequest KubernetesConfigRequest) (*http.Response, error) {
+func (a *Secrets) PostKubernetesConfig(ctx context.Context, kubernetesConfigRequest KubernetesConfigRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -13774,7 +13776,7 @@ func (a *SecretsService) PostKubernetesConfig(ctx context.Context, kubernetesCon
 
 // PostKubernetesCredsName
 // name: Name of the Vault role
-func (a *SecretsService) PostKubernetesCredsName(ctx context.Context, name string, kubernetesCredsRequest KubernetesCredsRequest) (*http.Response, error) {
+func (a *Secrets) PostKubernetesCredsName(ctx context.Context, name string, kubernetesCredsRequest KubernetesCredsRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -13843,7 +13845,7 @@ func (a *SecretsService) PostKubernetesCredsName(ctx context.Context, name strin
 
 // PostKubernetesRolesName
 // name: Name of the role
-func (a *SecretsService) PostKubernetesRolesName(ctx context.Context, name string, kubernetesRolesRequest KubernetesRolesRequest) (*http.Response, error) {
+func (a *Secrets) PostKubernetesRolesName(ctx context.Context, name string, kubernetesRolesRequest KubernetesRolesRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -13912,7 +13914,7 @@ func (a *SecretsService) PostKubernetesRolesName(ctx context.Context, name strin
 
 // PostKvPath Pass-through secret storage to the storage backend, allowing you to read/write arbitrary data into secret storage.
 // path: Location of the secret.
-func (a *SecretsService) PostKvPath(ctx context.Context, path string) (*http.Response, error) {
+func (a *Secrets) PostKvPath(ctx context.Context, path string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -13978,7 +13980,7 @@ func (a *SecretsService) PostKvPath(ctx context.Context, path string) (*http.Res
 }
 
 // PostMongodbatlasConfig Configure the  credentials that are used to manage Database Users.
-func (a *SecretsService) PostMongodbatlasConfig(ctx context.Context, mongodbatlasConfigRequest MongodbatlasConfigRequest) (*http.Response, error) {
+func (a *Secrets) PostMongodbatlasConfig(ctx context.Context, mongodbatlasConfigRequest MongodbatlasConfigRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -14046,7 +14048,7 @@ func (a *SecretsService) PostMongodbatlasConfig(ctx context.Context, mongodbatla
 
 // PostMongodbatlasCredsName Generate MongoDB Atlas Programmatic API from a specific Vault role.
 // name: Name of the role
-func (a *SecretsService) PostMongodbatlasCredsName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Secrets) PostMongodbatlasCredsName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -14113,7 +14115,7 @@ func (a *SecretsService) PostMongodbatlasCredsName(ctx context.Context, name str
 
 // PostMongodbatlasRolesName Manage the roles used to generate MongoDB Atlas Programmatic API Keys.
 // name: Name of the Roles
-func (a *SecretsService) PostMongodbatlasRolesName(ctx context.Context, name string, mongodbatlasRolesRequest MongodbatlasRolesRequest) (*http.Response, error) {
+func (a *Secrets) PostMongodbatlasRolesName(ctx context.Context, name string, mongodbatlasRolesRequest MongodbatlasRolesRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -14181,7 +14183,7 @@ func (a *SecretsService) PostMongodbatlasRolesName(ctx context.Context, name str
 }
 
 // PostNomadConfigAccess
-func (a *SecretsService) PostNomadConfigAccess(ctx context.Context, nomadConfigAccessRequest NomadConfigAccessRequest) (*http.Response, error) {
+func (a *Secrets) PostNomadConfigAccess(ctx context.Context, nomadConfigAccessRequest NomadConfigAccessRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -14248,7 +14250,7 @@ func (a *SecretsService) PostNomadConfigAccess(ctx context.Context, nomadConfigA
 }
 
 // PostNomadConfigLease Configure the lease parameters for generated tokens
-func (a *SecretsService) PostNomadConfigLease(ctx context.Context, nomadConfigLeaseRequest NomadConfigLeaseRequest) (*http.Response, error) {
+func (a *Secrets) PostNomadConfigLease(ctx context.Context, nomadConfigLeaseRequest NomadConfigLeaseRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -14316,7 +14318,7 @@ func (a *SecretsService) PostNomadConfigLease(ctx context.Context, nomadConfigLe
 
 // PostNomadRoleName
 // name: Name of the role
-func (a *SecretsService) PostNomadRoleName(ctx context.Context, name string, nomadRoleRequest NomadRoleRequest) (*http.Response, error) {
+func (a *Secrets) PostNomadRoleName(ctx context.Context, name string, nomadRoleRequest NomadRoleRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -14384,7 +14386,7 @@ func (a *SecretsService) PostNomadRoleName(ctx context.Context, name string, nom
 }
 
 // PostOpenldapConfig
-func (a *SecretsService) PostOpenldapConfig(ctx context.Context, openldapConfigRequest OpenldapConfigRequest) (*http.Response, error) {
+func (a *Secrets) PostOpenldapConfig(ctx context.Context, openldapConfigRequest OpenldapConfigRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -14452,7 +14454,7 @@ func (a *SecretsService) PostOpenldapConfig(ctx context.Context, openldapConfigR
 
 // PostOpenldapRoleName
 // name: Name of the role (lowercase)
-func (a *SecretsService) PostOpenldapRoleName(ctx context.Context, name string, openldapRoleRequest OpenldapRoleRequest) (*http.Response, error) {
+func (a *Secrets) PostOpenldapRoleName(ctx context.Context, name string, openldapRoleRequest OpenldapRoleRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -14521,7 +14523,7 @@ func (a *SecretsService) PostOpenldapRoleName(ctx context.Context, name string, 
 
 // PostOpenldapRotateRoleName
 // name: Name of the static role
-func (a *SecretsService) PostOpenldapRotateRoleName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Secrets) PostOpenldapRotateRoleName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -14587,7 +14589,7 @@ func (a *SecretsService) PostOpenldapRotateRoleName(ctx context.Context, name st
 }
 
 // PostOpenldapRotateRoot
-func (a *SecretsService) PostOpenldapRotateRoot(ctx context.Context) (*http.Response, error) {
+func (a *Secrets) PostOpenldapRotateRoot(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -14653,7 +14655,7 @@ func (a *SecretsService) PostOpenldapRotateRoot(ctx context.Context) (*http.Resp
 
 // PostOpenldapStaticRoleName
 // name: Name of the role
-func (a *SecretsService) PostOpenldapStaticRoleName(ctx context.Context, name string, openldapStaticRoleRequest OpenldapStaticRoleRequest) (*http.Response, error) {
+func (a *Secrets) PostOpenldapStaticRoleName(ctx context.Context, name string, openldapStaticRoleRequest OpenldapStaticRoleRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -14721,7 +14723,7 @@ func (a *SecretsService) PostOpenldapStaticRoleName(ctx context.Context, name st
 }
 
 // PostPkiBundle
-func (a *SecretsService) PostPkiBundle(ctx context.Context, pkiBundleRequest PkiBundleRequest) (*http.Response, error) {
+func (a *Secrets) PostPkiBundle(ctx context.Context, pkiBundleRequest PkiBundleRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -14788,7 +14790,7 @@ func (a *SecretsService) PostPkiBundle(ctx context.Context, pkiBundleRequest Pki
 }
 
 // PostPkiCert
-func (a *SecretsService) PostPkiCert(ctx context.Context, pkiCertRequest PkiCertRequest) (*http.Response, error) {
+func (a *Secrets) PostPkiCert(ctx context.Context, pkiCertRequest PkiCertRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -14855,7 +14857,7 @@ func (a *SecretsService) PostPkiCert(ctx context.Context, pkiCertRequest PkiCert
 }
 
 // PostPkiConfigCa
-func (a *SecretsService) PostPkiConfigCa(ctx context.Context, pkiConfigCaRequest PkiConfigCaRequest) (*http.Response, error) {
+func (a *Secrets) PostPkiConfigCa(ctx context.Context, pkiConfigCaRequest PkiConfigCaRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -14922,7 +14924,7 @@ func (a *SecretsService) PostPkiConfigCa(ctx context.Context, pkiConfigCaRequest
 }
 
 // PostPkiConfigCrl
-func (a *SecretsService) PostPkiConfigCrl(ctx context.Context, pkiConfigCrlRequest PkiConfigCrlRequest) (*http.Response, error) {
+func (a *Secrets) PostPkiConfigCrl(ctx context.Context, pkiConfigCrlRequest PkiConfigCrlRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -14989,7 +14991,7 @@ func (a *SecretsService) PostPkiConfigCrl(ctx context.Context, pkiConfigCrlReque
 }
 
 // PostPkiConfigIssuers
-func (a *SecretsService) PostPkiConfigIssuers(ctx context.Context, pkiConfigIssuersRequest PkiConfigIssuersRequest) (*http.Response, error) {
+func (a *Secrets) PostPkiConfigIssuers(ctx context.Context, pkiConfigIssuersRequest PkiConfigIssuersRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -15056,7 +15058,7 @@ func (a *SecretsService) PostPkiConfigIssuers(ctx context.Context, pkiConfigIssu
 }
 
 // PostPkiConfigKeys
-func (a *SecretsService) PostPkiConfigKeys(ctx context.Context, pkiConfigKeysRequest PkiConfigKeysRequest) (*http.Response, error) {
+func (a *Secrets) PostPkiConfigKeys(ctx context.Context, pkiConfigKeysRequest PkiConfigKeysRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -15123,7 +15125,7 @@ func (a *SecretsService) PostPkiConfigKeys(ctx context.Context, pkiConfigKeysReq
 }
 
 // PostPkiConfigUrls
-func (a *SecretsService) PostPkiConfigUrls(ctx context.Context, pkiConfigUrlsRequest PkiConfigUrlsRequest) (*http.Response, error) {
+func (a *Secrets) PostPkiConfigUrls(ctx context.Context, pkiConfigUrlsRequest PkiConfigUrlsRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -15190,7 +15192,7 @@ func (a *SecretsService) PostPkiConfigUrls(ctx context.Context, pkiConfigUrlsReq
 }
 
 // PostPkiIntermediateCrossSign
-func (a *SecretsService) PostPkiIntermediateCrossSign(ctx context.Context, pkiIntermediateCrossSignRequest PkiIntermediateCrossSignRequest) (*http.Response, error) {
+func (a *Secrets) PostPkiIntermediateCrossSign(ctx context.Context, pkiIntermediateCrossSignRequest PkiIntermediateCrossSignRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -15258,7 +15260,7 @@ func (a *SecretsService) PostPkiIntermediateCrossSign(ctx context.Context, pkiIn
 
 // PostPkiIntermediateGenerateExported
 // exported: Must be \&quot;internal\&quot;, \&quot;exported\&quot; or \&quot;kms\&quot;. If set to \&quot;exported\&quot;, the generated private key will be returned. This is your *only* chance to retrieve the private key!
-func (a *SecretsService) PostPkiIntermediateGenerateExported(ctx context.Context, exported string, pkiIntermediateGenerateRequest PkiIntermediateGenerateRequest) (*http.Response, error) {
+func (a *Secrets) PostPkiIntermediateGenerateExported(ctx context.Context, exported string, pkiIntermediateGenerateRequest PkiIntermediateGenerateRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -15326,7 +15328,7 @@ func (a *SecretsService) PostPkiIntermediateGenerateExported(ctx context.Context
 }
 
 // PostPkiIntermediateSetSigned
-func (a *SecretsService) PostPkiIntermediateSetSigned(ctx context.Context, pkiIntermediateSetSignedRequest PkiIntermediateSetSignedRequest) (*http.Response, error) {
+func (a *Secrets) PostPkiIntermediateSetSigned(ctx context.Context, pkiIntermediateSetSignedRequest PkiIntermediateSetSignedRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -15393,7 +15395,7 @@ func (a *SecretsService) PostPkiIntermediateSetSigned(ctx context.Context, pkiIn
 }
 
 // PostPkiInternalExported
-func (a *SecretsService) PostPkiInternalExported(ctx context.Context, pkiInternalExportedRequest PkiInternalExportedRequest) (*http.Response, error) {
+func (a *Secrets) PostPkiInternalExported(ctx context.Context, pkiInternalExportedRequest PkiInternalExportedRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -15461,7 +15463,7 @@ func (a *SecretsService) PostPkiInternalExported(ctx context.Context, pkiInterna
 
 // PostPkiIssueRole
 // role: The desired role with configuration for this request
-func (a *SecretsService) PostPkiIssueRole(ctx context.Context, role string, pkiIssueRequest PkiIssueRequest) (*http.Response, error) {
+func (a *Secrets) PostPkiIssueRole(ctx context.Context, role string, pkiIssueRequest PkiIssueRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -15531,7 +15533,7 @@ func (a *SecretsService) PostPkiIssueRole(ctx context.Context, role string, pkiI
 // PostPkiIssuerIssuerRefIssueRole
 // issuerRef: Reference to a existing issuer; either \&quot;default\&quot; for the configured default issuer, an identifier or the name assigned to the issuer.
 // role: The desired role with configuration for this request
-func (a *SecretsService) PostPkiIssuerIssuerRefIssueRole(ctx context.Context, issuerRef string, role string, pkiIssuerIssueRequest PkiIssuerIssueRequest) (*http.Response, error) {
+func (a *Secrets) PostPkiIssuerIssuerRefIssueRole(ctx context.Context, issuerRef string, role string, pkiIssuerIssueRequest PkiIssuerIssueRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -15601,7 +15603,7 @@ func (a *SecretsService) PostPkiIssuerIssuerRefIssueRole(ctx context.Context, is
 
 // PostPkiIssuerIssuerRefSignIntermediate
 // issuerRef: Reference to a existing issuer; either \&quot;default\&quot; for the configured default issuer, an identifier or the name assigned to the issuer.
-func (a *SecretsService) PostPkiIssuerIssuerRefSignIntermediate(ctx context.Context, issuerRef string, pkiIssuerSignIntermediateRequest PkiIssuerSignIntermediateRequest) (*http.Response, error) {
+func (a *Secrets) PostPkiIssuerIssuerRefSignIntermediate(ctx context.Context, issuerRef string, pkiIssuerSignIntermediateRequest PkiIssuerSignIntermediateRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -15671,7 +15673,7 @@ func (a *SecretsService) PostPkiIssuerIssuerRefSignIntermediate(ctx context.Cont
 // PostPkiIssuerIssuerRefSignRole
 // issuerRef: Reference to a existing issuer; either \&quot;default\&quot; for the configured default issuer, an identifier or the name assigned to the issuer.
 // role: The desired role with configuration for this request
-func (a *SecretsService) PostPkiIssuerIssuerRefSignRole(ctx context.Context, issuerRef string, role string, pkiIssuerSignRequest PkiIssuerSignRequest) (*http.Response, error) {
+func (a *Secrets) PostPkiIssuerIssuerRefSignRole(ctx context.Context, issuerRef string, role string, pkiIssuerSignRequest PkiIssuerSignRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -15741,7 +15743,7 @@ func (a *SecretsService) PostPkiIssuerIssuerRefSignRole(ctx context.Context, iss
 
 // PostPkiIssuerIssuerRefSignSelfIssued
 // issuerRef: Reference to a existing issuer; either \&quot;default\&quot; for the configured default issuer, an identifier or the name assigned to the issuer.
-func (a *SecretsService) PostPkiIssuerIssuerRefSignSelfIssued(ctx context.Context, issuerRef string, pkiIssuerSignSelfIssuedRequest PkiIssuerSignSelfIssuedRequest) (*http.Response, error) {
+func (a *Secrets) PostPkiIssuerIssuerRefSignSelfIssued(ctx context.Context, issuerRef string, pkiIssuerSignSelfIssuedRequest PkiIssuerSignSelfIssuedRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -15810,7 +15812,7 @@ func (a *SecretsService) PostPkiIssuerIssuerRefSignSelfIssued(ctx context.Contex
 
 // PostPkiIssuerIssuerRefSignVerbatim
 // issuerRef: Reference to a existing issuer; either \&quot;default\&quot; for the configured default issuer, an identifier or the name assigned to the issuer.
-func (a *SecretsService) PostPkiIssuerIssuerRefSignVerbatim(ctx context.Context, issuerRef string, pkiIssuerSignVerbatimRequest PkiIssuerSignVerbatimRequest) (*http.Response, error) {
+func (a *Secrets) PostPkiIssuerIssuerRefSignVerbatim(ctx context.Context, issuerRef string, pkiIssuerSignVerbatimRequest PkiIssuerSignVerbatimRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -15880,7 +15882,7 @@ func (a *SecretsService) PostPkiIssuerIssuerRefSignVerbatim(ctx context.Context,
 // PostPkiIssuerIssuerRefSignVerbatimRole
 // issuerRef: Reference to a existing issuer; either \&quot;default\&quot; for the configured default issuer, an identifier or the name assigned to the issuer.
 // role: The desired role with configuration for this request
-func (a *SecretsService) PostPkiIssuerIssuerRefSignVerbatimRole(ctx context.Context, issuerRef string, role string, pkiIssuerSignVerbatimRequest PkiIssuerSignVerbatimRequest) (*http.Response, error) {
+func (a *Secrets) PostPkiIssuerIssuerRefSignVerbatimRole(ctx context.Context, issuerRef string, role string, pkiIssuerSignVerbatimRequest PkiIssuerSignVerbatimRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -15950,7 +15952,7 @@ func (a *SecretsService) PostPkiIssuerIssuerRefSignVerbatimRole(ctx context.Cont
 
 // PostPkiIssuerRefDerPem
 // issuerRef: Reference to a existing issuer; either \&quot;default\&quot; for the configured default issuer, an identifier or the name assigned to the issuer.
-func (a *SecretsService) PostPkiIssuerRefDerPem(ctx context.Context, issuerRef string, pkiDerPemRequest PkiDerPemRequest) (*http.Response, error) {
+func (a *Secrets) PostPkiIssuerRefDerPem(ctx context.Context, issuerRef string, pkiDerPemRequest PkiDerPemRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -16019,7 +16021,7 @@ func (a *SecretsService) PostPkiIssuerRefDerPem(ctx context.Context, issuerRef s
 
 // PostPkiIssuersGenerateIntermediateExported
 // exported: Must be \&quot;internal\&quot;, \&quot;exported\&quot; or \&quot;kms\&quot;. If set to \&quot;exported\&quot;, the generated private key will be returned. This is your *only* chance to retrieve the private key!
-func (a *SecretsService) PostPkiIssuersGenerateIntermediateExported(ctx context.Context, exported string, pkiIssuersGenerateIntermediateRequest PkiIssuersGenerateIntermediateRequest) (*http.Response, error) {
+func (a *Secrets) PostPkiIssuersGenerateIntermediateExported(ctx context.Context, exported string, pkiIssuersGenerateIntermediateRequest PkiIssuersGenerateIntermediateRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -16088,7 +16090,7 @@ func (a *SecretsService) PostPkiIssuersGenerateIntermediateExported(ctx context.
 
 // PostPkiIssuersGenerateRootExported
 // exported: Must be \&quot;internal\&quot;, \&quot;exported\&quot; or \&quot;kms\&quot;. If set to \&quot;exported\&quot;, the generated private key will be returned. This is your *only* chance to retrieve the private key!
-func (a *SecretsService) PostPkiIssuersGenerateRootExported(ctx context.Context, exported string, pkiIssuersGenerateRootRequest PkiIssuersGenerateRootRequest) (*http.Response, error) {
+func (a *Secrets) PostPkiIssuersGenerateRootExported(ctx context.Context, exported string, pkiIssuersGenerateRootRequest PkiIssuersGenerateRootRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -16156,7 +16158,7 @@ func (a *SecretsService) PostPkiIssuersGenerateRootExported(ctx context.Context,
 }
 
 // PostPkiJson
-func (a *SecretsService) PostPkiJson(ctx context.Context, pkiJsonRequest PkiJsonRequest) (*http.Response, error) {
+func (a *Secrets) PostPkiJson(ctx context.Context, pkiJsonRequest PkiJsonRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -16224,7 +16226,7 @@ func (a *SecretsService) PostPkiJson(ctx context.Context, pkiJsonRequest PkiJson
 
 // PostPkiKeyKeyRef
 // keyRef: Reference to key; either \&quot;default\&quot; for the configured default key, an identifier of a key, or the name assigned to the key.
-func (a *SecretsService) PostPkiKeyKeyRef(ctx context.Context, keyRef string, pkiKeyRequest PkiKeyRequest) (*http.Response, error) {
+func (a *Secrets) PostPkiKeyKeyRef(ctx context.Context, keyRef string, pkiKeyRequest PkiKeyRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -16292,7 +16294,7 @@ func (a *SecretsService) PostPkiKeyKeyRef(ctx context.Context, keyRef string, pk
 }
 
 // PostPkiKeysImport
-func (a *SecretsService) PostPkiKeysImport(ctx context.Context, pkiKeysImportRequest PkiKeysImportRequest) (*http.Response, error) {
+func (a *Secrets) PostPkiKeysImport(ctx context.Context, pkiKeysImportRequest PkiKeysImportRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -16359,7 +16361,7 @@ func (a *SecretsService) PostPkiKeysImport(ctx context.Context, pkiKeysImportReq
 }
 
 // PostPkiKms
-func (a *SecretsService) PostPkiKms(ctx context.Context, pkiKmsRequest PkiKmsRequest) (*http.Response, error) {
+func (a *Secrets) PostPkiKms(ctx context.Context, pkiKmsRequest PkiKmsRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -16426,7 +16428,7 @@ func (a *SecretsService) PostPkiKms(ctx context.Context, pkiKmsRequest PkiKmsReq
 }
 
 // PostPkiRevoke
-func (a *SecretsService) PostPkiRevoke(ctx context.Context, pkiRevokeRequest PkiRevokeRequest) (*http.Response, error) {
+func (a *Secrets) PostPkiRevoke(ctx context.Context, pkiRevokeRequest PkiRevokeRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -16494,7 +16496,7 @@ func (a *SecretsService) PostPkiRevoke(ctx context.Context, pkiRevokeRequest Pki
 
 // PostPkiRolesName
 // name: Name of the role
-func (a *SecretsService) PostPkiRolesName(ctx context.Context, name string, pkiRolesRequest PkiRolesRequest) (*http.Response, error) {
+func (a *Secrets) PostPkiRolesName(ctx context.Context, name string, pkiRolesRequest PkiRolesRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -16563,7 +16565,7 @@ func (a *SecretsService) PostPkiRolesName(ctx context.Context, name string, pkiR
 
 // PostPkiRootGenerateExported
 // exported: Must be \&quot;internal\&quot;, \&quot;exported\&quot; or \&quot;kms\&quot;. If set to \&quot;exported\&quot;, the generated private key will be returned. This is your *only* chance to retrieve the private key!
-func (a *SecretsService) PostPkiRootGenerateExported(ctx context.Context, exported string, pkiRootGenerateRequest PkiRootGenerateRequest) (*http.Response, error) {
+func (a *Secrets) PostPkiRootGenerateExported(ctx context.Context, exported string, pkiRootGenerateRequest PkiRootGenerateRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -16631,7 +16633,7 @@ func (a *SecretsService) PostPkiRootGenerateExported(ctx context.Context, export
 }
 
 // PostPkiRootReplace
-func (a *SecretsService) PostPkiRootReplace(ctx context.Context, pkiRootReplaceRequest PkiRootReplaceRequest) (*http.Response, error) {
+func (a *Secrets) PostPkiRootReplace(ctx context.Context, pkiRootReplaceRequest PkiRootReplaceRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -16699,7 +16701,7 @@ func (a *SecretsService) PostPkiRootReplace(ctx context.Context, pkiRootReplaceR
 
 // PostPkiRootRotateExported
 // exported: Must be \&quot;internal\&quot;, \&quot;exported\&quot; or \&quot;kms\&quot;. If set to \&quot;exported\&quot;, the generated private key will be returned. This is your *only* chance to retrieve the private key!
-func (a *SecretsService) PostPkiRootRotateExported(ctx context.Context, exported string, pkiRootRotateRequest PkiRootRotateRequest) (*http.Response, error) {
+func (a *Secrets) PostPkiRootRotateExported(ctx context.Context, exported string, pkiRootRotateRequest PkiRootRotateRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -16767,7 +16769,7 @@ func (a *SecretsService) PostPkiRootRotateExported(ctx context.Context, exported
 }
 
 // PostPkiRootSignIntermediate
-func (a *SecretsService) PostPkiRootSignIntermediate(ctx context.Context, pkiRootSignIntermediateRequest PkiRootSignIntermediateRequest) (*http.Response, error) {
+func (a *Secrets) PostPkiRootSignIntermediate(ctx context.Context, pkiRootSignIntermediateRequest PkiRootSignIntermediateRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -16834,7 +16836,7 @@ func (a *SecretsService) PostPkiRootSignIntermediate(ctx context.Context, pkiRoo
 }
 
 // PostPkiRootSignSelfIssued
-func (a *SecretsService) PostPkiRootSignSelfIssued(ctx context.Context, pkiRootSignSelfIssuedRequest PkiRootSignSelfIssuedRequest) (*http.Response, error) {
+func (a *Secrets) PostPkiRootSignSelfIssued(ctx context.Context, pkiRootSignSelfIssuedRequest PkiRootSignSelfIssuedRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -16902,7 +16904,7 @@ func (a *SecretsService) PostPkiRootSignSelfIssued(ctx context.Context, pkiRootS
 
 // PostPkiSignRole
 // role: The desired role with configuration for this request
-func (a *SecretsService) PostPkiSignRole(ctx context.Context, role string, pkiSignRequest PkiSignRequest) (*http.Response, error) {
+func (a *Secrets) PostPkiSignRole(ctx context.Context, role string, pkiSignRequest PkiSignRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -16970,7 +16972,7 @@ func (a *SecretsService) PostPkiSignRole(ctx context.Context, role string, pkiSi
 }
 
 // PostPkiSignVerbatim
-func (a *SecretsService) PostPkiSignVerbatim(ctx context.Context, pkiSignVerbatimRequest PkiSignVerbatimRequest) (*http.Response, error) {
+func (a *Secrets) PostPkiSignVerbatim(ctx context.Context, pkiSignVerbatimRequest PkiSignVerbatimRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -17038,7 +17040,7 @@ func (a *SecretsService) PostPkiSignVerbatim(ctx context.Context, pkiSignVerbati
 
 // PostPkiSignVerbatimRole
 // role: The desired role with configuration for this request
-func (a *SecretsService) PostPkiSignVerbatimRole(ctx context.Context, role string, pkiSignVerbatimRequest PkiSignVerbatimRequest) (*http.Response, error) {
+func (a *Secrets) PostPkiSignVerbatimRole(ctx context.Context, role string, pkiSignVerbatimRequest PkiSignVerbatimRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -17106,7 +17108,7 @@ func (a *SecretsService) PostPkiSignVerbatimRole(ctx context.Context, role strin
 }
 
 // PostPkiTidy
-func (a *SecretsService) PostPkiTidy(ctx context.Context, pkiTidyRequest PkiTidyRequest) (*http.Response, error) {
+func (a *Secrets) PostPkiTidy(ctx context.Context, pkiTidyRequest PkiTidyRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -17173,7 +17175,7 @@ func (a *SecretsService) PostPkiTidy(ctx context.Context, pkiTidyRequest PkiTidy
 }
 
 // PostRabbitmqConfigConnection Configure the connection URI, username, and password to talk to RabbitMQ management HTTP API.
-func (a *SecretsService) PostRabbitmqConfigConnection(ctx context.Context, rabbitmqConfigConnectionRequest RabbitmqConfigConnectionRequest) (*http.Response, error) {
+func (a *Secrets) PostRabbitmqConfigConnection(ctx context.Context, rabbitmqConfigConnectionRequest RabbitmqConfigConnectionRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -17240,7 +17242,7 @@ func (a *SecretsService) PostRabbitmqConfigConnection(ctx context.Context, rabbi
 }
 
 // PostRabbitmqConfigLease Configure the lease parameters for generated credentials
-func (a *SecretsService) PostRabbitmqConfigLease(ctx context.Context, rabbitmqConfigLeaseRequest RabbitmqConfigLeaseRequest) (*http.Response, error) {
+func (a *Secrets) PostRabbitmqConfigLease(ctx context.Context, rabbitmqConfigLeaseRequest RabbitmqConfigLeaseRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -17308,7 +17310,7 @@ func (a *SecretsService) PostRabbitmqConfigLease(ctx context.Context, rabbitmqCo
 
 // PostRabbitmqRolesName Manage the roles that can be created with this backend.
 // name: Name of the role.
-func (a *SecretsService) PostRabbitmqRolesName(ctx context.Context, name string, rabbitmqRolesRequest RabbitmqRolesRequest) (*http.Response, error) {
+func (a *Secrets) PostRabbitmqRolesName(ctx context.Context, name string, rabbitmqRolesRequest RabbitmqRolesRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -17376,7 +17378,7 @@ func (a *SecretsService) PostRabbitmqRolesName(ctx context.Context, name string,
 }
 
 // PostSecretConfig Configure backend level settings that are applied to every key in the key-value store.
-func (a *SecretsService) PostSecretConfig(ctx context.Context, kvConfigRequest KvConfigRequest) (*http.Response, error) {
+func (a *Secrets) PostSecretConfig(ctx context.Context, kvConfigRequest KvConfigRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -17444,7 +17446,7 @@ func (a *SecretsService) PostSecretConfig(ctx context.Context, kvConfigRequest K
 
 // PostSecretDataPath Write, Patch, Read, and Delete data in the Key-Value Store.
 // path: Location of the secret.
-func (a *SecretsService) PostSecretDataPath(ctx context.Context, path string, kvDataRequest KvDataRequest) (*http.Response, error) {
+func (a *Secrets) PostSecretDataPath(ctx context.Context, path string, kvDataRequest KvDataRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -17513,7 +17515,7 @@ func (a *SecretsService) PostSecretDataPath(ctx context.Context, path string, kv
 
 // PostSecretDeletePath Marks one or more versions as deleted in the KV store.
 // path: Location of the secret.
-func (a *SecretsService) PostSecretDeletePath(ctx context.Context, path string, kvDeleteRequest KvDeleteRequest) (*http.Response, error) {
+func (a *Secrets) PostSecretDeletePath(ctx context.Context, path string, kvDeleteRequest KvDeleteRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -17582,7 +17584,7 @@ func (a *SecretsService) PostSecretDeletePath(ctx context.Context, path string, 
 
 // PostSecretDestroyPath Permanently removes one or more versions in the KV store
 // path: Location of the secret.
-func (a *SecretsService) PostSecretDestroyPath(ctx context.Context, path string, kvDestroyRequest KvDestroyRequest) (*http.Response, error) {
+func (a *Secrets) PostSecretDestroyPath(ctx context.Context, path string, kvDestroyRequest KvDestroyRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -17651,7 +17653,7 @@ func (a *SecretsService) PostSecretDestroyPath(ctx context.Context, path string,
 
 // PostSecretMetadataPath Configures settings for the KV store
 // path: Location of the secret.
-func (a *SecretsService) PostSecretMetadataPath(ctx context.Context, path string, kvMetadataRequest KvMetadataRequest) (*http.Response, error) {
+func (a *Secrets) PostSecretMetadataPath(ctx context.Context, path string, kvMetadataRequest KvMetadataRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -17720,7 +17722,7 @@ func (a *SecretsService) PostSecretMetadataPath(ctx context.Context, path string
 
 // PostSecretUndeletePath Undeletes one or more versions from the KV store.
 // path: Location of the secret.
-func (a *SecretsService) PostSecretUndeletePath(ctx context.Context, path string, kvUndeleteRequest KvUndeleteRequest) (*http.Response, error) {
+func (a *Secrets) PostSecretUndeletePath(ctx context.Context, path string, kvUndeleteRequest KvUndeleteRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -17788,7 +17790,7 @@ func (a *SecretsService) PostSecretUndeletePath(ctx context.Context, path string
 }
 
 // PostSshConfigCa Set the SSH private key used for signing certificates.
-func (a *SecretsService) PostSshConfigCa(ctx context.Context, sshConfigCaRequest SshConfigCaRequest) (*http.Response, error) {
+func (a *Secrets) PostSshConfigCa(ctx context.Context, sshConfigCaRequest SshConfigCaRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -17855,7 +17857,7 @@ func (a *SecretsService) PostSshConfigCa(ctx context.Context, sshConfigCaRequest
 }
 
 // PostSshConfigZeroaddress Assign zero address as default CIDR block for select roles.
-func (a *SecretsService) PostSshConfigZeroaddress(ctx context.Context, sshConfigZeroaddressRequest SshConfigZeroaddressRequest) (*http.Response, error) {
+func (a *Secrets) PostSshConfigZeroaddress(ctx context.Context, sshConfigZeroaddressRequest SshConfigZeroaddressRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -17923,7 +17925,7 @@ func (a *SecretsService) PostSshConfigZeroaddress(ctx context.Context, sshConfig
 
 // PostSshCredsRole Creates a credential for establishing SSH connection with the remote host.
 // role: [Required] Name of the role
-func (a *SecretsService) PostSshCredsRole(ctx context.Context, role string, sshCredsRequest SshCredsRequest) (*http.Response, error) {
+func (a *Secrets) PostSshCredsRole(ctx context.Context, role string, sshCredsRequest SshCredsRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -17992,7 +17994,7 @@ func (a *SecretsService) PostSshCredsRole(ctx context.Context, role string, sshC
 
 // PostSshKeysKeyName Register a shared private key with Vault.
 // keyName: [Required] Name of the key
-func (a *SecretsService) PostSshKeysKeyName(ctx context.Context, keyName string, sshKeysRequest SshKeysRequest) (*http.Response, error) {
+func (a *Secrets) PostSshKeysKeyName(ctx context.Context, keyName string, sshKeysRequest SshKeysRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -18060,7 +18062,7 @@ func (a *SecretsService) PostSshKeysKeyName(ctx context.Context, keyName string,
 }
 
 // PostSshLookup List all the roles associated with the given IP address.
-func (a *SecretsService) PostSshLookup(ctx context.Context, sshLookupRequest SshLookupRequest) (*http.Response, error) {
+func (a *Secrets) PostSshLookup(ctx context.Context, sshLookupRequest SshLookupRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -18128,7 +18130,7 @@ func (a *SecretsService) PostSshLookup(ctx context.Context, sshLookupRequest Ssh
 
 // PostSshRolesRole Manage the 'roles' that can be created with this backend.
 // role: [Required for all types] Name of the role being created.
-func (a *SecretsService) PostSshRolesRole(ctx context.Context, role string, sshRolesRequest SshRolesRequest) (*http.Response, error) {
+func (a *Secrets) PostSshRolesRole(ctx context.Context, role string, sshRolesRequest SshRolesRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -18197,7 +18199,7 @@ func (a *SecretsService) PostSshRolesRole(ctx context.Context, role string, sshR
 
 // PostSshSignRole Request signing an SSH key using a certain role with the provided details.
 // role: The desired role with configuration for this request.
-func (a *SecretsService) PostSshSignRole(ctx context.Context, role string, sshSignRequest SshSignRequest) (*http.Response, error) {
+func (a *Secrets) PostSshSignRole(ctx context.Context, role string, sshSignRequest SshSignRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -18265,7 +18267,7 @@ func (a *SecretsService) PostSshSignRole(ctx context.Context, role string, sshSi
 }
 
 // PostSshVerify Validate the OTP provided by Vault SSH Agent.
-func (a *SecretsService) PostSshVerify(ctx context.Context, sshVerifyRequest SshVerifyRequest) (*http.Response, error) {
+func (a *Secrets) PostSshVerify(ctx context.Context, sshVerifyRequest SshVerifyRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -18332,7 +18334,7 @@ func (a *SecretsService) PostSshVerify(ctx context.Context, sshVerifyRequest Ssh
 }
 
 // PostTerraformConfig
-func (a *SecretsService) PostTerraformConfig(ctx context.Context, terraformConfigRequest TerraformConfigRequest) (*http.Response, error) {
+func (a *Secrets) PostTerraformConfig(ctx context.Context, terraformConfigRequest TerraformConfigRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -18400,7 +18402,7 @@ func (a *SecretsService) PostTerraformConfig(ctx context.Context, terraformConfi
 
 // PostTerraformCredsName Generate a Terraform Cloud or Enterprise API token from a specific Vault role.
 // name: Name of the role
-func (a *SecretsService) PostTerraformCredsName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Secrets) PostTerraformCredsName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -18467,7 +18469,7 @@ func (a *SecretsService) PostTerraformCredsName(ctx context.Context, name string
 
 // PostTerraformRoleName
 // name: Name of the role
-func (a *SecretsService) PostTerraformRoleName(ctx context.Context, name string, terraformRoleRequest TerraformRoleRequest) (*http.Response, error) {
+func (a *Secrets) PostTerraformRoleName(ctx context.Context, name string, terraformRoleRequest TerraformRoleRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -18536,7 +18538,7 @@ func (a *SecretsService) PostTerraformRoleName(ctx context.Context, name string,
 
 // PostTerraformRotateRoleName
 // name: Name of the team or organization role
-func (a *SecretsService) PostTerraformRotateRoleName(ctx context.Context, name string) (*http.Response, error) {
+func (a *Secrets) PostTerraformRotateRoleName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -18603,7 +18605,7 @@ func (a *SecretsService) PostTerraformRotateRoleName(ctx context.Context, name s
 
 // PostTotpCodeName Request time-based one-time use password or validate a password for a certain key .
 // name: Name of the key.
-func (a *SecretsService) PostTotpCodeName(ctx context.Context, name string, totpCodeRequest TotpCodeRequest) (*http.Response, error) {
+func (a *Secrets) PostTotpCodeName(ctx context.Context, name string, totpCodeRequest TotpCodeRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -18672,7 +18674,7 @@ func (a *SecretsService) PostTotpCodeName(ctx context.Context, name string, totp
 
 // PostTotpKeysName Manage the keys that can be created with this backend.
 // name: Name of the key.
-func (a *SecretsService) PostTotpKeysName(ctx context.Context, name string, totpKeysRequest TotpKeysRequest) (*http.Response, error) {
+func (a *Secrets) PostTotpKeysName(ctx context.Context, name string, totpKeysRequest TotpKeysRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -18740,7 +18742,7 @@ func (a *SecretsService) PostTotpKeysName(ctx context.Context, name string, totp
 }
 
 // PostTransitCacheConfig Configures a new cache of the specified size
-func (a *SecretsService) PostTransitCacheConfig(ctx context.Context, transitCacheConfigRequest TransitCacheConfigRequest) (*http.Response, error) {
+func (a *Secrets) PostTransitCacheConfig(ctx context.Context, transitCacheConfigRequest TransitCacheConfigRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -18809,7 +18811,7 @@ func (a *SecretsService) PostTransitCacheConfig(ctx context.Context, transitCach
 // PostTransitDatakeyPlaintextName Generate a data key
 // name: The backend key used for encrypting the data key
 // plaintext: \&quot;plaintext\&quot; will return the key in both plaintext and ciphertext; \&quot;wrapped\&quot; will return the ciphertext only.
-func (a *SecretsService) PostTransitDatakeyPlaintextName(ctx context.Context, name string, plaintext string, transitDatakeyRequest TransitDatakeyRequest) (*http.Response, error) {
+func (a *Secrets) PostTransitDatakeyPlaintextName(ctx context.Context, name string, plaintext string, transitDatakeyRequest TransitDatakeyRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -18879,7 +18881,7 @@ func (a *SecretsService) PostTransitDatakeyPlaintextName(ctx context.Context, na
 
 // PostTransitDecryptName Decrypt a ciphertext value using a named key
 // name: Name of the policy
-func (a *SecretsService) PostTransitDecryptName(ctx context.Context, name string, transitDecryptRequest TransitDecryptRequest) (*http.Response, error) {
+func (a *Secrets) PostTransitDecryptName(ctx context.Context, name string, transitDecryptRequest TransitDecryptRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -18948,7 +18950,7 @@ func (a *SecretsService) PostTransitDecryptName(ctx context.Context, name string
 
 // PostTransitEncryptName Encrypt a plaintext value or a batch of plaintext blocks using a named key
 // name: Name of the policy
-func (a *SecretsService) PostTransitEncryptName(ctx context.Context, name string, transitEncryptRequest TransitEncryptRequest) (*http.Response, error) {
+func (a *Secrets) PostTransitEncryptName(ctx context.Context, name string, transitEncryptRequest TransitEncryptRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -19016,7 +19018,7 @@ func (a *SecretsService) PostTransitEncryptName(ctx context.Context, name string
 }
 
 // PostTransitHash Generate a hash sum for input data
-func (a *SecretsService) PostTransitHash(ctx context.Context, transitHashRequest TransitHashRequest) (*http.Response, error) {
+func (a *Secrets) PostTransitHash(ctx context.Context, transitHashRequest TransitHashRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -19084,7 +19086,7 @@ func (a *SecretsService) PostTransitHash(ctx context.Context, transitHashRequest
 
 // PostTransitHashUrlalgorithm Generate a hash sum for input data
 // urlalgorithm: Algorithm to use (POST URL parameter)
-func (a *SecretsService) PostTransitHashUrlalgorithm(ctx context.Context, urlalgorithm string, transitHashRequest TransitHashRequest) (*http.Response, error) {
+func (a *Secrets) PostTransitHashUrlalgorithm(ctx context.Context, urlalgorithm string, transitHashRequest TransitHashRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -19153,7 +19155,7 @@ func (a *SecretsService) PostTransitHashUrlalgorithm(ctx context.Context, urlalg
 
 // PostTransitHmacName Generate an HMAC for input data using the named key
 // name: The key to use for the HMAC function
-func (a *SecretsService) PostTransitHmacName(ctx context.Context, name string, transitHmacRequest TransitHmacRequest) (*http.Response, error) {
+func (a *Secrets) PostTransitHmacName(ctx context.Context, name string, transitHmacRequest TransitHmacRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -19223,7 +19225,7 @@ func (a *SecretsService) PostTransitHmacName(ctx context.Context, name string, t
 // PostTransitHmacNameUrlalgorithm Generate an HMAC for input data using the named key
 // name: The key to use for the HMAC function
 // urlalgorithm: Algorithm to use (POST URL parameter)
-func (a *SecretsService) PostTransitHmacNameUrlalgorithm(ctx context.Context, name string, urlalgorithm string, transitHmacRequest TransitHmacRequest) (*http.Response, error) {
+func (a *Secrets) PostTransitHmacNameUrlalgorithm(ctx context.Context, name string, urlalgorithm string, transitHmacRequest TransitHmacRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -19293,7 +19295,7 @@ func (a *SecretsService) PostTransitHmacNameUrlalgorithm(ctx context.Context, na
 
 // PostTransitKeysName Managed named encryption keys
 // name: Name of the key
-func (a *SecretsService) PostTransitKeysName(ctx context.Context, name string, transitKeysRequest TransitKeysRequest) (*http.Response, error) {
+func (a *Secrets) PostTransitKeysName(ctx context.Context, name string, transitKeysRequest TransitKeysRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -19362,7 +19364,7 @@ func (a *SecretsService) PostTransitKeysName(ctx context.Context, name string, t
 
 // PostTransitKeysNameConfig Configure a named encryption key
 // name: Name of the key
-func (a *SecretsService) PostTransitKeysNameConfig(ctx context.Context, name string, transitKeysConfigRequest TransitKeysConfigRequest) (*http.Response, error) {
+func (a *Secrets) PostTransitKeysNameConfig(ctx context.Context, name string, transitKeysConfigRequest TransitKeysConfigRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -19431,7 +19433,7 @@ func (a *SecretsService) PostTransitKeysNameConfig(ctx context.Context, name str
 
 // PostTransitKeysNameImport Imports an externally-generated key into a new transit key
 // name: The name of the key
-func (a *SecretsService) PostTransitKeysNameImport(ctx context.Context, name string, transitKeysImportRequest TransitKeysImportRequest) (*http.Response, error) {
+func (a *Secrets) PostTransitKeysNameImport(ctx context.Context, name string, transitKeysImportRequest TransitKeysImportRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -19500,7 +19502,7 @@ func (a *SecretsService) PostTransitKeysNameImport(ctx context.Context, name str
 
 // PostTransitKeysNameImportVersion Imports an externally-generated key into an existing imported key
 // name: The name of the key
-func (a *SecretsService) PostTransitKeysNameImportVersion(ctx context.Context, name string, transitKeysImportVersionRequest TransitKeysImportVersionRequest) (*http.Response, error) {
+func (a *Secrets) PostTransitKeysNameImportVersion(ctx context.Context, name string, transitKeysImportVersionRequest TransitKeysImportVersionRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -19569,7 +19571,7 @@ func (a *SecretsService) PostTransitKeysNameImportVersion(ctx context.Context, n
 
 // PostTransitKeysNameRotate Rotate named encryption key
 // name: Name of the key
-func (a *SecretsService) PostTransitKeysNameRotate(ctx context.Context, name string) (*http.Response, error) {
+func (a *Secrets) PostTransitKeysNameRotate(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -19636,7 +19638,7 @@ func (a *SecretsService) PostTransitKeysNameRotate(ctx context.Context, name str
 
 // PostTransitKeysNameTrim Trim key versions of a named key
 // name: Name of the key
-func (a *SecretsService) PostTransitKeysNameTrim(ctx context.Context, name string, transitKeysTrimRequest TransitKeysTrimRequest) (*http.Response, error) {
+func (a *Secrets) PostTransitKeysNameTrim(ctx context.Context, name string, transitKeysTrimRequest TransitKeysTrimRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -19704,7 +19706,7 @@ func (a *SecretsService) PostTransitKeysNameTrim(ctx context.Context, name strin
 }
 
 // PostTransitRandom Generate random bytes
-func (a *SecretsService) PostTransitRandom(ctx context.Context, transitRandomRequest TransitRandomRequest) (*http.Response, error) {
+func (a *Secrets) PostTransitRandom(ctx context.Context, transitRandomRequest TransitRandomRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -19772,7 +19774,7 @@ func (a *SecretsService) PostTransitRandom(ctx context.Context, transitRandomReq
 
 // PostTransitRandomSource Generate random bytes
 // source: Which system to source random data from, ether \&quot;platform\&quot;, \&quot;seal\&quot;, or \&quot;all\&quot;.
-func (a *SecretsService) PostTransitRandomSource(ctx context.Context, source string, transitRandomRequest TransitRandomRequest) (*http.Response, error) {
+func (a *Secrets) PostTransitRandomSource(ctx context.Context, source string, transitRandomRequest TransitRandomRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -19842,7 +19844,7 @@ func (a *SecretsService) PostTransitRandomSource(ctx context.Context, source str
 // PostTransitRandomSourceUrlbytes Generate random bytes
 // source: Which system to source random data from, ether \&quot;platform\&quot;, \&quot;seal\&quot;, or \&quot;all\&quot;.
 // urlbytes: The number of bytes to generate (POST URL parameter)
-func (a *SecretsService) PostTransitRandomSourceUrlbytes(ctx context.Context, source string, urlbytes string, transitRandomRequest TransitRandomRequest) (*http.Response, error) {
+func (a *Secrets) PostTransitRandomSourceUrlbytes(ctx context.Context, source string, urlbytes string, transitRandomRequest TransitRandomRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -19912,7 +19914,7 @@ func (a *SecretsService) PostTransitRandomSourceUrlbytes(ctx context.Context, so
 
 // PostTransitRandomUrlbytes Generate random bytes
 // urlbytes: The number of bytes to generate (POST URL parameter)
-func (a *SecretsService) PostTransitRandomUrlbytes(ctx context.Context, urlbytes string, transitRandomRequest TransitRandomRequest) (*http.Response, error) {
+func (a *Secrets) PostTransitRandomUrlbytes(ctx context.Context, urlbytes string, transitRandomRequest TransitRandomRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -19980,7 +19982,7 @@ func (a *SecretsService) PostTransitRandomUrlbytes(ctx context.Context, urlbytes
 }
 
 // PostTransitRestore Restore the named key
-func (a *SecretsService) PostTransitRestore(ctx context.Context, transitRestoreRequest TransitRestoreRequest) (*http.Response, error) {
+func (a *Secrets) PostTransitRestore(ctx context.Context, transitRestoreRequest TransitRestoreRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -20048,7 +20050,7 @@ func (a *SecretsService) PostTransitRestore(ctx context.Context, transitRestoreR
 
 // PostTransitRestoreName Restore the named key
 // name: If set, this will be the name of the restored key.
-func (a *SecretsService) PostTransitRestoreName(ctx context.Context, name string, transitRestoreRequest TransitRestoreRequest) (*http.Response, error) {
+func (a *Secrets) PostTransitRestoreName(ctx context.Context, name string, transitRestoreRequest TransitRestoreRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -20117,7 +20119,7 @@ func (a *SecretsService) PostTransitRestoreName(ctx context.Context, name string
 
 // PostTransitRewrapName Rewrap ciphertext
 // name: Name of the key
-func (a *SecretsService) PostTransitRewrapName(ctx context.Context, name string, transitRewrapRequest TransitRewrapRequest) (*http.Response, error) {
+func (a *Secrets) PostTransitRewrapName(ctx context.Context, name string, transitRewrapRequest TransitRewrapRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -20186,7 +20188,7 @@ func (a *SecretsService) PostTransitRewrapName(ctx context.Context, name string,
 
 // PostTransitSignName Generate a signature for input data using the named key
 // name: The key to use
-func (a *SecretsService) PostTransitSignName(ctx context.Context, name string, transitSignRequest TransitSignRequest) (*http.Response, error) {
+func (a *Secrets) PostTransitSignName(ctx context.Context, name string, transitSignRequest TransitSignRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -20256,7 +20258,7 @@ func (a *SecretsService) PostTransitSignName(ctx context.Context, name string, t
 // PostTransitSignNameUrlalgorithm Generate a signature for input data using the named key
 // name: The key to use
 // urlalgorithm: Hash algorithm to use (POST URL parameter)
-func (a *SecretsService) PostTransitSignNameUrlalgorithm(ctx context.Context, name string, urlalgorithm string, transitSignRequest TransitSignRequest) (*http.Response, error) {
+func (a *Secrets) PostTransitSignNameUrlalgorithm(ctx context.Context, name string, urlalgorithm string, transitSignRequest TransitSignRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -20326,7 +20328,7 @@ func (a *SecretsService) PostTransitSignNameUrlalgorithm(ctx context.Context, na
 
 // PostTransitVerifyName Verify a signature or HMAC for input data created using the named key
 // name: The key to use
-func (a *SecretsService) PostTransitVerifyName(ctx context.Context, name string, transitVerifyRequest TransitVerifyRequest) (*http.Response, error) {
+func (a *Secrets) PostTransitVerifyName(ctx context.Context, name string, transitVerifyRequest TransitVerifyRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -20396,7 +20398,7 @@ func (a *SecretsService) PostTransitVerifyName(ctx context.Context, name string,
 // PostTransitVerifyNameUrlalgorithm Verify a signature or HMAC for input data created using the named key
 // name: The key to use
 // urlalgorithm: Hash algorithm to use (POST URL parameter)
-func (a *SecretsService) PostTransitVerifyNameUrlalgorithm(ctx context.Context, name string, urlalgorithm string, transitVerifyRequest TransitVerifyRequest) (*http.Response, error) {
+func (a *Secrets) PostTransitVerifyNameUrlalgorithm(ctx context.Context, name string, urlalgorithm string, transitVerifyRequest TransitVerifyRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}

--- a/api_system.go
+++ b/api_system.go
@@ -19,12 +19,14 @@ import (
 	"strings"
 )
 
-// SystemService System service
-type SystemService service
+// System is a simple wrapper around the client for System requests
+type System struct {
+	client *Client
+}
 
 // DeleteSysAuditPath Disable the audit device at the given path.
 // path: The name of the backend. Cannot be delimited. Example: \&quot;mysql\&quot;
-func (a *SystemService) DeleteSysAuditPath(ctx context.Context, path string) (*http.Response, error) {
+func (a *System) DeleteSysAuditPath(ctx context.Context, path string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -91,7 +93,7 @@ func (a *SystemService) DeleteSysAuditPath(ctx context.Context, path string) (*h
 
 // DeleteSysAuthPath Disable the auth method at the given auth path
 // path: The path to mount to. Cannot be delimited. Example: \&quot;user\&quot;
-func (a *SystemService) DeleteSysAuthPath(ctx context.Context, path string) (*http.Response, error) {
+func (a *System) DeleteSysAuthPath(ctx context.Context, path string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -157,7 +159,7 @@ func (a *SystemService) DeleteSysAuthPath(ctx context.Context, path string) (*ht
 }
 
 // DeleteSysConfigAuditingRequestHeadersHeader Disable auditing of the given request header.
-func (a *SystemService) DeleteSysConfigAuditingRequestHeadersHeader(ctx context.Context, header string) (*http.Response, error) {
+func (a *System) DeleteSysConfigAuditingRequestHeadersHeader(ctx context.Context, header string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -223,7 +225,7 @@ func (a *SystemService) DeleteSysConfigAuditingRequestHeadersHeader(ctx context.
 }
 
 // DeleteSysConfigCors Remove any CORS settings.
-func (a *SystemService) DeleteSysConfigCors(ctx context.Context) (*http.Response, error) {
+func (a *System) DeleteSysConfigCors(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -289,7 +291,7 @@ func (a *SystemService) DeleteSysConfigCors(ctx context.Context) (*http.Response
 
 // DeleteSysConfigUiHeadersHeader Remove a UI header.
 // header: The name of the header.
-func (a *SystemService) DeleteSysConfigUiHeadersHeader(ctx context.Context, header string) (*http.Response, error) {
+func (a *System) DeleteSysConfigUiHeadersHeader(ctx context.Context, header string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -355,7 +357,7 @@ func (a *SystemService) DeleteSysConfigUiHeadersHeader(ctx context.Context, head
 }
 
 // DeleteSysGenerateRoot Cancels any in-progress root generation attempt.
-func (a *SystemService) DeleteSysGenerateRoot(ctx context.Context) (*http.Response, error) {
+func (a *System) DeleteSysGenerateRoot(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -420,7 +422,7 @@ func (a *SystemService) DeleteSysGenerateRoot(ctx context.Context) (*http.Respon
 }
 
 // DeleteSysGenerateRootAttempt Cancels any in-progress root generation attempt.
-func (a *SystemService) DeleteSysGenerateRootAttempt(ctx context.Context) (*http.Response, error) {
+func (a *System) DeleteSysGenerateRootAttempt(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -486,7 +488,7 @@ func (a *SystemService) DeleteSysGenerateRootAttempt(ctx context.Context) (*http
 
 // DeleteSysMountsPath Disable the mount point specified at the given path.
 // path: The path to mount to. Example: \&quot;aws/east\&quot;
-func (a *SystemService) DeleteSysMountsPath(ctx context.Context, path string) (*http.Response, error) {
+func (a *System) DeleteSysMountsPath(ctx context.Context, path string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -553,7 +555,7 @@ func (a *SystemService) DeleteSysMountsPath(ctx context.Context, path string) (*
 
 // DeleteSysPluginsCatalogName Remove the plugin with the given name.
 // name: The name of the plugin
-func (a *SystemService) DeleteSysPluginsCatalogName(ctx context.Context, name string) (*http.Response, error) {
+func (a *System) DeleteSysPluginsCatalogName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -621,7 +623,7 @@ func (a *SystemService) DeleteSysPluginsCatalogName(ctx context.Context, name st
 // DeleteSysPluginsCatalogTypeName Remove the plugin with the given name.
 // name: The name of the plugin
 // type_: The type of the plugin, may be auth, secret, or database
-func (a *SystemService) DeleteSysPluginsCatalogTypeName(ctx context.Context, name string, type_ string) (*http.Response, error) {
+func (a *System) DeleteSysPluginsCatalogTypeName(ctx context.Context, name string, type_ string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -689,7 +691,7 @@ func (a *SystemService) DeleteSysPluginsCatalogTypeName(ctx context.Context, nam
 
 // DeleteSysPoliciesAclName Delete the ACL policy with the given name.
 // name: The name of the policy. Example: \&quot;ops\&quot;
-func (a *SystemService) DeleteSysPoliciesAclName(ctx context.Context, name string) (*http.Response, error) {
+func (a *System) DeleteSysPoliciesAclName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -756,7 +758,7 @@ func (a *SystemService) DeleteSysPoliciesAclName(ctx context.Context, name strin
 
 // DeleteSysPoliciesPasswordName Delete a password policy.
 // name: The name of the password policy.
-func (a *SystemService) DeleteSysPoliciesPasswordName(ctx context.Context, name string) (*http.Response, error) {
+func (a *System) DeleteSysPoliciesPasswordName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -823,7 +825,7 @@ func (a *SystemService) DeleteSysPoliciesPasswordName(ctx context.Context, name 
 
 // DeleteSysPolicyName Delete the policy with the given name.
 // name: The name of the policy. Example: \&quot;ops\&quot;
-func (a *SystemService) DeleteSysPolicyName(ctx context.Context, name string) (*http.Response, error) {
+func (a *System) DeleteSysPolicyName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -890,7 +892,7 @@ func (a *SystemService) DeleteSysPolicyName(ctx context.Context, name string) (*
 
 // DeleteSysQuotasRateLimitName
 // name: Name of the quota rule.
-func (a *SystemService) DeleteSysQuotasRateLimitName(ctx context.Context, name string) (*http.Response, error) {
+func (a *System) DeleteSysQuotasRateLimitName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -956,7 +958,7 @@ func (a *SystemService) DeleteSysQuotasRateLimitName(ctx context.Context, name s
 }
 
 // DeleteSysRaw Delete the key with given path.
-func (a *SystemService) DeleteSysRaw(ctx context.Context) (*http.Response, error) {
+func (a *System) DeleteSysRaw(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -1021,7 +1023,7 @@ func (a *SystemService) DeleteSysRaw(ctx context.Context) (*http.Response, error
 }
 
 // DeleteSysRawPath Delete the key with given path.
-func (a *SystemService) DeleteSysRawPath(ctx context.Context, path string) (*http.Response, error) {
+func (a *System) DeleteSysRawPath(ctx context.Context, path string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -1087,7 +1089,7 @@ func (a *SystemService) DeleteSysRawPath(ctx context.Context, path string) (*htt
 }
 
 // DeleteSysRekeyBackup Delete the backup copy of PGP-encrypted unseal keys.
-func (a *SystemService) DeleteSysRekeyBackup(ctx context.Context) (*http.Response, error) {
+func (a *System) DeleteSysRekeyBackup(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -1153,7 +1155,7 @@ func (a *SystemService) DeleteSysRekeyBackup(ctx context.Context) (*http.Respons
 
 // DeleteSysRekeyInit Cancels any in-progress rekey.
 // This clears the rekey settings as well as any progress made. This must be called to change the parameters of the rekey. Note: verification is still a part of a rekey. If rekeying is canceled during the verification flow, the current unseal keys remain valid.
-func (a *SystemService) DeleteSysRekeyInit(ctx context.Context) (*http.Response, error) {
+func (a *System) DeleteSysRekeyInit(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -1218,7 +1220,7 @@ func (a *SystemService) DeleteSysRekeyInit(ctx context.Context) (*http.Response,
 }
 
 // DeleteSysRekeyRecoveryKeyBackup Allows fetching or deleting the backup of the rotated unseal keys.
-func (a *SystemService) DeleteSysRekeyRecoveryKeyBackup(ctx context.Context) (*http.Response, error) {
+func (a *System) DeleteSysRekeyRecoveryKeyBackup(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -1284,7 +1286,7 @@ func (a *SystemService) DeleteSysRekeyRecoveryKeyBackup(ctx context.Context) (*h
 
 // DeleteSysRekeyVerify Cancel any in-progress rekey verification operation.
 // This clears any progress made and resets the nonce. Unlike a `DELETE` against `sys/rekey/init`, this only resets the current verification operation, not the entire rekey atttempt.
-func (a *SystemService) DeleteSysRekeyVerify(ctx context.Context) (*http.Response, error) {
+func (a *System) DeleteSysRekeyVerify(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
@@ -1349,7 +1351,7 @@ func (a *SystemService) DeleteSysRekeyVerify(ctx context.Context) (*http.Respons
 }
 
 // GetSysAudit List the enabled audit devices.
-func (a *SystemService) GetSysAudit(ctx context.Context) (*http.Response, error) {
+func (a *System) GetSysAudit(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -1414,7 +1416,7 @@ func (a *SystemService) GetSysAudit(ctx context.Context) (*http.Response, error)
 }
 
 // GetSysAuth List the currently enabled credential backends.
-func (a *SystemService) GetSysAuth(ctx context.Context) (*http.Response, error) {
+func (a *System) GetSysAuth(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -1480,7 +1482,7 @@ func (a *SystemService) GetSysAuth(ctx context.Context) (*http.Response, error) 
 
 // GetSysAuthPath Read the configuration of the auth engine at the given path.
 // path: The path to mount to. Cannot be delimited. Example: \&quot;user\&quot;
-func (a *SystemService) GetSysAuthPath(ctx context.Context, path string) (*http.Response, error) {
+func (a *System) GetSysAuthPath(ctx context.Context, path string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -1548,7 +1550,7 @@ func (a *SystemService) GetSysAuthPath(ctx context.Context, path string) (*http.
 // GetSysAuthPathTune Reads the given auth path's configuration.
 // This endpoint requires sudo capability on the final path, but the same functionality can be achieved without sudo via `sys/mounts/auth/[auth-path]/tune`.
 // path: Tune the configuration parameters for an auth path.
-func (a *SystemService) GetSysAuthPathTune(ctx context.Context, path string) (*http.Response, error) {
+func (a *System) GetSysAuthPathTune(ctx context.Context, path string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -1614,7 +1616,7 @@ func (a *SystemService) GetSysAuthPathTune(ctx context.Context, path string) (*h
 }
 
 // GetSysConfigAuditingRequestHeaders List the request headers that are configured to be audited.
-func (a *SystemService) GetSysConfigAuditingRequestHeaders(ctx context.Context) (*http.Response, error) {
+func (a *System) GetSysConfigAuditingRequestHeaders(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -1679,7 +1681,7 @@ func (a *SystemService) GetSysConfigAuditingRequestHeaders(ctx context.Context) 
 }
 
 // GetSysConfigAuditingRequestHeadersHeader List the information for the given request header.
-func (a *SystemService) GetSysConfigAuditingRequestHeadersHeader(ctx context.Context, header string) (*http.Response, error) {
+func (a *System) GetSysConfigAuditingRequestHeadersHeader(ctx context.Context, header string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -1745,7 +1747,7 @@ func (a *SystemService) GetSysConfigAuditingRequestHeadersHeader(ctx context.Con
 }
 
 // GetSysConfigCors Return the current CORS settings.
-func (a *SystemService) GetSysConfigCors(ctx context.Context) (*http.Response, error) {
+func (a *System) GetSysConfigCors(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -1811,7 +1813,7 @@ func (a *SystemService) GetSysConfigCors(ctx context.Context) (*http.Response, e
 
 // GetSysConfigStateSanitized Return a sanitized version of the Vault server configuration.
 // The sanitized output strips configuration values in the storage, HA storage, and seals stanzas, which may contain sensitive values such as API tokens. It also removes any token or secret fields in other stanzas, such as the circonus_api_token from telemetry.
-func (a *SystemService) GetSysConfigStateSanitized(ctx context.Context) (*http.Response, error) {
+func (a *System) GetSysConfigStateSanitized(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -1877,7 +1879,7 @@ func (a *SystemService) GetSysConfigStateSanitized(ctx context.Context) (*http.R
 
 // GetSysConfigUiHeaders Return a list of configured UI headers.
 // list: Must be set to &#x60;true&#x60;
-func (a *SystemService) GetSysConfigUiHeaders(ctx context.Context, list string) (*http.Response, error) {
+func (a *System) GetSysConfigUiHeaders(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -1944,7 +1946,7 @@ func (a *SystemService) GetSysConfigUiHeaders(ctx context.Context, list string) 
 
 // GetSysConfigUiHeadersHeader Return the given UI header's configuration
 // header: The name of the header.
-func (a *SystemService) GetSysConfigUiHeadersHeader(ctx context.Context, header string) (*http.Response, error) {
+func (a *System) GetSysConfigUiHeadersHeader(ctx context.Context, header string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -2010,7 +2012,7 @@ func (a *SystemService) GetSysConfigUiHeadersHeader(ctx context.Context, header 
 }
 
 // GetSysGenerateRoot Read the configuration and progress of the current root generation attempt.
-func (a *SystemService) GetSysGenerateRoot(ctx context.Context) (*http.Response, error) {
+func (a *System) GetSysGenerateRoot(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -2075,7 +2077,7 @@ func (a *SystemService) GetSysGenerateRoot(ctx context.Context) (*http.Response,
 }
 
 // GetSysGenerateRootAttempt Read the configuration and progress of the current root generation attempt.
-func (a *SystemService) GetSysGenerateRootAttempt(ctx context.Context) (*http.Response, error) {
+func (a *System) GetSysGenerateRootAttempt(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -2140,7 +2142,7 @@ func (a *SystemService) GetSysGenerateRootAttempt(ctx context.Context) (*http.Re
 }
 
 // GetSysHaStatus Check the HA status of a Vault cluster
-func (a *SystemService) GetSysHaStatus(ctx context.Context) (*http.Response, error) {
+func (a *System) GetSysHaStatus(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -2205,7 +2207,7 @@ func (a *SystemService) GetSysHaStatus(ctx context.Context) (*http.Response, err
 }
 
 // GetSysHealth Returns the health status of Vault.
-func (a *SystemService) GetSysHealth(ctx context.Context) (*http.Response, error) {
+func (a *System) GetSysHealth(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -2271,7 +2273,7 @@ func (a *SystemService) GetSysHealth(ctx context.Context) (*http.Response, error
 
 // GetSysHostInfo Information about the host instance that this Vault server is running on.
 // Information about the host instance that this Vault server is running on.   The information that gets collected includes host hardware information, and CPU,   disk, and memory utilization
-func (a *SystemService) GetSysHostInfo(ctx context.Context) (*http.Response, error) {
+func (a *System) GetSysHostInfo(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -2337,7 +2339,7 @@ func (a *SystemService) GetSysHostInfo(ctx context.Context) (*http.Response, err
 
 // GetSysInFlightReq reports in-flight requests
 // This path responds to the following HTTP methods.   GET /    Returns a map of in-flight requests.
-func (a *SystemService) GetSysInFlightReq(ctx context.Context) (*http.Response, error) {
+func (a *System) GetSysInFlightReq(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -2402,7 +2404,7 @@ func (a *SystemService) GetSysInFlightReq(ctx context.Context) (*http.Response, 
 }
 
 // GetSysInit Returns the initialization status of Vault.
-func (a *SystemService) GetSysInit(ctx context.Context) (*http.Response, error) {
+func (a *System) GetSysInit(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -2467,7 +2469,7 @@ func (a *SystemService) GetSysInit(ctx context.Context) (*http.Response, error) 
 }
 
 // GetSysInternalCountersActivity Report the client count metrics, for this namespace and all child namespaces.
-func (a *SystemService) GetSysInternalCountersActivity(ctx context.Context) (*http.Response, error) {
+func (a *System) GetSysInternalCountersActivity(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -2532,7 +2534,7 @@ func (a *SystemService) GetSysInternalCountersActivity(ctx context.Context) (*ht
 }
 
 // GetSysInternalCountersActivityExport Report the client count metrics, for this namespace and all child namespaces.
-func (a *SystemService) GetSysInternalCountersActivityExport(ctx context.Context) (*http.Response, error) {
+func (a *System) GetSysInternalCountersActivityExport(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -2597,7 +2599,7 @@ func (a *SystemService) GetSysInternalCountersActivityExport(ctx context.Context
 }
 
 // GetSysInternalCountersActivityMonthly Report the number of clients for this month, for this namespace and all child namespaces.
-func (a *SystemService) GetSysInternalCountersActivityMonthly(ctx context.Context) (*http.Response, error) {
+func (a *System) GetSysInternalCountersActivityMonthly(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -2662,7 +2664,7 @@ func (a *SystemService) GetSysInternalCountersActivityMonthly(ctx context.Contex
 }
 
 // GetSysInternalCountersConfig Read the client count tracking configuration.
-func (a *SystemService) GetSysInternalCountersConfig(ctx context.Context) (*http.Response, error) {
+func (a *System) GetSysInternalCountersConfig(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -2727,7 +2729,7 @@ func (a *SystemService) GetSysInternalCountersConfig(ctx context.Context) (*http
 }
 
 // GetSysInternalCountersEntities Backwards compatibility is not guaranteed for this API
-func (a *SystemService) GetSysInternalCountersEntities(ctx context.Context) (*http.Response, error) {
+func (a *System) GetSysInternalCountersEntities(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -2792,7 +2794,7 @@ func (a *SystemService) GetSysInternalCountersEntities(ctx context.Context) (*ht
 }
 
 // GetSysInternalCountersRequests Backwards compatibility is not guaranteed for this API
-func (a *SystemService) GetSysInternalCountersRequests(ctx context.Context) (*http.Response, error) {
+func (a *System) GetSysInternalCountersRequests(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -2857,7 +2859,7 @@ func (a *SystemService) GetSysInternalCountersRequests(ctx context.Context) (*ht
 }
 
 // GetSysInternalCountersTokens Backwards compatibility is not guaranteed for this API
-func (a *SystemService) GetSysInternalCountersTokens(ctx context.Context) (*http.Response, error) {
+func (a *System) GetSysInternalCountersTokens(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -2922,7 +2924,7 @@ func (a *SystemService) GetSysInternalCountersTokens(ctx context.Context) (*http
 }
 
 // GetSysInternalSpecsOpenapi Generate an OpenAPI 3 document of all mounted paths.
-func (a *SystemService) GetSysInternalSpecsOpenapi(ctx context.Context) (*http.Response, error) {
+func (a *System) GetSysInternalSpecsOpenapi(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -2987,7 +2989,7 @@ func (a *SystemService) GetSysInternalSpecsOpenapi(ctx context.Context) (*http.R
 }
 
 // GetSysInternalUiFeatureFlags Lists enabled feature flags.
-func (a *SystemService) GetSysInternalUiFeatureFlags(ctx context.Context) (*http.Response, error) {
+func (a *System) GetSysInternalUiFeatureFlags(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -3052,7 +3054,7 @@ func (a *SystemService) GetSysInternalUiFeatureFlags(ctx context.Context) (*http
 }
 
 // GetSysInternalUiMounts Lists all enabled and visible auth and secrets mounts.
-func (a *SystemService) GetSysInternalUiMounts(ctx context.Context) (*http.Response, error) {
+func (a *System) GetSysInternalUiMounts(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -3118,7 +3120,7 @@ func (a *SystemService) GetSysInternalUiMounts(ctx context.Context) (*http.Respo
 
 // GetSysInternalUiMountsPath Return information about the given mount.
 // path: The path of the mount.
-func (a *SystemService) GetSysInternalUiMountsPath(ctx context.Context, path string) (*http.Response, error) {
+func (a *System) GetSysInternalUiMountsPath(ctx context.Context, path string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -3184,7 +3186,7 @@ func (a *SystemService) GetSysInternalUiMountsPath(ctx context.Context, path str
 }
 
 // GetSysInternalUiNamespaces Backwards compatibility is not guaranteed for this API
-func (a *SystemService) GetSysInternalUiNamespaces(ctx context.Context) (*http.Response, error) {
+func (a *System) GetSysInternalUiNamespaces(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -3249,7 +3251,7 @@ func (a *SystemService) GetSysInternalUiNamespaces(ctx context.Context) (*http.R
 }
 
 // GetSysInternalUiResultantAcl Backwards compatibility is not guaranteed for this API
-func (a *SystemService) GetSysInternalUiResultantAcl(ctx context.Context) (*http.Response, error) {
+func (a *System) GetSysInternalUiResultantAcl(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -3314,7 +3316,7 @@ func (a *SystemService) GetSysInternalUiResultantAcl(ctx context.Context) (*http
 }
 
 // GetSysKeyStatus Provides information about the backend encryption key.
-func (a *SystemService) GetSysKeyStatus(ctx context.Context) (*http.Response, error) {
+func (a *System) GetSysKeyStatus(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -3379,7 +3381,7 @@ func (a *SystemService) GetSysKeyStatus(ctx context.Context) (*http.Response, er
 }
 
 // GetSysLeader Returns the high availability status and current leader instance of Vault.
-func (a *SystemService) GetSysLeader(ctx context.Context) (*http.Response, error) {
+func (a *System) GetSysLeader(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -3444,7 +3446,7 @@ func (a *SystemService) GetSysLeader(ctx context.Context) (*http.Response, error
 }
 
 // GetSysLeases List leases associated with this Vault cluster
-func (a *SystemService) GetSysLeases(ctx context.Context) (*http.Response, error) {
+func (a *System) GetSysLeases(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -3509,7 +3511,7 @@ func (a *SystemService) GetSysLeases(ctx context.Context) (*http.Response, error
 }
 
 // GetSysLeasesCount Count of leases associated with this Vault cluster
-func (a *SystemService) GetSysLeasesCount(ctx context.Context) (*http.Response, error) {
+func (a *System) GetSysLeasesCount(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -3575,7 +3577,7 @@ func (a *SystemService) GetSysLeasesCount(ctx context.Context) (*http.Response, 
 
 // GetSysLeasesLookup Returns a list of lease ids.
 // list: Must be set to &#x60;true&#x60;
-func (a *SystemService) GetSysLeasesLookup(ctx context.Context, list string) (*http.Response, error) {
+func (a *System) GetSysLeasesLookup(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -3643,7 +3645,7 @@ func (a *SystemService) GetSysLeasesLookup(ctx context.Context, list string) (*h
 // GetSysLeasesLookupPrefix Returns a list of lease ids.
 // prefix: The path to list leases under. Example: \&quot;aws/creds/deploy\&quot;
 // list: Must be set to &#x60;true&#x60;
-func (a *SystemService) GetSysLeasesLookupPrefix(ctx context.Context, prefix string, list string) (*http.Response, error) {
+func (a *System) GetSysLeasesLookupPrefix(ctx context.Context, prefix string, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -3711,7 +3713,7 @@ func (a *SystemService) GetSysLeasesLookupPrefix(ctx context.Context, prefix str
 
 // GetSysMetrics Export the metrics aggregated for telemetry purpose.
 // format: Format to export metrics into. Currently accepts only \&quot;prometheus\&quot;.
-func (a *SystemService) GetSysMetrics(ctx context.Context, format string) (*http.Response, error) {
+func (a *System) GetSysMetrics(ctx context.Context, format string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -3779,7 +3781,7 @@ func (a *SystemService) GetSysMetrics(ctx context.Context, format string) (*http
 // GetSysMonitor
 // logFormat: Output format of logs. Supported values are \&quot;standard\&quot; and \&quot;json\&quot;. The default is \&quot;standard\&quot;.
 // logLevel: Log level to view system logs at. Currently supported values are \&quot;trace\&quot;, \&quot;debug\&quot;, \&quot;info\&quot;, \&quot;warn\&quot;, \&quot;error\&quot;.
-func (a *SystemService) GetSysMonitor(ctx context.Context, logFormat string, logLevel string) (*http.Response, error) {
+func (a *System) GetSysMonitor(ctx context.Context, logFormat string, logLevel string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -3846,7 +3848,7 @@ func (a *SystemService) GetSysMonitor(ctx context.Context, logFormat string, log
 }
 
 // GetSysMounts List the currently mounted backends.
-func (a *SystemService) GetSysMounts(ctx context.Context) (*http.Response, error) {
+func (a *System) GetSysMounts(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -3912,7 +3914,7 @@ func (a *SystemService) GetSysMounts(ctx context.Context) (*http.Response, error
 
 // GetSysMountsPath Read the configuration of the secret engine at the given path.
 // path: The path to mount to. Example: \&quot;aws/east\&quot;
-func (a *SystemService) GetSysMountsPath(ctx context.Context, path string) (*http.Response, error) {
+func (a *System) GetSysMountsPath(ctx context.Context, path string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -3979,7 +3981,7 @@ func (a *SystemService) GetSysMountsPath(ctx context.Context, path string) (*htt
 
 // GetSysMountsPathTune Tune backend configuration parameters for this mount.
 // path: The path to mount to. Example: \&quot;aws/east\&quot;
-func (a *SystemService) GetSysMountsPathTune(ctx context.Context, path string) (*http.Response, error) {
+func (a *System) GetSysMountsPathTune(ctx context.Context, path string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -4045,7 +4047,7 @@ func (a *SystemService) GetSysMountsPathTune(ctx context.Context, path string) (
 }
 
 // GetSysPluginsCatalog Lists all the plugins known to Vault
-func (a *SystemService) GetSysPluginsCatalog(ctx context.Context) (*http.Response, error) {
+func (a *System) GetSysPluginsCatalog(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -4111,7 +4113,7 @@ func (a *SystemService) GetSysPluginsCatalog(ctx context.Context) (*http.Respons
 
 // GetSysPluginsCatalogName Return the configuration data for the plugin with the given name.
 // name: The name of the plugin
-func (a *SystemService) GetSysPluginsCatalogName(ctx context.Context, name string) (*http.Response, error) {
+func (a *System) GetSysPluginsCatalogName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -4179,7 +4181,7 @@ func (a *SystemService) GetSysPluginsCatalogName(ctx context.Context, name strin
 // GetSysPluginsCatalogType List the plugins in the catalog.
 // type_: The type of the plugin, may be auth, secret, or database
 // list: Must be set to &#x60;true&#x60;
-func (a *SystemService) GetSysPluginsCatalogType(ctx context.Context, type_ string, list string) (*http.Response, error) {
+func (a *System) GetSysPluginsCatalogType(ctx context.Context, type_ string, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -4248,7 +4250,7 @@ func (a *SystemService) GetSysPluginsCatalogType(ctx context.Context, type_ stri
 // GetSysPluginsCatalogTypeName Return the configuration data for the plugin with the given name.
 // name: The name of the plugin
 // type_: The type of the plugin, may be auth, secret, or database
-func (a *SystemService) GetSysPluginsCatalogTypeName(ctx context.Context, name string, type_ string) (*http.Response, error) {
+func (a *System) GetSysPluginsCatalogTypeName(ctx context.Context, name string, type_ string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -4316,7 +4318,7 @@ func (a *SystemService) GetSysPluginsCatalogTypeName(ctx context.Context, name s
 
 // GetSysPoliciesAcl List the configured access control policies.
 // list: Must be set to &#x60;true&#x60;
-func (a *SystemService) GetSysPoliciesAcl(ctx context.Context, list string) (*http.Response, error) {
+func (a *System) GetSysPoliciesAcl(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -4383,7 +4385,7 @@ func (a *SystemService) GetSysPoliciesAcl(ctx context.Context, list string) (*ht
 
 // GetSysPoliciesAclName Retrieve information about the named ACL policy.
 // name: The name of the policy. Example: \&quot;ops\&quot;
-func (a *SystemService) GetSysPoliciesAclName(ctx context.Context, name string) (*http.Response, error) {
+func (a *System) GetSysPoliciesAclName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -4450,7 +4452,7 @@ func (a *SystemService) GetSysPoliciesAclName(ctx context.Context, name string) 
 
 // GetSysPoliciesPassword List the existing password policies.
 // list: Must be set to &#x60;true&#x60;
-func (a *SystemService) GetSysPoliciesPassword(ctx context.Context, list string) (*http.Response, error) {
+func (a *System) GetSysPoliciesPassword(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -4517,7 +4519,7 @@ func (a *SystemService) GetSysPoliciesPassword(ctx context.Context, list string)
 
 // GetSysPoliciesPasswordName Retrieve an existing password policy.
 // name: The name of the password policy.
-func (a *SystemService) GetSysPoliciesPasswordName(ctx context.Context, name string) (*http.Response, error) {
+func (a *System) GetSysPoliciesPasswordName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -4584,7 +4586,7 @@ func (a *SystemService) GetSysPoliciesPasswordName(ctx context.Context, name str
 
 // GetSysPoliciesPasswordNameGenerate Generate a password from an existing password policy.
 // name: The name of the password policy.
-func (a *SystemService) GetSysPoliciesPasswordNameGenerate(ctx context.Context, name string) (*http.Response, error) {
+func (a *System) GetSysPoliciesPasswordNameGenerate(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -4651,7 +4653,7 @@ func (a *SystemService) GetSysPoliciesPasswordNameGenerate(ctx context.Context, 
 
 // GetSysPolicy List the configured access control policies.
 // list: Return a list if &#x60;true&#x60;
-func (a *SystemService) GetSysPolicy(ctx context.Context, list string) (*http.Response, error) {
+func (a *System) GetSysPolicy(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -4718,7 +4720,7 @@ func (a *SystemService) GetSysPolicy(ctx context.Context, list string) (*http.Re
 
 // GetSysPolicyName Retrieve the policy body for the named policy.
 // name: The name of the policy. Example: \&quot;ops\&quot;
-func (a *SystemService) GetSysPolicyName(ctx context.Context, name string) (*http.Response, error) {
+func (a *System) GetSysPolicyName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -4785,7 +4787,7 @@ func (a *SystemService) GetSysPolicyName(ctx context.Context, name string) (*htt
 
 // GetSysPprof Returns an HTML page listing the available profiles.
 // Returns an HTML page listing the available  profiles. This should be mainly accessed via browsers or applications that can  render pages.
-func (a *SystemService) GetSysPprof(ctx context.Context) (*http.Response, error) {
+func (a *System) GetSysPprof(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -4851,7 +4853,7 @@ func (a *SystemService) GetSysPprof(ctx context.Context) (*http.Response, error)
 
 // GetSysPprofAllocs Returns a sampling of all past memory allocations.
 // Returns a sampling of all past memory allocations.
-func (a *SystemService) GetSysPprofAllocs(ctx context.Context) (*http.Response, error) {
+func (a *System) GetSysPprofAllocs(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -4917,7 +4919,7 @@ func (a *SystemService) GetSysPprofAllocs(ctx context.Context) (*http.Response, 
 
 // GetSysPprofBlock Returns stack traces that led to blocking on synchronization primitives
 // Returns stack traces that led to blocking on synchronization primitives
-func (a *SystemService) GetSysPprofBlock(ctx context.Context) (*http.Response, error) {
+func (a *System) GetSysPprofBlock(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -4983,7 +4985,7 @@ func (a *SystemService) GetSysPprofBlock(ctx context.Context) (*http.Response, e
 
 // GetSysPprofCmdline Returns the running program's command line.
 // Returns the running program's command line, with arguments separated by NUL bytes.
-func (a *SystemService) GetSysPprofCmdline(ctx context.Context) (*http.Response, error) {
+func (a *System) GetSysPprofCmdline(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -5049,7 +5051,7 @@ func (a *SystemService) GetSysPprofCmdline(ctx context.Context) (*http.Response,
 
 // GetSysPprofGoroutine Returns stack traces of all current goroutines.
 // Returns stack traces of all current goroutines.
-func (a *SystemService) GetSysPprofGoroutine(ctx context.Context) (*http.Response, error) {
+func (a *System) GetSysPprofGoroutine(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -5115,7 +5117,7 @@ func (a *SystemService) GetSysPprofGoroutine(ctx context.Context) (*http.Respons
 
 // GetSysPprofHeap Returns a sampling of memory allocations of live object.
 // Returns a sampling of memory allocations of live object.
-func (a *SystemService) GetSysPprofHeap(ctx context.Context) (*http.Response, error) {
+func (a *System) GetSysPprofHeap(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -5181,7 +5183,7 @@ func (a *SystemService) GetSysPprofHeap(ctx context.Context) (*http.Response, er
 
 // GetSysPprofMutex Returns stack traces of holders of contended mutexes
 // Returns stack traces of holders of contended mutexes
-func (a *SystemService) GetSysPprofMutex(ctx context.Context) (*http.Response, error) {
+func (a *System) GetSysPprofMutex(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -5247,7 +5249,7 @@ func (a *SystemService) GetSysPprofMutex(ctx context.Context) (*http.Response, e
 
 // GetSysPprofProfile Returns a pprof-formatted cpu profile payload.
 // Returns a pprof-formatted cpu profile payload. Profiling lasts for duration specified in seconds GET parameter, or for 30 seconds if not specified.
-func (a *SystemService) GetSysPprofProfile(ctx context.Context) (*http.Response, error) {
+func (a *System) GetSysPprofProfile(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -5313,7 +5315,7 @@ func (a *SystemService) GetSysPprofProfile(ctx context.Context) (*http.Response,
 
 // GetSysPprofSymbol Returns the program counters listed in the request.
 // Returns the program counters listed in the request.
-func (a *SystemService) GetSysPprofSymbol(ctx context.Context) (*http.Response, error) {
+func (a *System) GetSysPprofSymbol(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -5379,7 +5381,7 @@ func (a *SystemService) GetSysPprofSymbol(ctx context.Context) (*http.Response, 
 
 // GetSysPprofThreadcreate Returns stack traces that led to the creation of new OS threads
 // Returns stack traces that led to the creation of new OS threads
-func (a *SystemService) GetSysPprofThreadcreate(ctx context.Context) (*http.Response, error) {
+func (a *System) GetSysPprofThreadcreate(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -5445,7 +5447,7 @@ func (a *SystemService) GetSysPprofThreadcreate(ctx context.Context) (*http.Resp
 
 // GetSysPprofTrace Returns the execution trace in binary form.
 // Returns  the execution trace in binary form. Tracing lasts for duration specified in seconds GET parameter, or for 1 second if not specified.
-func (a *SystemService) GetSysPprofTrace(ctx context.Context) (*http.Response, error) {
+func (a *System) GetSysPprofTrace(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -5510,7 +5512,7 @@ func (a *SystemService) GetSysPprofTrace(ctx context.Context) (*http.Response, e
 }
 
 // GetSysQuotasConfig
-func (a *SystemService) GetSysQuotasConfig(ctx context.Context) (*http.Response, error) {
+func (a *System) GetSysQuotasConfig(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -5576,7 +5578,7 @@ func (a *SystemService) GetSysQuotasConfig(ctx context.Context) (*http.Response,
 
 // GetSysQuotasRateLimit
 // list: Must be set to &#x60;true&#x60;
-func (a *SystemService) GetSysQuotasRateLimit(ctx context.Context, list string) (*http.Response, error) {
+func (a *System) GetSysQuotasRateLimit(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -5643,7 +5645,7 @@ func (a *SystemService) GetSysQuotasRateLimit(ctx context.Context, list string) 
 
 // GetSysQuotasRateLimitName
 // name: Name of the quota rule.
-func (a *SystemService) GetSysQuotasRateLimitName(ctx context.Context, name string) (*http.Response, error) {
+func (a *System) GetSysQuotasRateLimitName(ctx context.Context, name string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -5710,7 +5712,7 @@ func (a *SystemService) GetSysQuotasRateLimitName(ctx context.Context, name stri
 
 // GetSysRaw Read the value of the key at the given path.
 // list: Return a list if &#x60;true&#x60;
-func (a *SystemService) GetSysRaw(ctx context.Context, list string) (*http.Response, error) {
+func (a *System) GetSysRaw(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -5777,7 +5779,7 @@ func (a *SystemService) GetSysRaw(ctx context.Context, list string) (*http.Respo
 
 // GetSysRawPath Read the value of the key at the given path.
 // list: Return a list if &#x60;true&#x60;
-func (a *SystemService) GetSysRawPath(ctx context.Context, path string, list string) (*http.Response, error) {
+func (a *System) GetSysRawPath(ctx context.Context, path string, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -5844,7 +5846,7 @@ func (a *SystemService) GetSysRawPath(ctx context.Context, path string, list str
 }
 
 // GetSysRekeyBackup Return the backup copy of PGP-encrypted unseal keys.
-func (a *SystemService) GetSysRekeyBackup(ctx context.Context) (*http.Response, error) {
+func (a *System) GetSysRekeyBackup(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -5909,7 +5911,7 @@ func (a *SystemService) GetSysRekeyBackup(ctx context.Context) (*http.Response, 
 }
 
 // GetSysRekeyInit Reads the configuration and progress of the current rekey attempt.
-func (a *SystemService) GetSysRekeyInit(ctx context.Context) (*http.Response, error) {
+func (a *System) GetSysRekeyInit(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -5974,7 +5976,7 @@ func (a *SystemService) GetSysRekeyInit(ctx context.Context) (*http.Response, er
 }
 
 // GetSysRekeyRecoveryKeyBackup Allows fetching or deleting the backup of the rotated unseal keys.
-func (a *SystemService) GetSysRekeyRecoveryKeyBackup(ctx context.Context) (*http.Response, error) {
+func (a *System) GetSysRekeyRecoveryKeyBackup(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -6039,7 +6041,7 @@ func (a *SystemService) GetSysRekeyRecoveryKeyBackup(ctx context.Context) (*http
 }
 
 // GetSysRekeyVerify Read the configuration and progress of the current rekey verification attempt.
-func (a *SystemService) GetSysRekeyVerify(ctx context.Context) (*http.Response, error) {
+func (a *System) GetSysRekeyVerify(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -6105,7 +6107,7 @@ func (a *SystemService) GetSysRekeyVerify(ctx context.Context) (*http.Response, 
 
 // GetSysRemountStatusMigrationId Check status of a mount migration
 // migrationId: The ID of the migration operation
-func (a *SystemService) GetSysRemountStatusMigrationId(ctx context.Context, migrationId string) (*http.Response, error) {
+func (a *System) GetSysRemountStatusMigrationId(ctx context.Context, migrationId string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -6171,7 +6173,7 @@ func (a *SystemService) GetSysRemountStatusMigrationId(ctx context.Context, migr
 }
 
 // GetSysReplicationStatus
-func (a *SystemService) GetSysReplicationStatus(ctx context.Context) (*http.Response, error) {
+func (a *System) GetSysReplicationStatus(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -6236,7 +6238,7 @@ func (a *SystemService) GetSysReplicationStatus(ctx context.Context) (*http.Resp
 }
 
 // GetSysRotateConfig
-func (a *SystemService) GetSysRotateConfig(ctx context.Context) (*http.Response, error) {
+func (a *System) GetSysRotateConfig(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -6301,7 +6303,7 @@ func (a *SystemService) GetSysRotateConfig(ctx context.Context) (*http.Response,
 }
 
 // GetSysSealStatus Check the seal status of a Vault.
-func (a *SystemService) GetSysSealStatus(ctx context.Context) (*http.Response, error) {
+func (a *System) GetSysSealStatus(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -6367,7 +6369,7 @@ func (a *SystemService) GetSysSealStatus(ctx context.Context) (*http.Response, e
 
 // GetSysVersionHistory Returns map of historical version change entries
 // list: Must be set to &#x60;true&#x60;
-func (a *SystemService) GetSysVersionHistory(ctx context.Context, list string) (*http.Response, error) {
+func (a *System) GetSysVersionHistory(ctx context.Context, list string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -6433,7 +6435,7 @@ func (a *SystemService) GetSysVersionHistory(ctx context.Context, list string) (
 }
 
 // GetSysWrappingLookup Look up wrapping properties for the requester's token.
-func (a *SystemService) GetSysWrappingLookup(ctx context.Context) (*http.Response, error) {
+func (a *System) GetSysWrappingLookup(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodGet
 		localVarPostBody   interface{}
@@ -6499,7 +6501,7 @@ func (a *SystemService) GetSysWrappingLookup(ctx context.Context) (*http.Respons
 
 // PostSysAuditHashPath The hash of the given string via the given audit backend
 // path: The name of the backend. Cannot be delimited. Example: \&quot;mysql\&quot;
-func (a *SystemService) PostSysAuditHashPath(ctx context.Context, path string, systemAuditHashRequest SystemAuditHashRequest) (*http.Response, error) {
+func (a *System) PostSysAuditHashPath(ctx context.Context, path string, systemAuditHashRequest SystemAuditHashRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -6568,7 +6570,7 @@ func (a *SystemService) PostSysAuditHashPath(ctx context.Context, path string, s
 
 // PostSysAuditPath Enable a new audit device at the supplied path.
 // path: The name of the backend. Cannot be delimited. Example: \&quot;mysql\&quot;
-func (a *SystemService) PostSysAuditPath(ctx context.Context, path string, systemAuditRequest SystemAuditRequest) (*http.Response, error) {
+func (a *System) PostSysAuditPath(ctx context.Context, path string, systemAuditRequest SystemAuditRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -6638,7 +6640,7 @@ func (a *SystemService) PostSysAuditPath(ctx context.Context, path string, syste
 // PostSysAuthPath Enables a new auth method.
 // After enabling, the auth method can be accessed and configured via the auth path specified as part of the URL. This auth path will be nested under the auth prefix.  For example, enable the \"foo\" auth method will make it accessible at /auth/foo.
 // path: The path to mount to. Cannot be delimited. Example: \&quot;user\&quot;
-func (a *SystemService) PostSysAuthPath(ctx context.Context, path string, systemAuthRequest SystemAuthRequest) (*http.Response, error) {
+func (a *System) PostSysAuthPath(ctx context.Context, path string, systemAuthRequest SystemAuthRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -6708,7 +6710,7 @@ func (a *SystemService) PostSysAuthPath(ctx context.Context, path string, system
 // PostSysAuthPathTune Tune configuration parameters for a given auth path.
 // This endpoint requires sudo capability on the final path, but the same functionality can be achieved without sudo via `sys/mounts/auth/[auth-path]/tune`.
 // path: Tune the configuration parameters for an auth path.
-func (a *SystemService) PostSysAuthPathTune(ctx context.Context, path string, systemAuthTuneRequest SystemAuthTuneRequest) (*http.Response, error) {
+func (a *System) PostSysAuthPathTune(ctx context.Context, path string, systemAuthTuneRequest SystemAuthTuneRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -6776,7 +6778,7 @@ func (a *SystemService) PostSysAuthPathTune(ctx context.Context, path string, sy
 }
 
 // PostSysCapabilities Fetches the capabilities of the given token on the given path.
-func (a *SystemService) PostSysCapabilities(ctx context.Context, systemCapabilitiesRequest SystemCapabilitiesRequest) (*http.Response, error) {
+func (a *System) PostSysCapabilities(ctx context.Context, systemCapabilitiesRequest SystemCapabilitiesRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -6843,7 +6845,7 @@ func (a *SystemService) PostSysCapabilities(ctx context.Context, systemCapabilit
 }
 
 // PostSysCapabilitiesAccessor Fetches the capabilities of the token associated with the given token, on the given path.
-func (a *SystemService) PostSysCapabilitiesAccessor(ctx context.Context, systemCapabilitiesAccessorRequest SystemCapabilitiesAccessorRequest) (*http.Response, error) {
+func (a *System) PostSysCapabilitiesAccessor(ctx context.Context, systemCapabilitiesAccessorRequest SystemCapabilitiesAccessorRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -6910,7 +6912,7 @@ func (a *SystemService) PostSysCapabilitiesAccessor(ctx context.Context, systemC
 }
 
 // PostSysCapabilitiesSelf Fetches the capabilities of the given token on the given path.
-func (a *SystemService) PostSysCapabilitiesSelf(ctx context.Context, systemCapabilitiesSelfRequest SystemCapabilitiesSelfRequest) (*http.Response, error) {
+func (a *System) PostSysCapabilitiesSelf(ctx context.Context, systemCapabilitiesSelfRequest SystemCapabilitiesSelfRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -6977,7 +6979,7 @@ func (a *SystemService) PostSysCapabilitiesSelf(ctx context.Context, systemCapab
 }
 
 // PostSysConfigAuditingRequestHeadersHeader Enable auditing of a header.
-func (a *SystemService) PostSysConfigAuditingRequestHeadersHeader(ctx context.Context, header string, systemConfigAuditingRequestHeadersRequest SystemConfigAuditingRequestHeadersRequest) (*http.Response, error) {
+func (a *System) PostSysConfigAuditingRequestHeadersHeader(ctx context.Context, header string, systemConfigAuditingRequestHeadersRequest SystemConfigAuditingRequestHeadersRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -7045,7 +7047,7 @@ func (a *SystemService) PostSysConfigAuditingRequestHeadersHeader(ctx context.Co
 }
 
 // PostSysConfigCors Configure the CORS settings.
-func (a *SystemService) PostSysConfigCors(ctx context.Context, systemConfigCorsRequest SystemConfigCorsRequest) (*http.Response, error) {
+func (a *System) PostSysConfigCors(ctx context.Context, systemConfigCorsRequest SystemConfigCorsRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -7112,7 +7114,7 @@ func (a *SystemService) PostSysConfigCors(ctx context.Context, systemConfigCorsR
 }
 
 // PostSysConfigReloadSubsystem Reload the given subsystem
-func (a *SystemService) PostSysConfigReloadSubsystem(ctx context.Context, subsystem string) (*http.Response, error) {
+func (a *System) PostSysConfigReloadSubsystem(ctx context.Context, subsystem string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -7179,7 +7181,7 @@ func (a *SystemService) PostSysConfigReloadSubsystem(ctx context.Context, subsys
 
 // PostSysConfigUiHeadersHeader Configure the values to be returned for the UI header.
 // header: The name of the header.
-func (a *SystemService) PostSysConfigUiHeadersHeader(ctx context.Context, header string, systemConfigUiHeadersRequest SystemConfigUiHeadersRequest) (*http.Response, error) {
+func (a *System) PostSysConfigUiHeadersHeader(ctx context.Context, header string, systemConfigUiHeadersRequest SystemConfigUiHeadersRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -7248,7 +7250,7 @@ func (a *SystemService) PostSysConfigUiHeadersHeader(ctx context.Context, header
 
 // PostSysGenerateRoot Initializes a new root generation attempt.
 // Only a single root generation attempt can take place at a time. One (and only one) of otp or pgp_key are required.
-func (a *SystemService) PostSysGenerateRoot(ctx context.Context, systemGenerateRootRequest SystemGenerateRootRequest) (*http.Response, error) {
+func (a *System) PostSysGenerateRoot(ctx context.Context, systemGenerateRootRequest SystemGenerateRootRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -7316,7 +7318,7 @@ func (a *SystemService) PostSysGenerateRoot(ctx context.Context, systemGenerateR
 
 // PostSysGenerateRootAttempt Initializes a new root generation attempt.
 // Only a single root generation attempt can take place at a time. One (and only one) of otp or pgp_key are required.
-func (a *SystemService) PostSysGenerateRootAttempt(ctx context.Context, systemGenerateRootAttemptRequest SystemGenerateRootAttemptRequest) (*http.Response, error) {
+func (a *System) PostSysGenerateRootAttempt(ctx context.Context, systemGenerateRootAttemptRequest SystemGenerateRootAttemptRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -7384,7 +7386,7 @@ func (a *SystemService) PostSysGenerateRootAttempt(ctx context.Context, systemGe
 
 // PostSysGenerateRootUpdate Enter a single unseal key share to progress the root generation attempt.
 // If the threshold number of unseal key shares is reached, Vault will complete the root generation and issue the new token. Otherwise, this API must be called multiple times until that threshold is met. The attempt nonce must be provided with each call.
-func (a *SystemService) PostSysGenerateRootUpdate(ctx context.Context, systemGenerateRootUpdateRequest SystemGenerateRootUpdateRequest) (*http.Response, error) {
+func (a *System) PostSysGenerateRootUpdate(ctx context.Context, systemGenerateRootUpdateRequest SystemGenerateRootUpdateRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -7452,7 +7454,7 @@ func (a *SystemService) PostSysGenerateRootUpdate(ctx context.Context, systemGen
 
 // PostSysInit Initialize a new Vault.
 // The Vault must not have been previously initialized. The recovery options, as well as the stored shares option, are only available when using Vault HSM.
-func (a *SystemService) PostSysInit(ctx context.Context, systemInitRequest SystemInitRequest) (*http.Response, error) {
+func (a *System) PostSysInit(ctx context.Context, systemInitRequest SystemInitRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -7519,7 +7521,7 @@ func (a *SystemService) PostSysInit(ctx context.Context, systemInitRequest Syste
 }
 
 // PostSysInternalCountersConfig Enable or disable collection of client count, set retention period, or set default reporting period.
-func (a *SystemService) PostSysInternalCountersConfig(ctx context.Context, systemInternalCountersConfigRequest SystemInternalCountersConfigRequest) (*http.Response, error) {
+func (a *System) PostSysInternalCountersConfig(ctx context.Context, systemInternalCountersConfigRequest SystemInternalCountersConfigRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -7586,7 +7588,7 @@ func (a *SystemService) PostSysInternalCountersConfig(ctx context.Context, syste
 }
 
 // PostSysLeasesLookup Retrieve lease metadata.
-func (a *SystemService) PostSysLeasesLookup(ctx context.Context, systemLeasesLookupRequest SystemLeasesLookupRequest) (*http.Response, error) {
+func (a *System) PostSysLeasesLookup(ctx context.Context, systemLeasesLookupRequest SystemLeasesLookupRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -7653,7 +7655,7 @@ func (a *SystemService) PostSysLeasesLookup(ctx context.Context, systemLeasesLoo
 }
 
 // PostSysLeasesRenew Renews a lease, requesting to extend the lease.
-func (a *SystemService) PostSysLeasesRenew(ctx context.Context, systemLeasesRenewRequest SystemLeasesRenewRequest) (*http.Response, error) {
+func (a *System) PostSysLeasesRenew(ctx context.Context, systemLeasesRenewRequest SystemLeasesRenewRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -7721,7 +7723,7 @@ func (a *SystemService) PostSysLeasesRenew(ctx context.Context, systemLeasesRene
 
 // PostSysLeasesRenewUrlLeaseId Renews a lease, requesting to extend the lease.
 // urlLeaseId: The lease identifier to renew. This is included with a lease.
-func (a *SystemService) PostSysLeasesRenewUrlLeaseId(ctx context.Context, urlLeaseId string, systemLeasesRenewLeaseRequest SystemLeasesRenewLeaseRequest) (*http.Response, error) {
+func (a *System) PostSysLeasesRenewUrlLeaseId(ctx context.Context, urlLeaseId string, systemLeasesRenewLeaseRequest SystemLeasesRenewLeaseRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -7789,7 +7791,7 @@ func (a *SystemService) PostSysLeasesRenewUrlLeaseId(ctx context.Context, urlLea
 }
 
 // PostSysLeasesRevoke Revokes a lease immediately.
-func (a *SystemService) PostSysLeasesRevoke(ctx context.Context, systemLeasesRevokeRequest SystemLeasesRevokeRequest) (*http.Response, error) {
+func (a *System) PostSysLeasesRevoke(ctx context.Context, systemLeasesRevokeRequest SystemLeasesRevokeRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -7858,7 +7860,7 @@ func (a *SystemService) PostSysLeasesRevoke(ctx context.Context, systemLeasesRev
 // PostSysLeasesRevokeForcePrefix Revokes all secrets or tokens generated under a given prefix immediately
 // Unlike `/sys/leases/revoke-prefix`, this path ignores backend errors encountered during revocation. This is potentially very dangerous and should only be used in specific emergency situations where errors in the backend or the connected backend service prevent normal revocation.  By ignoring these errors, Vault abdicates responsibility for ensuring that the issued credentials or secrets are properly revoked and/or cleaned up. Access to this endpoint should be tightly controlled.
 // prefix: The path to revoke keys under. Example: \&quot;prod/aws/ops\&quot;
-func (a *SystemService) PostSysLeasesRevokeForcePrefix(ctx context.Context, prefix string) (*http.Response, error) {
+func (a *System) PostSysLeasesRevokeForcePrefix(ctx context.Context, prefix string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -7925,7 +7927,7 @@ func (a *SystemService) PostSysLeasesRevokeForcePrefix(ctx context.Context, pref
 
 // PostSysLeasesRevokePrefixPrefix Revokes all secrets (via a lease ID prefix) or tokens (via the tokens' path property) generated under a given prefix immediately.
 // prefix: The path to revoke keys under. Example: \&quot;prod/aws/ops\&quot;
-func (a *SystemService) PostSysLeasesRevokePrefixPrefix(ctx context.Context, prefix string, systemLeasesRevokePrefixRequest SystemLeasesRevokePrefixRequest) (*http.Response, error) {
+func (a *System) PostSysLeasesRevokePrefixPrefix(ctx context.Context, prefix string, systemLeasesRevokePrefixRequest SystemLeasesRevokePrefixRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -7994,7 +7996,7 @@ func (a *SystemService) PostSysLeasesRevokePrefixPrefix(ctx context.Context, pre
 
 // PostSysLeasesRevokeUrlLeaseId Revokes a lease immediately.
 // urlLeaseId: The lease identifier to renew. This is included with a lease.
-func (a *SystemService) PostSysLeasesRevokeUrlLeaseId(ctx context.Context, urlLeaseId string, systemLeasesRevokeLeaseRequest SystemLeasesRevokeLeaseRequest) (*http.Response, error) {
+func (a *System) PostSysLeasesRevokeUrlLeaseId(ctx context.Context, urlLeaseId string, systemLeasesRevokeLeaseRequest SystemLeasesRevokeLeaseRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -8062,7 +8064,7 @@ func (a *SystemService) PostSysLeasesRevokeUrlLeaseId(ctx context.Context, urlLe
 }
 
 // PostSysLeasesTidy This endpoint performs cleanup tasks that can be run if certain error conditions have occurred.
-func (a *SystemService) PostSysLeasesTidy(ctx context.Context) (*http.Response, error) {
+func (a *System) PostSysLeasesTidy(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -8127,7 +8129,7 @@ func (a *SystemService) PostSysLeasesTidy(ctx context.Context) (*http.Response, 
 }
 
 // PostSysMfaValidate Validates the login for the given MFA methods. Upon successful validation, it returns an auth response containing the client token
-func (a *SystemService) PostSysMfaValidate(ctx context.Context, systemMfaValidateRequest SystemMfaValidateRequest) (*http.Response, error) {
+func (a *System) PostSysMfaValidate(ctx context.Context, systemMfaValidateRequest SystemMfaValidateRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -8195,7 +8197,7 @@ func (a *SystemService) PostSysMfaValidate(ctx context.Context, systemMfaValidat
 
 // PostSysMountsPath Enable a new secrets engine at the given path.
 // path: The path to mount to. Example: \&quot;aws/east\&quot;
-func (a *SystemService) PostSysMountsPath(ctx context.Context, path string, systemMountsRequest SystemMountsRequest) (*http.Response, error) {
+func (a *System) PostSysMountsPath(ctx context.Context, path string, systemMountsRequest SystemMountsRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -8264,7 +8266,7 @@ func (a *SystemService) PostSysMountsPath(ctx context.Context, path string, syst
 
 // PostSysMountsPathTune Tune backend configuration parameters for this mount.
 // path: The path to mount to. Example: \&quot;aws/east\&quot;
-func (a *SystemService) PostSysMountsPathTune(ctx context.Context, path string, systemMountsTuneRequest SystemMountsTuneRequest) (*http.Response, error) {
+func (a *System) PostSysMountsPathTune(ctx context.Context, path string, systemMountsTuneRequest SystemMountsTuneRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -8333,7 +8335,7 @@ func (a *SystemService) PostSysMountsPathTune(ctx context.Context, path string, 
 
 // PostSysPluginsCatalogName Register a new plugin, or updates an existing one with the supplied name.
 // name: The name of the plugin
-func (a *SystemService) PostSysPluginsCatalogName(ctx context.Context, name string, systemPluginsCatalogRequest SystemPluginsCatalogRequest) (*http.Response, error) {
+func (a *System) PostSysPluginsCatalogName(ctx context.Context, name string, systemPluginsCatalogRequest SystemPluginsCatalogRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -8403,7 +8405,7 @@ func (a *SystemService) PostSysPluginsCatalogName(ctx context.Context, name stri
 // PostSysPluginsCatalogTypeName Register a new plugin, or updates an existing one with the supplied name.
 // name: The name of the plugin
 // type_: The type of the plugin, may be auth, secret, or database
-func (a *SystemService) PostSysPluginsCatalogTypeName(ctx context.Context, name string, type_ string, systemPluginsCatalogRequest SystemPluginsCatalogRequest) (*http.Response, error) {
+func (a *System) PostSysPluginsCatalogTypeName(ctx context.Context, name string, type_ string, systemPluginsCatalogRequest SystemPluginsCatalogRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -8473,7 +8475,7 @@ func (a *SystemService) PostSysPluginsCatalogTypeName(ctx context.Context, name 
 
 // PostSysPluginsReloadBackend Reload mounted plugin backends.
 // Either the plugin name (`plugin`) or the desired plugin backend mounts (`mounts`) must be provided, but not both. In the case that the plugin name is provided, all mounted paths that use that plugin backend will be reloaded.  If (`scope`) is provided and is (`global`), the plugin(s) are reloaded globally.
-func (a *SystemService) PostSysPluginsReloadBackend(ctx context.Context, systemPluginsReloadBackendRequest SystemPluginsReloadBackendRequest) (*http.Response, error) {
+func (a *System) PostSysPluginsReloadBackend(ctx context.Context, systemPluginsReloadBackendRequest SystemPluginsReloadBackendRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -8541,7 +8543,7 @@ func (a *SystemService) PostSysPluginsReloadBackend(ctx context.Context, systemP
 
 // PostSysPoliciesAclName Add a new or update an existing ACL policy.
 // name: The name of the policy. Example: \&quot;ops\&quot;
-func (a *SystemService) PostSysPoliciesAclName(ctx context.Context, name string, systemPoliciesAclRequest SystemPoliciesAclRequest) (*http.Response, error) {
+func (a *System) PostSysPoliciesAclName(ctx context.Context, name string, systemPoliciesAclRequest SystemPoliciesAclRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -8610,7 +8612,7 @@ func (a *SystemService) PostSysPoliciesAclName(ctx context.Context, name string,
 
 // PostSysPoliciesPasswordName Add a new or update an existing password policy.
 // name: The name of the password policy.
-func (a *SystemService) PostSysPoliciesPasswordName(ctx context.Context, name string, systemPoliciesPasswordRequest SystemPoliciesPasswordRequest) (*http.Response, error) {
+func (a *System) PostSysPoliciesPasswordName(ctx context.Context, name string, systemPoliciesPasswordRequest SystemPoliciesPasswordRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -8679,7 +8681,7 @@ func (a *SystemService) PostSysPoliciesPasswordName(ctx context.Context, name st
 
 // PostSysPolicyName Add a new or update an existing policy.
 // name: The name of the policy. Example: \&quot;ops\&quot;
-func (a *SystemService) PostSysPolicyName(ctx context.Context, name string, systemPolicyRequest SystemPolicyRequest) (*http.Response, error) {
+func (a *System) PostSysPolicyName(ctx context.Context, name string, systemPolicyRequest SystemPolicyRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -8747,7 +8749,7 @@ func (a *SystemService) PostSysPolicyName(ctx context.Context, name string, syst
 }
 
 // PostSysQuotasConfig
-func (a *SystemService) PostSysQuotasConfig(ctx context.Context, systemQuotasConfigRequest SystemQuotasConfigRequest) (*http.Response, error) {
+func (a *System) PostSysQuotasConfig(ctx context.Context, systemQuotasConfigRequest SystemQuotasConfigRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -8815,7 +8817,7 @@ func (a *SystemService) PostSysQuotasConfig(ctx context.Context, systemQuotasCon
 
 // PostSysQuotasRateLimitName
 // name: Name of the quota rule.
-func (a *SystemService) PostSysQuotasRateLimitName(ctx context.Context, name string, systemQuotasRateLimitRequest SystemQuotasRateLimitRequest) (*http.Response, error) {
+func (a *System) PostSysQuotasRateLimitName(ctx context.Context, name string, systemQuotasRateLimitRequest SystemQuotasRateLimitRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -8883,7 +8885,7 @@ func (a *SystemService) PostSysQuotasRateLimitName(ctx context.Context, name str
 }
 
 // PostSysRaw Update the value of the key at the given path.
-func (a *SystemService) PostSysRaw(ctx context.Context, systemRawRequest SystemRawRequest) (*http.Response, error) {
+func (a *System) PostSysRaw(ctx context.Context, systemRawRequest SystemRawRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -8950,7 +8952,7 @@ func (a *SystemService) PostSysRaw(ctx context.Context, systemRawRequest SystemR
 }
 
 // PostSysRawPath Update the value of the key at the given path.
-func (a *SystemService) PostSysRawPath(ctx context.Context, path string, systemRawRequest SystemRawRequest) (*http.Response, error) {
+func (a *System) PostSysRawPath(ctx context.Context, path string, systemRawRequest SystemRawRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -9019,7 +9021,7 @@ func (a *SystemService) PostSysRawPath(ctx context.Context, path string, systemR
 
 // PostSysRekeyInit Initializes a new rekey attempt.
 // Only a single rekey attempt can take place at a time, and changing the parameters of a rekey requires canceling and starting a new rekey, which will also provide a new nonce.
-func (a *SystemService) PostSysRekeyInit(ctx context.Context, systemRekeyInitRequest SystemRekeyInitRequest) (*http.Response, error) {
+func (a *System) PostSysRekeyInit(ctx context.Context, systemRekeyInitRequest SystemRekeyInitRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -9086,7 +9088,7 @@ func (a *SystemService) PostSysRekeyInit(ctx context.Context, systemRekeyInitReq
 }
 
 // PostSysRekeyUpdate Enter a single unseal key share to progress the rekey of the Vault.
-func (a *SystemService) PostSysRekeyUpdate(ctx context.Context, systemRekeyUpdateRequest SystemRekeyUpdateRequest) (*http.Response, error) {
+func (a *System) PostSysRekeyUpdate(ctx context.Context, systemRekeyUpdateRequest SystemRekeyUpdateRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -9153,7 +9155,7 @@ func (a *SystemService) PostSysRekeyUpdate(ctx context.Context, systemRekeyUpdat
 }
 
 // PostSysRekeyVerify Enter a single new key share to progress the rekey verification operation.
-func (a *SystemService) PostSysRekeyVerify(ctx context.Context, systemRekeyVerifyRequest SystemRekeyVerifyRequest) (*http.Response, error) {
+func (a *System) PostSysRekeyVerify(ctx context.Context, systemRekeyVerifyRequest SystemRekeyVerifyRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -9220,7 +9222,7 @@ func (a *SystemService) PostSysRekeyVerify(ctx context.Context, systemRekeyVerif
 }
 
 // PostSysRemount Initiate a mount migration
-func (a *SystemService) PostSysRemount(ctx context.Context, systemRemountRequest SystemRemountRequest) (*http.Response, error) {
+func (a *System) PostSysRemount(ctx context.Context, systemRemountRequest SystemRemountRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -9287,7 +9289,7 @@ func (a *SystemService) PostSysRemount(ctx context.Context, systemRemountRequest
 }
 
 // PostSysRenew Renews a lease, requesting to extend the lease.
-func (a *SystemService) PostSysRenew(ctx context.Context, systemRenewRequest SystemRenewRequest) (*http.Response, error) {
+func (a *System) PostSysRenew(ctx context.Context, systemRenewRequest SystemRenewRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -9355,7 +9357,7 @@ func (a *SystemService) PostSysRenew(ctx context.Context, systemRenewRequest Sys
 
 // PostSysRenewUrlLeaseId Renews a lease, requesting to extend the lease.
 // urlLeaseId: The lease identifier to renew. This is included with a lease.
-func (a *SystemService) PostSysRenewUrlLeaseId(ctx context.Context, urlLeaseId string, systemRenewLeaseRequest SystemRenewLeaseRequest) (*http.Response, error) {
+func (a *System) PostSysRenewUrlLeaseId(ctx context.Context, urlLeaseId string, systemRenewLeaseRequest SystemRenewLeaseRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -9423,7 +9425,7 @@ func (a *SystemService) PostSysRenewUrlLeaseId(ctx context.Context, urlLeaseId s
 }
 
 // PostSysRevoke Revokes a lease immediately.
-func (a *SystemService) PostSysRevoke(ctx context.Context, systemRevokeRequest SystemRevokeRequest) (*http.Response, error) {
+func (a *System) PostSysRevoke(ctx context.Context, systemRevokeRequest SystemRevokeRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -9492,7 +9494,7 @@ func (a *SystemService) PostSysRevoke(ctx context.Context, systemRevokeRequest S
 // PostSysRevokeForcePrefix Revokes all secrets or tokens generated under a given prefix immediately
 // Unlike `/sys/leases/revoke-prefix`, this path ignores backend errors encountered during revocation. This is potentially very dangerous and should only be used in specific emergency situations where errors in the backend or the connected backend service prevent normal revocation.  By ignoring these errors, Vault abdicates responsibility for ensuring that the issued credentials or secrets are properly revoked and/or cleaned up. Access to this endpoint should be tightly controlled.
 // prefix: The path to revoke keys under. Example: \&quot;prod/aws/ops\&quot;
-func (a *SystemService) PostSysRevokeForcePrefix(ctx context.Context, prefix string) (*http.Response, error) {
+func (a *System) PostSysRevokeForcePrefix(ctx context.Context, prefix string) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -9559,7 +9561,7 @@ func (a *SystemService) PostSysRevokeForcePrefix(ctx context.Context, prefix str
 
 // PostSysRevokePrefixPrefix Revokes all secrets (via a lease ID prefix) or tokens (via the tokens' path property) generated under a given prefix immediately.
 // prefix: The path to revoke keys under. Example: \&quot;prod/aws/ops\&quot;
-func (a *SystemService) PostSysRevokePrefixPrefix(ctx context.Context, prefix string, systemRevokePrefixRequest SystemRevokePrefixRequest) (*http.Response, error) {
+func (a *System) PostSysRevokePrefixPrefix(ctx context.Context, prefix string, systemRevokePrefixRequest SystemRevokePrefixRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -9628,7 +9630,7 @@ func (a *SystemService) PostSysRevokePrefixPrefix(ctx context.Context, prefix st
 
 // PostSysRevokeUrlLeaseId Revokes a lease immediately.
 // urlLeaseId: The lease identifier to renew. This is included with a lease.
-func (a *SystemService) PostSysRevokeUrlLeaseId(ctx context.Context, urlLeaseId string, systemRevokeLeaseRequest SystemRevokeLeaseRequest) (*http.Response, error) {
+func (a *System) PostSysRevokeUrlLeaseId(ctx context.Context, urlLeaseId string, systemRevokeLeaseRequest SystemRevokeLeaseRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -9696,7 +9698,7 @@ func (a *SystemService) PostSysRevokeUrlLeaseId(ctx context.Context, urlLeaseId 
 }
 
 // PostSysRotate Rotates the backend encryption key used to persist data.
-func (a *SystemService) PostSysRotate(ctx context.Context) (*http.Response, error) {
+func (a *System) PostSysRotate(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -9761,7 +9763,7 @@ func (a *SystemService) PostSysRotate(ctx context.Context) (*http.Response, erro
 }
 
 // PostSysRotateConfig
-func (a *SystemService) PostSysRotateConfig(ctx context.Context, systemRotateConfigRequest SystemRotateConfigRequest) (*http.Response, error) {
+func (a *System) PostSysRotateConfig(ctx context.Context, systemRotateConfigRequest SystemRotateConfigRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -9828,7 +9830,7 @@ func (a *SystemService) PostSysRotateConfig(ctx context.Context, systemRotateCon
 }
 
 // PostSysSeal Seal the Vault.
-func (a *SystemService) PostSysSeal(ctx context.Context) (*http.Response, error) {
+func (a *System) PostSysSeal(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -9894,7 +9896,7 @@ func (a *SystemService) PostSysSeal(ctx context.Context) (*http.Response, error)
 
 // PostSysStepDown Cause the node to give up active status.
 // This endpoint forces the node to give up active status. If the node does not have active status, this endpoint does nothing. Note that the node will sleep for ten seconds before attempting to grab the active lock again, but if no standby nodes grab the active lock in the interim, the same node may become the active node again.
-func (a *SystemService) PostSysStepDown(ctx context.Context) (*http.Response, error) {
+func (a *System) PostSysStepDown(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -9959,7 +9961,7 @@ func (a *SystemService) PostSysStepDown(ctx context.Context) (*http.Response, er
 }
 
 // PostSysToolsHash Generate a hash sum for input data
-func (a *SystemService) PostSysToolsHash(ctx context.Context, systemToolsHashRequest SystemToolsHashRequest) (*http.Response, error) {
+func (a *System) PostSysToolsHash(ctx context.Context, systemToolsHashRequest SystemToolsHashRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -10027,7 +10029,7 @@ func (a *SystemService) PostSysToolsHash(ctx context.Context, systemToolsHashReq
 
 // PostSysToolsHashUrlalgorithm Generate a hash sum for input data
 // urlalgorithm: Algorithm to use (POST URL parameter)
-func (a *SystemService) PostSysToolsHashUrlalgorithm(ctx context.Context, urlalgorithm string, systemToolsHashRequest SystemToolsHashRequest) (*http.Response, error) {
+func (a *System) PostSysToolsHashUrlalgorithm(ctx context.Context, urlalgorithm string, systemToolsHashRequest SystemToolsHashRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -10095,7 +10097,7 @@ func (a *SystemService) PostSysToolsHashUrlalgorithm(ctx context.Context, urlalg
 }
 
 // PostSysToolsRandom Generate random bytes
-func (a *SystemService) PostSysToolsRandom(ctx context.Context, systemToolsRandomRequest SystemToolsRandomRequest) (*http.Response, error) {
+func (a *System) PostSysToolsRandom(ctx context.Context, systemToolsRandomRequest SystemToolsRandomRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -10163,7 +10165,7 @@ func (a *SystemService) PostSysToolsRandom(ctx context.Context, systemToolsRando
 
 // PostSysToolsRandomSource Generate random bytes
 // source: Which system to source random data from, ether \&quot;platform\&quot;, \&quot;seal\&quot;, or \&quot;all\&quot;.
-func (a *SystemService) PostSysToolsRandomSource(ctx context.Context, source string, systemToolsRandomRequest SystemToolsRandomRequest) (*http.Response, error) {
+func (a *System) PostSysToolsRandomSource(ctx context.Context, source string, systemToolsRandomRequest SystemToolsRandomRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -10233,7 +10235,7 @@ func (a *SystemService) PostSysToolsRandomSource(ctx context.Context, source str
 // PostSysToolsRandomSourceUrlbytes Generate random bytes
 // source: Which system to source random data from, ether \&quot;platform\&quot;, \&quot;seal\&quot;, or \&quot;all\&quot;.
 // urlbytes: The number of bytes to generate (POST URL parameter)
-func (a *SystemService) PostSysToolsRandomSourceUrlbytes(ctx context.Context, source string, urlbytes string, systemToolsRandomRequest SystemToolsRandomRequest) (*http.Response, error) {
+func (a *System) PostSysToolsRandomSourceUrlbytes(ctx context.Context, source string, urlbytes string, systemToolsRandomRequest SystemToolsRandomRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -10303,7 +10305,7 @@ func (a *SystemService) PostSysToolsRandomSourceUrlbytes(ctx context.Context, so
 
 // PostSysToolsRandomUrlbytes Generate random bytes
 // urlbytes: The number of bytes to generate (POST URL parameter)
-func (a *SystemService) PostSysToolsRandomUrlbytes(ctx context.Context, urlbytes string, systemToolsRandomRequest SystemToolsRandomRequest) (*http.Response, error) {
+func (a *System) PostSysToolsRandomUrlbytes(ctx context.Context, urlbytes string, systemToolsRandomRequest SystemToolsRandomRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -10371,7 +10373,7 @@ func (a *SystemService) PostSysToolsRandomUrlbytes(ctx context.Context, urlbytes
 }
 
 // PostSysUnseal Unseal the Vault.
-func (a *SystemService) PostSysUnseal(ctx context.Context, systemUnsealRequest SystemUnsealRequest) (*http.Response, error) {
+func (a *System) PostSysUnseal(ctx context.Context, systemUnsealRequest SystemUnsealRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -10438,7 +10440,7 @@ func (a *SystemService) PostSysUnseal(ctx context.Context, systemUnsealRequest S
 }
 
 // PostSysWrappingLookup Look up wrapping properties for the given token.
-func (a *SystemService) PostSysWrappingLookup(ctx context.Context, systemWrappingLookupRequest SystemWrappingLookupRequest) (*http.Response, error) {
+func (a *System) PostSysWrappingLookup(ctx context.Context, systemWrappingLookupRequest SystemWrappingLookupRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -10505,7 +10507,7 @@ func (a *SystemService) PostSysWrappingLookup(ctx context.Context, systemWrappin
 }
 
 // PostSysWrappingRewrap Rotates a response-wrapped token.
-func (a *SystemService) PostSysWrappingRewrap(ctx context.Context, systemWrappingRewrapRequest SystemWrappingRewrapRequest) (*http.Response, error) {
+func (a *System) PostSysWrappingRewrap(ctx context.Context, systemWrappingRewrapRequest SystemWrappingRewrapRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -10572,7 +10574,7 @@ func (a *SystemService) PostSysWrappingRewrap(ctx context.Context, systemWrappin
 }
 
 // PostSysWrappingUnwrap Unwraps a response-wrapped token.
-func (a *SystemService) PostSysWrappingUnwrap(ctx context.Context, systemWrappingUnwrapRequest SystemWrappingUnwrapRequest) (*http.Response, error) {
+func (a *System) PostSysWrappingUnwrap(ctx context.Context, systemWrappingUnwrapRequest SystemWrappingUnwrapRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
@@ -10639,7 +10641,7 @@ func (a *SystemService) PostSysWrappingUnwrap(ctx context.Context, systemWrappin
 }
 
 // PostSysWrappingWrap Response-wraps an arbitrary JSON object.
-func (a *SystemService) PostSysWrappingWrap(ctx context.Context) (*http.Response, error) {
+func (a *System) PostSysWrappingWrap(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}

--- a/client.go
+++ b/client.go
@@ -40,22 +40,13 @@ var (
 // Client manages communication with the HashiCorp Vault API v1.12.0
 // In most cases there should be only one, shared, Client.
 type Client struct {
-	cfg    *Configuration
-	common service // Reuse a single struct instead of allocating one for each service on the heap.
+	cfg *Configuration
 
-	// API Services
-
-	Auth *AuthService
-
-	Identity *IdentityService
-
-	Secrets *SecretsService
-
-	System *SystemService
-}
-
-type service struct {
-	client *Client
+	// API wrappers
+	Auth     Auth
+	Identity Identity
+	Secrets  Secrets
+	System   System
 }
 
 // NewClient creates a new API client. Requires a userAgent string describing your application.
@@ -66,14 +57,20 @@ func NewClient(cfg *Configuration) *Client {
 	}
 
 	c := &Client{}
-	c.cfg = cfg
-	c.common.client = c
 
-	// API Services
-	c.Auth = (*AuthService)(&c.common)
-	c.Identity = (*IdentityService)(&c.common)
-	c.Secrets = (*SecretsService)(&c.common)
-	c.System = (*SystemService)(&c.common)
+	// API wrappers
+	c.Auth = Auth{
+		client: c,
+	}
+	c.Identity = Identity{
+		client: c,
+	}
+	c.Secrets = Secrets{
+		client: c,
+	}
+	c.System = System{
+		client: c,
+	}
 
 	return c
 }

--- a/generate/templates/api.mustache
+++ b/generate/templates/api.mustache
@@ -12,8 +12,10 @@ import (
 {{/imports}}
 )
 
-// {{classname}}Service {{classname}} service
-type {{classname}}Service service
+// {{classname}} is a simple wrapper around the client for {{classname}} requests
+type {{classname}} struct {
+	client *Client
+}
 {{#operation}}
 
 {{#isDeprecated}}
@@ -28,7 +30,7 @@ type {{classname}}Service service
 // {{paramName}}: {{.}}
 {{/description}}
 {{/allParams}}
-func (a *{{{classname}}}Service) {{nickname}}(ctx context.Context{{#pathParams}}, {{paramName}} {{{dataType}}}{{/pathParams}}{{#allParams}}{{^isPathParam}}, {{paramName}} {{{dataType}}}{{/isPathParam}}{{/allParams}}) ({{#returnType}}{{^isArray}}{{^returnTypeIsPrimitive}}*{{/returnTypeIsPrimitive}}{{/isArray}}{{{.}}}, {{/returnType}}*http.Response, error) {
+func (a *{{{classname}}}) {{nickname}}(ctx context.Context{{#pathParams}}, {{paramName}} {{{dataType}}}{{/pathParams}}{{#allParams}}{{^isPathParam}}, {{paramName}} {{{dataType}}}{{/isPathParam}}{{/allParams}}) ({{#returnType}}{{^isArray}}{{^returnTypeIsPrimitive}}*{{/returnTypeIsPrimitive}}{{/isArray}}{{{.}}}, {{/returnType}}*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.Method{{httpMethod}}
 		localVarPostBody     interface{}

--- a/generate/templates/client.mustache
+++ b/generate/templates/client.mustache
@@ -31,23 +31,18 @@ var (
 // Client manages communication with the {{appName}} v{{version}}
 // In most cases there should be only one, shared, Client.
 type Client struct {
-	cfg    *Configuration
-	common service // Reuse a single struct instead of allocating one for each service on the heap.
+	cfg *Configuration
 
-	// API Services
+	// API wrappers
 {{#apiInfo}}
 {{#apis}}
 {{#operations}}
-
-	{{classname}} {{#generateInterfaces}}{{classname}}{{/generateInterfaces}}{{^generateInterfaces}}*{{classname}}Service{{/generateInterfaces}}
+	{{classname}} {{classname}}
 {{/operations}}
 {{/apis}}
 {{/apiInfo}}
 }
 
-type service struct {
-	client *Client
-}
 
 // NewClient creates a new API client. Requires a userAgent string describing your application.
 // optionally a custom http.Client to allow for advanced features such as caching.
@@ -57,14 +52,14 @@ func NewClient(cfg *Configuration) *Client {
 	}
 
 	c := &Client{}
-	c.cfg = cfg
-	c.common.client = c
 
 {{#apiInfo}}
-	// API Services
+	// API wrappers
 {{#apis}}
 {{#operations}}
-	c.{{classname}} = (*{{classname}}Service)(&c.common)
+	c.{{classname}} = {{classname}} {
+		client: c,
+	}
 {{/operations}}
 {{/apis}}
 {{/apiInfo}}


### PR DESCRIPTION
Renaming the API wrappers from XyzService to Xyz (e.g. AuthService to Auth) + removing the service struct in favour of simple wrapper structs.