### PR TITLE
Remove response-specific Unwrap function

### DIFF
--- a/response.go
+++ b/response.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
 	"time"
@@ -82,34 +81,12 @@ type MFAMethodID struct {
 	UsesPasscode bool   `json:"uses_passcode"`
 }
 
-// Unwrap attempts to unwrap the given wrapped response using the wrapping
-// token contained in `response.WrapInfo.Token`
-//
-// See https://developer.hashicorp.com/vault/docs/concepts/response-wrapping
-// for more information on response wrapping
-func (r *Response[T]) Unwrap(ctx context.Context, client *Client) (*Response[T], error) {
-	if r.WrapInfo == nil {
-		return nil, fmt.Errorf("cannot unwrap response: missing wrap info")
-	}
-
-	if len(r.WrapInfo.Token) == 0 {
-		return nil, fmt.Errorf("cannot unwrap response: missing wrapping token")
-	}
-
-	r, err := UnwrapToken[T](ctx, client, r.WrapInfo.Token)
-	if err != nil {
-		return nil, fmt.Errorf("cannot unwrap response: %w", err)
-	}
-
-	return r, nil
-}
-
-// UnwrapToken sends a request with the given wrapping token and returns the
+// Unwrap sends a request with the given wrapping token and returns the
 // original wrapped response.
 //
 // See https://developer.hashicorp.com/vault/docs/concepts/response-wrapping
 // for more information on response wrapping
-func UnwrapToken[T any](ctx context.Context, client *Client, wrappingToken string, options ...RequestOption) (*Response[T], error) {
+func Unwrap[T any](ctx context.Context, client *Client, wrappingToken string, options ...RequestOption) (*Response[T], error) {
 	// set the wrapping token
 	options = append(options, WithToken(wrappingToken))
 


### PR DESCRIPTION
## Description

The previous Unwrap function gave users the wrong idea that they should call a request, wrap it and then unwrap it. This is not the intended workflow of wrapping/unwrapping. I'm removing this function to avoid confusion and renaming `UnwrapToken` to `Unwrap`.

Resolves https://hashicorp.atlassian.net/browse/VAULT-11744

## How has this been tested?

Local testing
