### PR TITLE
Remove old reminder from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,3 @@ Resolves # (issue)
 ## How has this been tested?
 
 > Please describe the tests you ran.
-
-## Don't forget to
-
-- [ ] run `make regen`


### PR DESCRIPTION
## Description

The reminder to regenerate is no longer needed since it's now enforced through CI

## How has this been tested?

Not at all
