### PR TITLE
Add support for namespaces

### DIFF
--- a/client.go
+++ b/client.go
@@ -109,6 +109,16 @@ func (c *Client) SetToken(token string) {
 	c.requestHeaders.token = token
 }
 
+// ClearToken clears the token for all subsequent requests.
+// See https://www.vaultproject.io/docs/concepts/tokens for more info on
+// tokens.
+func (c *Client) ClearToken() {
+	/* */ c.requestHeadersLock.Lock()
+	defer c.requestHeadersLock.Unlock()
+
+	c.requestHeaders.token = ""
+}
+
 // WithToken returns a shallow copy of the client with the token set to the
 // given value:
 //   client.WithToken("my-token").System.Get...  // use "my-token" token

--- a/generate/templates/client.mustache
+++ b/generate/templates/client.mustache
@@ -100,6 +100,16 @@ func (c *Client) SetToken(token string) {
 	c.requestHeaders.token = token
 }
 
+// ClearToken clears the token for all subsequent requests.
+// See https://www.vaultproject.io/docs/concepts/tokens for more info on
+// tokens.
+func (c *Client) ClearToken() {
+	/* */ c.requestHeadersLock.Lock()
+	defer c.requestHeadersLock.Unlock()
+
+	c.requestHeaders.token = ""
+}
+
 // WithToken returns a shallow copy of the client with the token set to the
 // given value:
 //   client.WithToken("my-token").System.Get...  // use "my-token" token


### PR DESCRIPTION
## Description

Adding support for two namespace setters:

```go
client.SetNamespace("blah")
client.Do(...)

// or

client.WithNamespace("blah").Do(...)
```

Resolves # (issue)

## How has this been tested?

With a local client

## Don't forget to

- [x] run `make regen`
