### PR TITLE
0.3.0 Release Notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to
 
 ### Added
 
-- Added response structures for many endpoints (`sys`, `kv-v1`, `kv-v2`, `pki`, `approle`).
+- Added response structures for `sys`, `kv-v1`, `kv-v2`, `pki`, and `approle`.
 - Added support for non-string query parameters.
 - Added prettier README formatter to the Makefile and GitHub actions.
 - Added security note to README.
@@ -27,8 +27,7 @@ and this project adheres to
 
 ### Changed
 
-- Regenerated with latest OpenAPI specification, resulting in new method names,
-  request names, and response names. This change is not backwards compatible!
+- Regenerated with new method names, request names, and response names.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,32 @@ and this project adheres to
 
 ## Unreleased ([diff][unreleased-diff])
 
+## [0.3.0][] ([diff][0.3.0-diff]) - 2023-05-04
+
+### Added
+
+- Added response structures for many endpoints (`sys`, `kv-v1`, `kv-v2`, `pki`, `approle`).
+- Added support for non-string query parameters.
+- Added prettier README formatter to the Makefile and GitHub actions.
+- Added security note to README.
+
+### Removed
+
+- Removed redundant methods (e.g. `TokenLookupSelf2`, `TokenLookupSelf3`, etc).
+- Removed endpoints for `ad` (consolidated into `ldap`).
+- Removed endpoints for `openldap` (alias of `ldap`).
+- Removed endpoints for `oidc` (consolidated into `jwt`).
+- Removed endpoints for `pfc` (deprecated plugin).
+
+### Changed
+
+- Regenerated with latest OpenAPI specification, resulting in new method names,
+  request names, and response names. This change is not backwards compatible!
+
+### Fixed
+
+- Fixed mount path logic in method signatures.
+
 ## [0.2.0][] ([diff][0.2.0-diff]) - 2023-03-01
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,9 @@ and this project adheres to
 <!-- diffs -->
 
 [unreleased-diff]:
-  https://github.com/hashicorp/vault-client-go/compare/v0.2.0...HEAD
+  https://github.com/hashicorp/vault-client-go/compare/v0.3.0...HEAD
+[0.3.0-diff]:
+  https://github.com/hashicorp/vault-client-go/compare/v0.2.0...v0.3.0
 [0.2.0-diff]:
   https://github.com/hashicorp/vault-client-go/compare/v0.1.0...v0.2.0
 [0.1.0-diff]:
@@ -79,6 +81,8 @@ and this project adheres to
 
 <!-- releases -->
 
+[0.3.0]:
+  https://github.com/hashicorp/vault-client-go/releases/tag/v0.3.0
 [0.2.0]:
   https://github.com/hashicorp/vault-client-go/releases/tag/v0.2.0
 [0.1.0]:

--- a/client.go
+++ b/client.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/go-retryablehttp"
 )
 
-const ClientVersion = "0.1.0-beta"
+const ClientVersion = "0.3.0"
 
 // Client manages communication with Vault, initialize it with vault.New(...)
 type Client struct {

--- a/generate/config.yaml
+++ b/generate/config.yaml
@@ -3,5 +3,5 @@
 
 additionalProperties:
   packageName: vault
-  packageVersion: 0.1.0-beta
+  packageVersion: 0.3.0
 


### PR DESCRIPTION
## [0.3.0][] ([diff][0.3.0-diff]) - 2023-05-04

### Added

- Added response structures for `sys`, `kv-v1`, `kv-v2`, `pki`, and `approle`.
- Added support for non-string query parameters.
- Added prettier README formatter to the Makefile and GitHub actions.
- Added security note to README.

### Removed

- Removed redundant methods (e.g. `TokenLookupSelf2`, `TokenLookupSelf3`, etc).
- Removed endpoints for `ad` (consolidated into `ldap`).
- Removed endpoints for `openldap` (alias of `ldap`).
- Removed endpoints for `oidc` (consolidated into `jwt`).
- Removed endpoints for `pfc` (deprecated plugin).

### Changed

- Regenerated with new method names, request names, and response names.

### Fixed

- Fixed mount path logic in method signatures.


[0.3.0-diff]:
  https://github.com/hashicorp/vault-client-go/compare/v0.2.0...v0.3.0
[0.3.0]:
  https://github.com/hashicorp/vault-client-go/releases/tag/v0.3.0
