### PR TITLE
Add support for unix domain sockets

### DIFF
--- a/client.go
+++ b/client.go
@@ -16,6 +16,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -112,15 +113,23 @@ func NewClient(configuration Configuration) (*Client, error) {
 		requestModifiersLock: sync.RWMutex{},
 	}
 
-	a, err := url.Parse(configuration.BaseAddress)
+	address, err := parseAddress(configuration.BaseAddress)
 	if err != nil {
 		return nil, err
 	}
-	c.parsedBaseAddress = *a
+	c.parsedBaseAddress = *address
 
 	transport, ok := c.client.Transport.(*http.Transport)
 	if !ok {
 		return nil, fmt.Errorf("the configured base client's transport (%T) is not of type *http.Transport", c.client.Transport)
+	}
+
+	// Adjust the dial contex for unix domain socket addresses
+	if strings.HasPrefix(configuration.BaseAddress, "unix://") {
+		transport.DialContext = func(context.Context, string, string) (net.Conn, error) {
+			socket := strings.TrimPrefix(configuration.BaseAddress, "unix://")
+			return net.Dial("unix", socket)
+		}
 	}
 
 	if err := configuration.TLS.applyTo(transport.TLSClientConfig); err != nil {
@@ -521,6 +530,26 @@ func handleRedirect(req *http.Request, resp *http.Response, redirectCount *int) 
 	}
 
 	return true, nil
+}
+
+// parseAddress parses the given address string with special handling for unix
+// domain sockets
+func parseAddress(address string) (*url.URL, error) {
+	parsed, err := url.Parse(address)
+	if err != nil {
+		return nil, err
+	}
+
+	if strings.HasPrefix(address, "unix://") {
+		// The address in the client is expected to be pointing to the protocol
+		// used in the application layer and not to the transport layer. Hence,
+		// setting the fields accordingly.
+		parsed.Scheme = "http"
+		parsed.Host = strings.TrimPrefix(address, "unix://") // socket
+		parsed.Path = ""
+	}
+
+	return parsed, nil
 }
 
 func validateToken(token string) error {

--- a/generate/templates/client.mustache
+++ b/generate/templates/client.mustache
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -120,6 +121,7 @@ func NewClient(configuration Configuration) (*Client, error) {
 	// Adjust the dial contex for unix domain socket addresses
 	if strings.HasPrefix(configuration.BaseAddress, "unix://") {
 		transport.DialContext = func(context.Context, string, string) (net.Conn, error) {
+			socket := strings.TrimPrefix(configuration.BaseAddress, "unix://")
 			return net.Dial("unix", socket)
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/go-rootcerts v1.0.2
 	github.com/hashicorp/go-secure-stdlib/strutil v0.1.2
 	github.com/stretchr/testify v1.4.0
-	golang.org/x/exp v0.0.0-20220914170420-dc92f8653013
+	golang.org/x/exp v0.0.0-20220916125017-b168a2c6b86b
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-golang.org/x/exp v0.0.0-20220914170420-dc92f8653013 h1:ZjglnWxEUdPyXl4o/j4T89SRCI+4X6NW6185PNLEOF4=
-golang.org/x/exp v0.0.0-20220914170420-dc92f8653013/go.mod h1:cyybsKvd6eL0RnXn6p/Grxp8F5bW7iYuBgsNCOHpMYE=
+golang.org/x/exp v0.0.0-20220916125017-b168a2c6b86b h1:SCE/18RnFsLrjydh/R/s5EVvHoZprqEQUuoxK8q2Pc4=
+golang.org/x/exp v0.0.0-20220916125017-b168a2c6b86b/go.mod h1:cyybsKvd6eL0RnXn6p/Grxp8F5bW7iYuBgsNCOHpMYE=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0 h1:/5xXl8Y5W96D+TtHSlonuFqGHIWVuyCkGJLwGh9JJFs=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
## Description

Implementing support for `unix://` URLs to match the one in `vault/api/client.go`

Resolves VAULT-7302

## How has this been tested?

Haven't tested it yet

## Don't forget to

- [x] run `make regen`
