### PR TITLE
Improve TLS configuration UX

### DIFF
--- a/.github/ISSUE_TEMPLATE/vault-client-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/vault-client-bug-report.md
@@ -1,0 +1,32 @@
+---
+name: Vault Go Client Bug Report
+about: Bug details to help investigate the issue faster
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+# Expected Behavior
+
+Please describe the behavior you are expecting.
+
+# Current Behavior
+
+What is the current behavior?
+
+# Failure Information
+
+Please include the version of Vault binary and the version of `vault-client-go` you're using.
+
+## Steps to Reproduce
+
+Please provide detailed steps for reproducing the issue.
+
+1. step 1
+2. step 2
+...
+
+# Additional Information
+
+Additional information including exception details, stack trace, etc.

--- a/.github/ISSUE_TEMPLATE/vault-client-feature-request.md
+++ b/.github/ISSUE_TEMPLATE/vault-client-feature-request.md
@@ -1,0 +1,20 @@
+---
+name: Vault Go Client Feature Request or Discussion
+about: Suggest a feature for this project or ask a question
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+## Describe the feature request or question
+
+A clear and concise description of what the problem is. 
+
+## Link to the Vault API Docs that support this feature
+
+The Vault Docs URL
+
+## Additional context
+
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
## Description

#### Old

```go
cfg := vault.DefaultConfiguration()
cfg.TLS.ServerCACertificateFile = "/tmp/vault-ca.pem"
cfg.TLS.ClientCertificateFile = "/tmp/client-cert.pem"
cfg.TLS.ClientCertificateKeyFile = "/tmp/client-key.pem"
```

#### New

```go
cfg := vault.DefaultConfiguration()
cfg.TLS.ServerCertificate.FromFile = "/tmp/vault-ca.pem"
cfg.TLS.ClientCertificate.FromFile = "/tmp/client-cert.pem"
cfg.TLS.ClientCertificateKey.FromFile = "/tmp/client-key.pem"
```

The entries also allow `.FromBytes` and `.FromDirectory`

Resolves # (issue)

## How has this been tested?

Local testing

## Don't forget to

- [x] run `make regen`
