### PR TITLE
use non-root user to generate files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ generate:
 	docker run \
 		--rm \
 		--volume "${PWD}:/local" \
+		--user=nobody \
 			openapitools/openapi-generator-cli:$(OPENAPI_GENERATOR_VERSION) generate \
 				--generator-name   go \
 				--input-spec       /local/$(OPENAPI_SPEC_PATH) \


### PR DESCRIPTION
## Description

attempting to add some CI to the repo. When `make regen` is run, the container is running as `root` and  mounts the users local directory to create the files

On linux, the files are created and owned as `root`. so when the `Makefile` tries to delete some of the files, it cannot due to the `rm` command being run by a non-root user
see [failed ci run](https://github.com/hashicorp/vault-client-go/actions/runs/3144740971/jobs/5111133437) for details

this change will allow `make regen` to run properly in CI and _should_ have no effect on local (mac) laptops

Resolves # (issue)

## How has this been tested?

tested locally (on my mac book) without issues

## Don't forget to

~~- [ ] run `make regen`~~
