### PR TITLE
Remove GOPRIVATE from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ A simple client library [generated][openapi-generator] from `OpenAPI`
 ## Installation
 
 ```sh
-export GOPRIVATE=github.com/hashicorp/vault-client-go
 go get github.com/hashicorp/vault-client-go
 ```
 


### PR DESCRIPTION
## Description

This PR is just a reminder to remove the tag from README before open-sourcing the repository.
