### PR TITLE
Add validation checks for token/namespace setters

### DIFF
--- a/client.go
+++ b/client.go
@@ -392,5 +392,5 @@ func printable(str string) bool {
 		return !unicode.IsPrint(c)
 	})
 
-	return idx != -1
+	return idx == -1
 }

--- a/generate/templates/client.mustache
+++ b/generate/templates/client.mustache
@@ -380,5 +380,5 @@ func printable(str string) bool {
 		return !unicode.IsPrint(c)
 	})
 
-	return idx != -1
+	return idx == -1
 }


### PR DESCRIPTION
## Description

Simple validation for printable characters (more may be added later)

Resolves VAULT-7295

## How has this been tested?

Tried locally with non-printable chars.

## Don't forget to

- [x] run `make regen`
