### PR TITLE
Rename FromEnv -> WithEnvironment

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,7 +335,6 @@ if err := client.SetToken(resp.Auth.ClientToken); err != nil {
 
 ```go
 client, err := vault.New(
-	vault.WithBaseAddress("http://not-an-address"),
 	vault.WithEnvironment(),
 )
 if err != nil {
@@ -347,7 +346,6 @@ if err != nil {
 export VAULT_ADDR=http://localhost:8200
 export VAULT_TOKEN=my-token
 go run main.go
-# the client will be initialized with 'http://localhost:8200' base address
 ```
 
 ### Logging Requests & Responses with Request/Response Callbacks

--- a/configuration.go
+++ b/configuration.go
@@ -170,7 +170,7 @@ func WithConfiguration(configuration Configuration) ClientOption {
 //	VAULT_MAX_RETRIES            (maximum number of retries for certain error codes)
 func WithEnvironment() ClientOption {
 	return func(c *Configuration) error {
-		return c.PopulateFromEnvironment()
+		return c.populateFromEnvironment()
 	}
 }
 
@@ -397,7 +397,7 @@ func DefaultConfiguration() Configuration {
 	}
 }
 
-// PopulateFromEnvironment populates the configuration object with values from
+// populateFromEnvironment populates the configuration object with values from
 // environment values. The following environment variables are currently
 // supported:
 //
@@ -418,7 +418,7 @@ func DefaultConfiguration() Configuration {
 //	VAULT_RETRY_WAIT_MIN         (minimum time to wait before retrying)
 //	VAULT_RETRY_WAIT_MAX         (maximum time to wait before retrying)
 //	VAULT_MAX_RETRIES            (maximum number of retries for certain error codes)
-func (c *Configuration) PopulateFromEnvironment() error {
+func (c *Configuration) populateFromEnvironment() error {
 	// this function will be recursively applied to each field within the configuration object
 	assignFieldFromEnvironment := func(field reflect.Value, environmentTags []string) error {
 		// for each 'env' tag ...


### PR DESCRIPTION
## Description

Renaming `FromEnv` -> `WithEnvironment` and changing it into `ClientOption` to make it consistent with other client options. Also added more comments to describe the environment variables we respect.

## How has this been tested?

Tested locally
