### PR TITLE
Standardize test format

### DIFF
--- a/client_configuration_test.go
+++ b/client_configuration_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestWalkConfigurationFields(t *testing.T) {
+func Test_walkconfigurationfields(t *testing.T) {
 	var (
 		actual   = []string{}
 		expected = []string{
@@ -29,6 +29,7 @@ func TestWalkConfigurationFields(t *testing.T) {
 			"VAULT_DISABLE_REDIRECTS",
 		}
 	)
+
 	var configuration ClientConfiguration
 
 	require.NoError(t, walkConfigurationFields(

--- a/client_requests_test.go
+++ b/client_requests_test.go
@@ -5,43 +5,60 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestV1Path(t *testing.T) {
-	tests := []struct {
+func Test_v1Path(t *testing.T) {
+	cases := map[string]struct {
 		path     string
 		expected string
-	}{{
-		path:     "/v1/path/to/a",
-		expected: "/v1/path/to/a",
-	}, {
-		path:     "v1/path/to/a",
-		expected: "/v1/path/to/a",
-	}, {
-		path:     "/path/to/a",
-		expected: "/v1/path/to/a",
-	}, {
-		path:     "path/to/a",
-		expected: "/v1/path/to/a",
-	}}
+	}{
+		"slash-v1-slash-path": {
+			path:     "/v1/path/to/a",
+			expected: "/v1/path/to/a",
+		},
+		"v1-slash-path": {
+			path:     "v1/path/to/a",
+			expected: "/v1/path/to/a",
+		},
+		"slash-path": {
+			path:     "/path/to/a",
+			expected: "/v1/path/to/a",
+		},
+		"path": {
+			path:     "path/to/a",
+			expected: "/v1/path/to/a",
+		},
+	}
 
-	for _, tt := range tests {
-		t.Run(tt.path, func(t *testing.T) {
-			assert.Equal(t, tt.expected, v1Path(tt.path))
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, tc.expected, v1Path(tc.path))
 		})
 	}
 }
 
-func FuzzV1Path(f *testing.F) {
+func Fuzz_v1Path(f *testing.F) {
 	f.Fuzz(func(t *testing.T, path string) {
 		formatted := v1Path(path)
 
 		if !strings.HasPrefix(formatted, "/v1/") {
-			assert.Failf(t, "unexpected prefix", "want: a path starting with /v1/, got: %s", formatted)
+			assert.Failf(
+				t,
+				"unexpected prefix",
+				"want: a path starting with /v1/, got: %s",
+				formatted,
+			)
 		}
 
 		if !strings.HasSuffix(formatted, path) {
-			assert.Failf(t, "unexpected suffix", "want: a path ending with %q, got: %q", path, formatted)
+			assert.Failf(
+				t,
+				"unexpected suffix",
+				"want: a path ending with %q, got: %q",
+				path,
+				formatted,
+			)
 		}
 	})
 }

--- a/replication_consistency_test.go
+++ b/replication_consistency_test.go
@@ -7,103 +7,102 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestParseReplicationState(t *testing.T) {
-	tests := []struct {
-		name          string
+func Test_ParseReplicationState(t *testing.T) {
+	cases := map[string]struct {
 		raw           string
 		hmacKey       []byte
-		expectedState ReplicationState
-		expectedErr   string
-	}{{
-		name:          "simple",
-		raw:           "v1:my-cluster:12345:54321:",
-		expectedState: ReplicationState{Cluster: "my-cluster", LocalIndex: 12345, ReplicatedIndex: 54321},
-	}, {
-		name:          "with-hmac",
-		raw:           "v1:my-cluster:12345:54321:1B9144F5EC067A2A6D6099F16418A3AFD2E5CDA5C9EC318C92D00ED8DD8207E4",
-		hmacKey:       []byte("my-hmac-key"),
-		expectedState: ReplicationState{Cluster: "my-cluster", LocalIndex: 12345, ReplicatedIndex: 54321},
-	}, {
-		name:        "with-bad-hmac-key",
-		raw:         "v1:my-cluster:12345:54321:1B9144F5EC067A2A6D6099F16418A3AFD2E5CDA5C9EC318C92D00ED8DD8207E4",
-		hmacKey:     []byte("bad-key"),
-		expectedErr: "invalid replication state header HMAC",
-	}, {
-		name:        "bad-format",
-		raw:         "bad-format",
-		expectedErr: "invalid replication state header format",
-	}}
+		expected      ReplicationState
+		expectedError bool
+	}{
+		"simple": {
+			raw:      "v1:my-cluster:12345:54321:",
+			expected: ReplicationState{Cluster: "my-cluster", LocalIndex: 12345, ReplicatedIndex: 54321},
+		},
+		"with-hmac": {
+			raw:      "v1:my-cluster:12345:54321:1B9144F5EC067A2A6D6099F16418A3AFD2E5CDA5C9EC318C92D00ED8DD8207E4",
+			hmacKey:  []byte("my-hmac-key"),
+			expected: ReplicationState{Cluster: "my-cluster", LocalIndex: 12345, ReplicatedIndex: 54321},
+		},
+		"with-bad-hmac-key": {
+			raw:           "v1:my-cluster:12345:54321:1B9144F5EC067A2A6D6099F16418A3AFD2E5CDA5C9EC318C92D00ED8DD8207E4",
+			hmacKey:       []byte("bad-key"),
+			expectedError: true,
+		},
+		"bad-format": {
+			raw:           "bad-format",
+			expectedError: true,
+		},
+	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
 			parsed, err := ParseReplicationState(
-				base64Encode(tt.raw),
-				tt.hmacKey,
+				base64Encode(tc.raw),
+				tc.hmacKey,
 			)
-			if tt.expectedErr != "" {
+			if tc.expectedError {
 				require.Error(t, err)
-				require.Regexp(t, tt.expectedErr, err)
 			} else {
 				require.NoError(t, err)
-				require.Equal(t, tt.expectedState, parsed)
+				require.Equal(t, tc.expected, parsed)
 			}
 		})
 	}
 }
 
-func TestMergeReplicationStates(t *testing.T) {
-	tests := []struct {
-		name           string
+func Test_MergeReplicationStates(t *testing.T) {
+	cases := map[string]struct {
 		oldStates      []string
 		newState       string
 		expectedStates []string
-	}{{
-		name:           "empty-old",
-		oldStates:      nil,
-		newState:       "v1:cid:1:0:",
-		expectedStates: []string{"v1:cid:1:0:"},
-	}, {
-		name:           "old-smaller",
-		oldStates:      []string{"v1:cid:1:0:"},
-		newState:       "v1:cid:2:0:",
-		expectedStates: []string{"v1:cid:2:0:"},
-	}, {
-		name:           "old-bigger",
-		oldStates:      []string{"v1:cid:2:0:"},
-		newState:       "v1:cid:1:0:",
-		expectedStates: []string{"v1:cid:2:0:"},
-	}, {
-		name:           "mixed-single",
-		oldStates:      []string{"v1:cid:1:0:"},
-		newState:       "v1:cid:0:1:",
-		expectedStates: []string{"v1:cid:0:1:", "v1:cid:1:0:"},
-	}, {
-		name:           "mixed-single-alt",
-		oldStates:      []string{"v1:cid:0:1:"},
-		newState:       "v1:cid:1:0:",
-		expectedStates: []string{"v1:cid:0:1:", "v1:cid:1:0:"},
-	}, {
-		name:           "mixed-double",
-		oldStates:      []string{"v1:cid:0:1:", "v1:cid:1:0:"},
-		newState:       "v1:cid:2:0:",
-		expectedStates: []string{"v1:cid:0:1:", "v1:cid:2:0:"},
-	}, {
-		name:           "newer-both",
-		oldStates:      []string{"v1:cid:0:1:", "v1:cid:1:0:"},
-		newState:       "v1:cid:2:1:",
-		expectedStates: []string{"v1:cid:2:1:"},
-	}}
+	}{
+		"empty-old": {
+			oldStates:      nil,
+			newState:       "v1:cid:1:0:",
+			expectedStates: []string{"v1:cid:1:0:"},
+		},
+		"old-smaller": {
+			oldStates:      []string{"v1:cid:1:0:"},
+			newState:       "v1:cid:2:0:",
+			expectedStates: []string{"v1:cid:2:0:"},
+		},
+		"old-bigger": {
+			oldStates:      []string{"v1:cid:2:0:"},
+			newState:       "v1:cid:1:0:",
+			expectedStates: []string{"v1:cid:2:0:"},
+		},
+		"mixed-single": {
+			oldStates:      []string{"v1:cid:1:0:"},
+			newState:       "v1:cid:0:1:",
+			expectedStates: []string{"v1:cid:0:1:", "v1:cid:1:0:"},
+		},
+		"mixed-single-alt": {
+			oldStates:      []string{"v1:cid:0:1:"},
+			newState:       "v1:cid:1:0:",
+			expectedStates: []string{"v1:cid:0:1:", "v1:cid:1:0:"},
+		},
+		"mixed-double": {
+			oldStates:      []string{"v1:cid:0:1:", "v1:cid:1:0:"},
+			newState:       "v1:cid:2:0:",
+			expectedStates: []string{"v1:cid:0:1:", "v1:cid:2:0:"},
+		},
+		"newer-both": {
+			oldStates:      []string{"v1:cid:0:1:", "v1:cid:1:0:"},
+			newState:       "v1:cid:2:1:",
+			expectedStates: []string{"v1:cid:2:1:"},
+		},
+	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
 			merged, err := base64DecodeSlice(
 				MergeReplicationStates(
-					base64EncodeSlice(tt.oldStates),
-					base64Encode(tt.newState),
+					base64EncodeSlice(tc.oldStates),
+					base64Encode(tc.newState),
 				),
 			)
 			require.NoError(t, err)
-			require.Equal(t, tt.expectedStates, merged)
+			require.Equal(t, tc.expectedStates, merged)
 		})
 	}
 }

--- a/response_test.go
+++ b/response_test.go
@@ -4,50 +4,49 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestParseResponseGeneric(t *testing.T) {
-	tests := []struct {
-		name     string
+func Test_parseResponse_generic(t *testing.T) {
+	cases := map[string]struct {
 		body     string
 		expected *Response[map[string]interface{}]
-	}{{
-		name:     "empty",
-		body:     "",
-		expected: nil,
-	}, {
-		name: "empty-object",
-		body: `{}`,
-		expected: &Response[map[string]interface{}]{
-			Data: map[string]interface{}{},
+	}{
+		"empty": {
+			body:     "",
+			expected: nil,
 		},
-	}, {
-		name: "with-data",
-		body: `{"data":{"key1":"value1","key2":"value2"}}`,
-		expected: &Response[map[string]interface{}]{
-			Data: map[string]interface{}{
-				"key1": "value1",
-				"key2": "value2",
+		"empty-object": {
+			body: `{}`,
+			expected: &Response[map[string]interface{}]{
+				Data: map[string]interface{}{},
 			},
 		},
-	}, {
-		name: "with-no-data",
-		body: `{"key1":"value1","key2":"value2"}`,
-		expected: &Response[map[string]interface{}]{
-			Data: map[string]interface{}{
-				"key1": "value1",
-				"key2": "value2",
+		"with-data": {
+			body: `{"data":{"key1":"value1","key2":"value2"}}`,
+			expected: &Response[map[string]interface{}]{
+				Data: map[string]interface{}{
+					"key1": "value1",
+					"key2": "value2",
+				},
 			},
 		},
-	}}
+		"with-no-data": {
+			body: `{"key1":"value1","key2":"value2"}`,
+			expected: &Response[map[string]interface{}]{
+				Data: map[string]interface{}{
+					"key1": "value1",
+					"key2": "value2",
+				},
+			},
+		},
+	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			actual, err := parseResponse[map[string]interface{}](strings.NewReader(tt.body))
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			actual, err := parseResponse[map[string]interface{}](strings.NewReader(tc.body))
 			require.NoError(t, err)
-			assert.Equal(t, tt.expected, actual)
+			require.Equal(t, tc.expected, actual)
 		})
 	}
 }
@@ -57,46 +56,46 @@ type testStruct struct {
 	TestBool   bool   `json:"test_bool"`
 }
 
-func TestParseResponseStructured(t *testing.T) {
-	tests := []struct {
-		name     string
+func Test_parseResponse_structured(t *testing.T) {
+	cases := map[string]struct {
 		body     string
 		expected *Response[testStruct]
-	}{{
-		name:     "empty",
-		body:     "",
-		expected: nil,
-	}, {
-		name: "empty-object",
-		body: `{}`,
-		expected: &Response[testStruct]{
-			Data: testStruct{},
+	}{
+		"empty": {
+			body:     "",
+			expected: nil,
 		},
-	}, {
-		name: "with-data",
-		body: `{"data":{"test_string":"test","test_bool":true}}`,
-		expected: &Response[testStruct]{
-			Data: testStruct{
-				TestString: "test",
-				TestBool:   true,
+		"empty-object": {
+			body: `{}`,
+			expected: &Response[testStruct]{
+				Data: testStruct{},
 			},
 		},
-	}, {
-		name: "with-no-data",
-		body: `{"test_string":"test","test_bool":false}`,
-		expected: &Response[testStruct]{
-			Data: testStruct{
-				TestString: "test",
-				TestBool:   false,
+		"with-data": {
+			body: `{"data":{"test_string":"test","test_bool":true}}`,
+			expected: &Response[testStruct]{
+				Data: testStruct{
+					TestString: "test",
+					TestBool:   true,
+				},
 			},
 		},
-	}}
+		"with-no-data": {
+			body: `{"test_string":"test","test_bool":false}`,
+			expected: &Response[testStruct]{
+				Data: testStruct{
+					TestString: "test",
+					TestBool:   false,
+				},
+			},
+		},
+	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			actual, err := parseResponse[testStruct](strings.NewReader(tt.body))
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			actual, err := parseResponse[testStruct](strings.NewReader(tc.body))
 			require.NoError(t, err)
-			assert.Equal(t, tt.expected, actual)
+			require.Equal(t, tc.expected, actual)
 		})
 	}
 }


### PR DESCRIPTION
## Description

Converting the existing tests to match a common format (Test_funcName + map for test cases)

Resolves [VAULT-12805](https://hashicorp.atlassian.net/browse/VAULT-12805)

## How has this been tested?

`go test`


[VAULT-12805]: https://hashicorp.atlassian.net/browse/VAULT-12805?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ