### PR TITLE
Refactor: a cleaner way to parse errors

### DIFF
--- a/client_request_modifiers.go
+++ b/client_request_modifiers.go
@@ -255,9 +255,10 @@ const (
 
 // SetReplicationForwardingMode will add a forwarding header to all subsequent
 // requests:
-//   ReplicationForwardNone         - no forwarding headers
-//   ReplicationForwardAlways       - 'X-Vault-Forward'
-//   ReplicationForwardInconsistent - 'X-Vault-Inconsistent'
+//
+//	ReplicationForwardNone         - no forwarding headers
+//	ReplicationForwardAlways       - 'X-Vault-Forward'
+//	ReplicationForwardInconsistent - 'X-Vault-Inconsistent'
 //
 // Note: this feature must be enabled in Vault's configuration.
 //
@@ -282,9 +283,10 @@ func (c *Client) ClearReplicationForwardingMode() {
 
 // WithReplicationForwardingMode returns a shallow copy of the client with
 // a replication header set to the given value for subsequent requests:
-//   ReplicationForwardNone         - no forwarding headers
-//   ReplicationForwardAlways       - 'X-Vault-Forward'
-//   ReplicationForwardInconsistent - 'X-Vault-Inconsistent'
+//
+//	ReplicationForwardNone         - no forwarding headers
+//	ReplicationForwardAlways       - 'X-Vault-Forward'
+//	ReplicationForwardInconsistent - 'X-Vault-Inconsistent'
 //
 // See https://www.vaultproject.io/docs/enterprise/consistency#vault-1-7-mitigations
 func (c *Client) WithReplicationForwardingMode(mode ReplicationForwardingMode) *Client {
@@ -359,7 +361,8 @@ type ReplicationState struct {
 // into its individual components. If an optional hmacKey is provided, it will
 // used to verify the replication state contents. The format of the string
 // (after decoding) is expected to be:
-//    v1:cluster-id-string:local-index:replicated-index:hmac
+//
+//	v1:cluster-id-string:local-index:replicated-index:hmac
 func ParseReplicationState(raw string, hmacKey []byte) (ReplicationState, error) {
 	d, err := base64.StdEncoding.DecodeString(raw)
 	if err != nil {

--- a/client_requests.go
+++ b/client_requests.go
@@ -241,9 +241,10 @@ func (c *Client) doWithRetries(req *http.Request, retry bool) (*http.Response, e
 }
 
 // handleRedirect checks the given response for a redirect status
-//  returns:
-//    true & modifies the request accordingly if the redirect is needed
-//    false otherwise
+//
+//	returns:
+//	  true & modifies the request accordingly if the redirect is needed
+//	  false otherwise
 func handleRedirect(req *http.Request, resp *http.Response, redirectCount *int) (bool, error) {
 	// allow at most one redirect
 	if *redirectCount != 0 {


### PR DESCRIPTION
## Description

A quick followup to #62, swapping to a cleaner implementation of error parsing. Thanks @dhuckins for the suggestion!

## How has this been tested?

Local test with an invalid token.

## Don't forget to

- [x] run `make regen`
