### PR TITLE
Fix copyRequestHeaders bug

### DIFF
--- a/client.go
+++ b/client.go
@@ -408,7 +408,12 @@ func (c *Client) copyRequestHeaders() requestHeaders {
 	/* */ c.requestHeadersLock.RLock()
 	defer c.requestHeadersLock.RUnlock()
 
-	return c.requestHeaders
+	return requestHeaders{
+		token:           c.requestHeaders.token,
+		namespace:       c.requestHeaders.namespace,
+		customHeaders:   c.requestHeaders.customHeaders.Clone(),
+		validationError: c.requestHeaders.validationError,
+	}
 }
 
 func validateToken(token string) error {

--- a/generate/templates/client.mustache
+++ b/generate/templates/client.mustache
@@ -396,7 +396,12 @@ func (c *Client) copyRequestHeaders() requestHeaders {
 	/* */ c.requestHeadersLock.RLock()
 	defer c.requestHeadersLock.RUnlock()
 
-	return c.requestHeaders
+	return requestHeaders{
+		token:           c.requestHeaders.token,
+		namespace:       c.requestHeaders.namespace,
+		customHeaders:   c.requestHeaders.customHeaders.Clone(),
+		validationError: c.requestHeaders.validationError,
+	}
 }
 
 func validateToken(token string) error {

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-retryablehttp v0.7.1
-	golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e
+	golang.org/x/exp v0.0.0-20220827204233-334a2380cb91
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -12,7 +12,7 @@ github.com/hashicorp/go-retryablehttp v0.7.1 h1:sUiuQAnLlbvmExtFQs72iFW/HXeUn8Z1
 github.com/hashicorp/go-retryablehttp v0.7.1/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
-golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e h1:+WEEuIdZHnUeJJmEUjyYC2gfUMj69yZXw17EnHg/otA=
-golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e/go.mod h1:Kr81I6Kryrl9sr8s2FK3vxD90NdsKWRuOIl2O4CvYbA=
+golang.org/x/exp v0.0.0-20220827204233-334a2380cb91 h1:tnebWN09GYg9OLPss1KXj8txwZc6X6uMr6VFdcGNbHw=
+golang.org/x/exp v0.0.0-20220827204233-334a2380cb91/go.mod h1:cyybsKvd6eL0RnXn6p/Grxp8F5bW7iYuBgsNCOHpMYE=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0 h1:/5xXl8Y5W96D+TtHSlonuFqGHIWVuyCkGJLwGh9JJFs=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=


### PR DESCRIPTION
## Description

The `customHeaders` value used to be copied as a pointer rather than cloned. This would break the behaviour of `client.WithCustomHeaders(...)` -- the original client's custom headers would also be modified.

This PR fixes the issued by using header.Clone() method. 

## How has this been tested?

Tested with a local client.

## Don't forget to

- [x] run `make regen`
