### PR TITLE
Fix setting RateLimiter from environment variable

### DIFF
--- a/client_configuration.go
+++ b/client_configuration.go
@@ -13,7 +13,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-	"unsafe"
 
 	"github.com/hashicorp/go-cleanhttp"
 	"github.com/hashicorp/go-retryablehttp"
@@ -319,7 +318,7 @@ func (c *ClientConfiguration) populateFromEnvironment() error {
 					}
 					limiterBurst = int(limiterRate)
 				}
-				field.SetPointer(unsafe.Pointer(rate.NewLimiter(rate.Limit(limiterRate), limiterBurst)))
+				field.Set(reflect.ValueOf(rate.NewLimiter(rate.Limit(limiterRate), limiterBurst)))
 
 			default:
 				return fmt.Errorf("environment variable parsing not implemented for %q type", field.Type().String())


### PR DESCRIPTION
## Description

Currently the following panics:

```sh
VAULT_RATE_LIMIT=1 go run main.go
```
This fixes the issue and the env is read correctly.

## How has this been tested?

Tested locally. I might add a better test for this once we have docker-based tests.
