### PR TITLE
Fix mount path template in method signatures

### DIFF
--- a/generate/templates/api.handlebars
+++ b/generate/templates/api.handlebars
@@ -21,11 +21,11 @@ type {{cut classname "Api"}} struct {
 {{#if isDeprecated}}
 // Deprecated{{/if}}
 // {{operationId}} {{{summary}}}{{#if notes}}
-// {{{notes}}}{{/if}}{{#each pathParams}}{{#with required}}{{#with description}}
-// {{paramName}}: {{.}}{{/with}}{{/with}}{{/each}}{{#each bodyParams}}{{#with description}}
+// {{{notes}}}{{/if}}{{#each pathParams}}{{#endsWith baseName "_mount_path"}}{{else}}{{#with description}}
+// {{paramName}}: {{.}}{{/with}}{{/endsWith}}{{/each}}{{#each bodyParams}}{{#with description}}
 // {{paramName}}: {{.}}{{/with}}{{/each}}{{#each queryParams}}{{#neq paramName "list"}}{{#with description}}
 // {{paramName}}: {{.}}{{/with}}{{/neq}}{{/each}}
-func ({{lower (substring classname 0 1)}} *{{cut classname "Api"}}) {{nickname}}(ctx context.Context{{#each pathParams}}{{#with required}}, {{paramName}} {{{dataType}}}{{/with}}{{/each}}{{#each bodyParams}}, request schema.{{{dataType}}}{{/each}}{{#each queryParams}}{{#neq paramName "list"}}, {{paramName}} {{{dataType}}}{{/neq}}{{/each}}, options ...RequestOption) (*Response[{{#with returnType}}schema.{{{.}}}{{/with}}{{#unless returnType}}map[string]interface{}{{/unless}}], error) {
+func ({{lower (substring classname 0 1)}} *{{cut classname "Api"}}) {{nickname}}(ctx context.Context{{#each pathParams}}{{#endsWith baseName "_mount_path"}}{{else}}, {{paramName}} {{{dataType}}}{{/endsWith}}{{/each}}{{#each bodyParams}}, request schema.{{{dataType}}}{{/each}}{{#each queryParams}}{{#neq paramName "list"}}, {{paramName}} {{{dataType}}}{{/neq}}{{/each}}, options ...RequestOption) (*Response[{{#with returnType}}schema.{{{.}}}{{/with}}{{#unless returnType}}map[string]interface{}{{/unless}}], error) {
 	requestModifiers, err := requestOptionsToRequestModifiers(options)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Description

I missed a couple places where mount path logic relied on it being an optional param. Fixing these here.

Related ticket: [VAULT-12036](https://hashicorp.atlassian.net/browse/VAULT-12036)




[VAULT-12036]: https://hashicorp.atlassian.net/browse/VAULT-12036?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ