### PR TITLE
Improve error handling

### DIFF
--- a/client_requests.go
+++ b/client_requests.go
@@ -292,16 +292,15 @@ func (c *Client) handleRedirect(req *http.Request, resp *http.Response, redirect
 
 	// a helper function to form a redirect error
 	redirectError := func(redirectTo *url.URL, message string, args ...any) *RedirectError {
-		var redirectURL string
+		var redirectLocation string
 		if redirectTo != nil {
-			redirectURL = redirectTo.String()
+			redirectLocation = redirectTo.String()
 		}
 		return &RedirectError{
-			StatusCode:    resp.StatusCode,
-			Message:       fmt.Sprintf(message, args...),
-			RedirectURL:   redirectURL,
-			RequestMethod: req.Method,
-			RequestURL:    req.URL.String(),
+			StatusCode:       resp.StatusCode,
+			Message:          fmt.Sprintf(message, args...),
+			RedirectLocation: redirectLocation,
+			OriginalRequest:  req,
 		}
 	}
 

--- a/errors.go
+++ b/errors.go
@@ -9,37 +9,43 @@ import (
 	"strings"
 )
 
-// IsErrorStatus returns true if the given error is a ResponseError with the
-// given status code.
+// IsErrorStatus returns true if the given error is either a ResponseError or a
+// RedirectError with the given status code.
 func IsErrorStatus(err error, status int) bool {
 	var responseError *ResponseError
 	if errors.As(err, &responseError) {
 		return responseError.StatusCode == status
 	}
+
+	var redirectError *RedirectError
+	if errors.As(err, &redirectError) {
+		return redirectError.StatusCode == status
+	}
+
 	return false
 }
 
-// ResponseError is the error returned when Vault responds with a status code
-// outside of the 200 - 399 range. If a request to Vault fails because of a
-// network error a different error message will be returned.
+// ResponseError is the error returned when Vault responds with an HTTP status
+// code outside of the 200 - 399 range. If a request to Vault fails due to a
+// network error, a different error message will be returned.
 type ResponseError struct {
+	// StatusCode is the HTTP status code returned in the response
 	StatusCode int
 
 	// Errors are the underlying error messages returned in the response body
 	Errors []string
 
-	RequestMethod string
-	RequestURL    string
+	// OriginalRequest is a pointer to the request that caused this error
+	OriginalRequest *http.Request
 }
 
 func (e *ResponseError) Error() string {
-	return fmt.Sprintf("status: %d; errors: [ %s ]", e.StatusCode, strings.Join(e.Errors, ", "))
+	return fmt.Sprintf("%d: %s", e.StatusCode, strings.Join(e.Errors, ", "))
 }
 
-// isResponseError determines if this is an error response based on the
-// response status code. If it is determined to be an error, the function
-// consumes the response body without closing it and parses the underlying
-// error messages.
+// isResponseError determines if this is a response error based on the response
+// status code. If it is determined to be an error, the function consumes the
+// response body without closing it and parses the underlying error messages.
 func isResponseError(req *http.Request, resp *http.Response) *ResponseError {
 	// 200 to 399 are non-error status codes
 	if resp.StatusCode >= 200 && resp.StatusCode <= 399 {
@@ -54,9 +60,8 @@ func isResponseError(req *http.Request, resp *http.Response) *ResponseError {
 	}
 
 	responseError := &ResponseError{
-		StatusCode:    resp.StatusCode,
-		RequestMethod: req.Method,
-		RequestURL:    req.URL.String(),
+		StatusCode:      resp.StatusCode,
+		OriginalRequest: req,
 	}
 
 	// read the entire response first so that we can return it as a raw error
@@ -103,16 +108,19 @@ func isResponseError(req *http.Request, resp *http.Response) *ResponseError {
 //  2. more than one redirect was encountered
 //  3. the redirect response could not be properly parsed
 type RedirectError struct {
+	// StatusCode is the HTTP status code returned in the response
 	StatusCode int
 
+	// Message is the error message
 	Message string
 
-	RedirectURL string
+	// RedirectLocation is populated with the "Location" header, if set
+	RedirectLocation string
 
-	RequestMethod string
-	RequestURL    string
+	// OriginalRequest is a pointer to the request that caused this error
+	OriginalRequest *http.Request
 }
 
 func (e *RedirectError) Error() string {
-	return fmt.Sprintf("status: %d; redirect error: %s", e.StatusCode, e.Message)
+	return fmt.Sprintf("%d: redirect error: %s", e.StatusCode, e.Message)
 }


### PR DESCRIPTION
## Description

A few small error handling improvements:

- Store a pointer to the original request (the request object could be useful for debugging/reporting purposes)
- `IsErrorStatus` now handles `RedirectError` as well
- `redirectURL` -> `redirectLocation` (to match the header name)
- simpler error format for the basic case

Resolves https://hashicorp.atlassian.net/browse/VAULT-11743

## How has this been tested?

Tested locally.
