### PR TITLE
Remove redundant mount path table entries in docs

### DIFF
--- a/docs/AuthApi.md
+++ b/docs/AuthApi.md
@@ -300,7 +300,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **role** | **string** | The name of the role as it should appear in Vault. | 
-**alicloudMountPath** | **string** | Path that the backend was mounted at | [default to &quot;alicloud&quot;]
 
 ### Other Parameters
 
@@ -361,7 +360,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**alicloudMountPath** | **string** | Path that the backend was mounted at | [default to &quot;alicloud&quot;]
 
 ### Other Parameters
 
@@ -425,7 +423,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**alicloudMountPath** | **string** | Path that the backend was mounted at | [default to &quot;alicloud&quot;]
 
 ### Other Parameters
 
@@ -489,7 +486,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **role** | **string** | The name of the role as it should appear in Vault. | 
-**alicloudMountPath** | **string** | Path that the backend was mounted at | [default to &quot;alicloud&quot;]
 
 ### Other Parameters
 
@@ -556,7 +552,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **role** | **string** | The name of the role as it should appear in Vault. | 
-**alicloudMountPath** | **string** | Path that the backend was mounted at | [default to &quot;alicloud&quot;]
 
 ### Other Parameters
 
@@ -621,7 +616,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **roleName** | **string** | Name of the role. Must be less than 4096 bytes. | 
-**approleMountPath** | **string** | Path that the backend was mounted at | [default to &quot;approle&quot;]
 
 ### Other Parameters
 
@@ -685,7 +679,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **roleName** | **string** | Name of the role. Must be less than 4096 bytes. | 
-**approleMountPath** | **string** | Path that the backend was mounted at | [default to &quot;approle&quot;]
 
 ### Other Parameters
 
@@ -749,7 +742,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **roleName** | **string** | Name of the role. Must be less than 4096 bytes. | 
-**approleMountPath** | **string** | Path that the backend was mounted at | [default to &quot;approle&quot;]
 
 ### Other Parameters
 
@@ -813,7 +805,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **roleName** | **string** | Name of the role. Must be less than 4096 bytes. | 
-**approleMountPath** | **string** | Path that the backend was mounted at | [default to &quot;approle&quot;]
 
 ### Other Parameters
 
@@ -877,7 +868,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **roleName** | **string** | Name of the role. Must be less than 4096 bytes. | 
-**approleMountPath** | **string** | Path that the backend was mounted at | [default to &quot;approle&quot;]
 
 ### Other Parameters
 
@@ -941,7 +931,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **roleName** | **string** | Name of the role. Must be less than 4096 bytes. | 
-**approleMountPath** | **string** | Path that the backend was mounted at | [default to &quot;approle&quot;]
 
 ### Other Parameters
 
@@ -1005,7 +994,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **roleName** | **string** | Name of the role. Must be less than 4096 bytes. | 
-**approleMountPath** | **string** | Path that the backend was mounted at | [default to &quot;approle&quot;]
 
 ### Other Parameters
 
@@ -1069,7 +1057,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **roleName** | **string** | Name of the role. Must be less than 4096 bytes. | 
-**approleMountPath** | **string** | Path that the backend was mounted at | [default to &quot;approle&quot;]
 
 ### Other Parameters
 
@@ -1133,7 +1120,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **roleName** | **string** | Name of the role. Must be less than 4096 bytes. | 
-**approleMountPath** | **string** | Path that the backend was mounted at | [default to &quot;approle&quot;]
 
 ### Other Parameters
 
@@ -1197,7 +1183,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **roleName** | **string** | Name of the role. Must be less than 4096 bytes. | 
-**approleMountPath** | **string** | Path that the backend was mounted at | [default to &quot;approle&quot;]
 
 ### Other Parameters
 
@@ -1261,7 +1246,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **roleName** | **string** | Name of the role. Must be less than 4096 bytes. | 
-**approleMountPath** | **string** | Path that the backend was mounted at | [default to &quot;approle&quot;]
 
 ### Other Parameters
 
@@ -1325,7 +1309,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **roleName** | **string** | Name of the role. Must be less than 4096 bytes. | 
-**approleMountPath** | **string** | Path that the backend was mounted at | [default to &quot;approle&quot;]
 
 ### Other Parameters
 
@@ -1392,7 +1375,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **roleName** | **string** | Name of the role. Must be less than 4096 bytes. | 
-**approleMountPath** | **string** | Path that the backend was mounted at | [default to &quot;approle&quot;]
 
 ### Other Parameters
 
@@ -1460,7 +1442,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **roleName** | **string** | Name of the role. Must be less than 4096 bytes. | 
-**approleMountPath** | **string** | Path that the backend was mounted at | [default to &quot;approle&quot;]
 
 ### Other Parameters
 
@@ -1522,7 +1503,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**approleMountPath** | **string** | Path that the backend was mounted at | [default to &quot;approle&quot;]
 
 ### Other Parameters
 
@@ -1586,7 +1566,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **roleName** | **string** | Name of the role. Must be less than 4096 bytes. | 
-**approleMountPath** | **string** | Path that the backend was mounted at | [default to &quot;approle&quot;]
 
 ### Other Parameters
 
@@ -1651,7 +1630,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**approleMountPath** | **string** | Path that the backend was mounted at | [default to &quot;approle&quot;]
 
 ### Other Parameters
 
@@ -1718,7 +1696,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **roleName** | **string** | Name of the role. Must be less than 4096 bytes. | 
-**approleMountPath** | **string** | Path that the backend was mounted at | [default to &quot;approle&quot;]
 
 ### Other Parameters
 
@@ -1786,7 +1763,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **roleName** | **string** | Name of the role. Must be less than 4096 bytes. | 
-**approleMountPath** | **string** | Path that the backend was mounted at | [default to &quot;approle&quot;]
 
 ### Other Parameters
 
@@ -1851,7 +1827,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **roleName** | **string** | Name of the role. Must be less than 4096 bytes. | 
-**approleMountPath** | **string** | Path that the backend was mounted at | [default to &quot;approle&quot;]
 
 ### Other Parameters
 
@@ -1915,7 +1890,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **roleName** | **string** | Name of the role. Must be less than 4096 bytes. | 
-**approleMountPath** | **string** | Path that the backend was mounted at | [default to &quot;approle&quot;]
 
 ### Other Parameters
 
@@ -1979,7 +1953,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **roleName** | **string** | Name of the role. Must be less than 4096 bytes. | 
-**approleMountPath** | **string** | Path that the backend was mounted at | [default to &quot;approle&quot;]
 
 ### Other Parameters
 
@@ -2043,7 +2016,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **roleName** | **string** | Name of the role. Must be less than 4096 bytes. | 
-**approleMountPath** | **string** | Path that the backend was mounted at | [default to &quot;approle&quot;]
 
 ### Other Parameters
 
@@ -2107,7 +2079,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **roleName** | **string** | Name of the role. Must be less than 4096 bytes. | 
-**approleMountPath** | **string** | Path that the backend was mounted at | [default to &quot;approle&quot;]
 
 ### Other Parameters
 
@@ -2171,7 +2142,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **roleName** | **string** | Name of the role. Must be less than 4096 bytes. | 
-**approleMountPath** | **string** | Path that the backend was mounted at | [default to &quot;approle&quot;]
 
 ### Other Parameters
 
@@ -2235,7 +2205,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **roleName** | **string** | Name of the role. Must be less than 4096 bytes. | 
-**approleMountPath** | **string** | Path that the backend was mounted at | [default to &quot;approle&quot;]
 
 ### Other Parameters
 
@@ -2299,7 +2268,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **roleName** | **string** | Name of the role. Must be less than 4096 bytes. | 
-**approleMountPath** | **string** | Path that the backend was mounted at | [default to &quot;approle&quot;]
 
 ### Other Parameters
 
@@ -2363,7 +2331,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **roleName** | **string** | Name of the role. Must be less than 4096 bytes. | 
-**approleMountPath** | **string** | Path that the backend was mounted at | [default to &quot;approle&quot;]
 
 ### Other Parameters
 
@@ -2427,7 +2394,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **roleName** | **string** | Name of the role. Must be less than 4096 bytes. | 
-**approleMountPath** | **string** | Path that the backend was mounted at | [default to &quot;approle&quot;]
 
 ### Other Parameters
 
@@ -2491,7 +2457,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **roleName** | **string** | Name of the role. Must be less than 4096 bytes. | 
-**approleMountPath** | **string** | Path that the backend was mounted at | [default to &quot;approle&quot;]
 
 ### Other Parameters
 
@@ -2555,7 +2520,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **roleName** | **string** | Name of the role. Must be less than 4096 bytes. | 
-**approleMountPath** | **string** | Path that the backend was mounted at | [default to &quot;approle&quot;]
 
 ### Other Parameters
 
@@ -2619,7 +2583,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **roleName** | **string** | Name of the role. Must be less than 4096 bytes. | 
-**approleMountPath** | **string** | Path that the backend was mounted at | [default to &quot;approle&quot;]
 
 ### Other Parameters
 
@@ -2683,7 +2646,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **roleName** | **string** | Name of the role. Must be less than 4096 bytes. | 
-**approleMountPath** | **string** | Path that the backend was mounted at | [default to &quot;approle&quot;]
 
 ### Other Parameters
 
@@ -2744,7 +2706,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**approleMountPath** | **string** | Path that the backend was mounted at | [default to &quot;approle&quot;]
 
 ### Other Parameters
 
@@ -2810,7 +2771,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **roleName** | **string** | Name of the role. Must be less than 4096 bytes. | 
-**approleMountPath** | **string** | Path that the backend was mounted at | [default to &quot;approle&quot;]
 
 ### Other Parameters
 
@@ -2878,7 +2838,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **roleName** | **string** | Name of the role. Must be less than 4096 bytes. | 
-**approleMountPath** | **string** | Path that the backend was mounted at | [default to &quot;approle&quot;]
 
 ### Other Parameters
 
@@ -2946,7 +2905,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **roleName** | **string** | Name of the role. Must be less than 4096 bytes. | 
-**approleMountPath** | **string** | Path that the backend was mounted at | [default to &quot;approle&quot;]
 
 ### Other Parameters
 
@@ -3014,7 +2972,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **roleName** | **string** | Name of the role. Must be less than 4096 bytes. | 
-**approleMountPath** | **string** | Path that the backend was mounted at | [default to &quot;approle&quot;]
 
 ### Other Parameters
 
@@ -3082,7 +3039,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **roleName** | **string** | Name of the role. Must be less than 4096 bytes. | 
-**approleMountPath** | **string** | Path that the backend was mounted at | [default to &quot;approle&quot;]
 
 ### Other Parameters
 
@@ -3150,7 +3106,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **roleName** | **string** | Name of the role. Must be less than 4096 bytes. | 
-**approleMountPath** | **string** | Path that the backend was mounted at | [default to &quot;approle&quot;]
 
 ### Other Parameters
 
@@ -3218,7 +3173,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **roleName** | **string** | Name of the role. Must be less than 4096 bytes. | 
-**approleMountPath** | **string** | Path that the backend was mounted at | [default to &quot;approle&quot;]
 
 ### Other Parameters
 
@@ -3286,7 +3240,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **roleName** | **string** | Name of the role. Must be less than 4096 bytes. | 
-**approleMountPath** | **string** | Path that the backend was mounted at | [default to &quot;approle&quot;]
 
 ### Other Parameters
 
@@ -3354,7 +3307,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **roleName** | **string** | Name of the role. Must be less than 4096 bytes. | 
-**approleMountPath** | **string** | Path that the backend was mounted at | [default to &quot;approle&quot;]
 
 ### Other Parameters
 
@@ -3422,7 +3374,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **roleName** | **string** | Name of the role. Must be less than 4096 bytes. | 
-**approleMountPath** | **string** | Path that the backend was mounted at | [default to &quot;approle&quot;]
 
 ### Other Parameters
 
@@ -3490,7 +3441,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **roleName** | **string** | Name of the role. Must be less than 4096 bytes. | 
-**approleMountPath** | **string** | Path that the backend was mounted at | [default to &quot;approle&quot;]
 
 ### Other Parameters
 
@@ -3558,7 +3508,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **roleName** | **string** | Name of the role. Must be less than 4096 bytes. | 
-**approleMountPath** | **string** | Path that the backend was mounted at | [default to &quot;approle&quot;]
 
 ### Other Parameters
 
@@ -3626,7 +3575,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **roleName** | **string** | Name of the role. Must be less than 4096 bytes. | 
-**approleMountPath** | **string** | Path that the backend was mounted at | [default to &quot;approle&quot;]
 
 ### Other Parameters
 
@@ -3694,7 +3642,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **roleName** | **string** | Name of the role. Must be less than 4096 bytes. | 
-**approleMountPath** | **string** | Path that the backend was mounted at | [default to &quot;approle&quot;]
 
 ### Other Parameters
 
@@ -3762,7 +3709,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **roleName** | **string** | Name of the role. Must be less than 4096 bytes. | 
-**approleMountPath** | **string** | Path that the backend was mounted at | [default to &quot;approle&quot;]
 
 ### Other Parameters
 
@@ -3830,7 +3776,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **certName** | **string** | Name of the certificate. | 
-**awsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;aws&quot;]
 
 ### Other Parameters
 
@@ -3895,7 +3840,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**awsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;aws&quot;]
 
 ### Other Parameters
 
@@ -3959,7 +3903,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**awsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;aws&quot;]
 
 ### Other Parameters
 
@@ -4023,7 +3966,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**awsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;aws&quot;]
 
 ### Other Parameters
 
@@ -4087,7 +4029,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**awsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;aws&quot;]
 
 ### Other Parameters
 
@@ -4151,7 +4092,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**awsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;aws&quot;]
 
 ### Other Parameters
 
@@ -4215,7 +4155,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**awsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;aws&quot;]
 
 ### Other Parameters
 
@@ -4279,7 +4218,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **role** | **string** | Name of the role. | 
-**awsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;aws&quot;]
 
 ### Other Parameters
 
@@ -4343,7 +4281,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **certName** | **string** | Name of the certificate. | 
-**awsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;aws&quot;]
 
 ### Other Parameters
 
@@ -4404,7 +4341,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**awsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;aws&quot;]
 
 ### Other Parameters
 
@@ -4467,7 +4403,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **instanceId** | **string** | EC2 instance ID. A successful login operation from an EC2 instance gets cached in this accesslist, keyed off of instance ID. | 
-**awsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;aws&quot;]
 
 ### Other Parameters
 
@@ -4528,7 +4463,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**awsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;aws&quot;]
 
 ### Other Parameters
 
@@ -4591,7 +4525,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **instanceId** | **string** | EC2 instance ID. A successful login operation from an EC2 instance gets cached in this accesslist, keyed off of instance ID. | 
-**awsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;aws&quot;]
 
 ### Other Parameters
 
@@ -4652,7 +4585,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**awsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;aws&quot;]
 
 ### Other Parameters
 
@@ -4715,7 +4647,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **roleTag** | **string** | Role tag to be deny listed. The tag can be supplied as-is. In order to avoid any encoding problems, it can be base64 encoded. | 
-**awsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;aws&quot;]
 
 ### Other Parameters
 
@@ -4776,7 +4707,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**awsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;aws&quot;]
 
 ### Other Parameters
 
@@ -4839,7 +4769,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **roleTag** | **string** | Role tag to be deny listed. The tag can be supplied as-is. In order to avoid any encoding problems, it can be base64 encoded. | 
-**awsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;aws&quot;]
 
 ### Other Parameters
 
@@ -4900,7 +4829,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**awsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;aws&quot;]
 
 ### Other Parameters
 
@@ -4963,7 +4891,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **accountId** | **string** | AWS account ID to be associated with STS role. If set, Vault will use assumed credentials to verify any login attempts from EC2 instances in this account. | 
-**awsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;aws&quot;]
 
 ### Other Parameters
 
@@ -5024,7 +4951,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**awsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;aws&quot;]
 
 ### Other Parameters
 
@@ -5085,7 +5011,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**awsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;aws&quot;]
 
 ### Other Parameters
 
@@ -5146,7 +5071,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**awsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;aws&quot;]
 
 ### Other Parameters
 
@@ -5207,7 +5131,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**awsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;aws&quot;]
 
 ### Other Parameters
 
@@ -5268,7 +5191,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**awsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;aws&quot;]
 
 ### Other Parameters
 
@@ -5329,7 +5251,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**awsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;aws&quot;]
 
 ### Other Parameters
 
@@ -5390,7 +5311,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**awsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;aws&quot;]
 
 ### Other Parameters
 
@@ -5454,7 +5374,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**awsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;aws&quot;]
 
 ### Other Parameters
 
@@ -5518,7 +5437,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **role** | **string** | Name of the role. | 
-**awsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;aws&quot;]
 
 ### Other Parameters
 
@@ -5582,7 +5500,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **certName** | **string** | Name of the certificate. | 
-**awsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;aws&quot;]
 
 ### Other Parameters
 
@@ -5643,7 +5560,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**awsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;aws&quot;]
 
 ### Other Parameters
 
@@ -5706,7 +5622,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **instanceId** | **string** | EC2 instance ID. A successful login operation from an EC2 instance gets cached in this accesslist, keyed off of instance ID. | 
-**awsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;aws&quot;]
 
 ### Other Parameters
 
@@ -5767,7 +5682,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**awsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;aws&quot;]
 
 ### Other Parameters
 
@@ -5827,7 +5741,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**awsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;aws&quot;]
 
 ### Other Parameters
 
@@ -5890,7 +5803,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **instanceId** | **string** | EC2 instance ID. A successful login operation from an EC2 instance gets cached in this accesslist, keyed off of instance ID. | 
-**awsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;aws&quot;]
 
 ### Other Parameters
 
@@ -5951,7 +5863,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**awsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;aws&quot;]
 
 ### Other Parameters
 
@@ -6014,7 +5925,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **roleTag** | **string** | Role tag to be deny listed. The tag can be supplied as-is. In order to avoid any encoding problems, it can be base64 encoded. | 
-**awsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;aws&quot;]
 
 ### Other Parameters
 
@@ -6075,7 +5985,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**awsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;aws&quot;]
 
 ### Other Parameters
 
@@ -6138,7 +6047,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **roleTag** | **string** | Role tag to be deny listed. The tag can be supplied as-is. In order to avoid any encoding problems, it can be base64 encoded. | 
-**awsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;aws&quot;]
 
 ### Other Parameters
 
@@ -6199,7 +6107,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**awsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;aws&quot;]
 
 ### Other Parameters
 
@@ -6262,7 +6169,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **accountId** | **string** | AWS account ID to be associated with STS role. If set, Vault will use assumed credentials to verify any login attempts from EC2 instances in this account. | 
-**awsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;aws&quot;]
 
 ### Other Parameters
 
@@ -6323,7 +6229,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**awsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;aws&quot;]
 
 ### Other Parameters
 
@@ -6386,7 +6291,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**awsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;aws&quot;]
 
 ### Other Parameters
 
@@ -6450,7 +6354,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**awsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;aws&quot;]
 
 ### Other Parameters
 
@@ -6514,7 +6417,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**awsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;aws&quot;]
 
 ### Other Parameters
 
@@ -6578,7 +6480,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**awsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;aws&quot;]
 
 ### Other Parameters
 
@@ -6645,7 +6546,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **role** | **string** | Name of the role. | 
-**awsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;aws&quot;]
 
 ### Other Parameters
 
@@ -6713,7 +6613,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **role** | **string** | Name of the role. | 
-**awsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;aws&quot;]
 
 ### Other Parameters
 
@@ -6778,7 +6677,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **roleTag** | **string** | Role tag to be deny listed. The tag can be supplied as-is. In order to avoid any encoding problems, it can be base64 encoded. | 
-**awsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;aws&quot;]
 
 ### Other Parameters
 
@@ -6842,7 +6740,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **roleTag** | **string** | Role tag to be deny listed. The tag can be supplied as-is. In order to avoid any encoding problems, it can be base64 encoded. | 
-**awsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;aws&quot;]
 
 ### Other Parameters
 
@@ -6909,7 +6806,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **accountId** | **string** | AWS account ID to be associated with STS role. If set, Vault will use assumed credentials to verify any login attempts from EC2 instances in this account. | 
-**awsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;aws&quot;]
 
 ### Other Parameters
 
@@ -6974,7 +6870,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**azureMountPath** | **string** | Path that the backend was mounted at | [default to &quot;azure&quot;]
 
 ### Other Parameters
 
@@ -7035,7 +6930,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**azureMountPath** | **string** | Path that the backend was mounted at | [default to &quot;azure&quot;]
 
 ### Other Parameters
 
@@ -7098,7 +6992,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the role. | 
-**azureMountPath** | **string** | Path that the backend was mounted at | [default to &quot;azure&quot;]
 
 ### Other Parameters
 
@@ -7159,7 +7052,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**azureMountPath** | **string** | Path that the backend was mounted at | [default to &quot;azure&quot;]
 
 ### Other Parameters
 
@@ -7223,7 +7115,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**azureMountPath** | **string** | Path that the backend was mounted at | [default to &quot;azure&quot;]
 
 ### Other Parameters
 
@@ -7284,7 +7175,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**azureMountPath** | **string** | Path that the backend was mounted at | [default to &quot;azure&quot;]
 
 ### Other Parameters
 
@@ -7347,7 +7237,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the role. | 
-**azureMountPath** | **string** | Path that the backend was mounted at | [default to &quot;azure&quot;]
 
 ### Other Parameters
 
@@ -7408,7 +7297,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**azureMountPath** | **string** | Path that the backend was mounted at | [default to &quot;azure&quot;]
 
 ### Other Parameters
 
@@ -7474,7 +7362,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the role. | 
-**azureMountPath** | **string** | Path that the backend was mounted at | [default to &quot;azure&quot;]
 
 ### Other Parameters
 
@@ -7539,7 +7426,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**centrifyMountPath** | **string** | Path that the backend was mounted at | [default to &quot;centrify&quot;]
 
 ### Other Parameters
 
@@ -7603,7 +7489,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**centrifyMountPath** | **string** | Path that the backend was mounted at | [default to &quot;centrify&quot;]
 
 ### Other Parameters
 
@@ -7664,7 +7549,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**centrifyMountPath** | **string** | Path that the backend was mounted at | [default to &quot;centrify&quot;]
 
 ### Other Parameters
 
@@ -7727,7 +7611,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**certMountPath** | **string** | Path that the backend was mounted at | [default to &quot;cert&quot;]
 
 ### Other Parameters
 
@@ -7791,7 +7674,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | The name of the certificate | 
-**certMountPath** | **string** | Path that the backend was mounted at | [default to &quot;cert&quot;]
 
 ### Other Parameters
 
@@ -7855,7 +7737,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | The name of the certificate | 
-**certMountPath** | **string** | Path that the backend was mounted at | [default to &quot;cert&quot;]
 
 ### Other Parameters
 
@@ -7916,7 +7797,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**certMountPath** | **string** | Path that the backend was mounted at | [default to &quot;cert&quot;]
 
 ### Other Parameters
 
@@ -7977,7 +7857,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**certMountPath** | **string** | Path that the backend was mounted at | [default to &quot;cert&quot;]
 
 ### Other Parameters
 
@@ -8041,7 +7920,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**certMountPath** | **string** | Path that the backend was mounted at | [default to &quot;cert&quot;]
 
 ### Other Parameters
 
@@ -8105,7 +7983,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | The name of the certificate | 
-**certMountPath** | **string** | Path that the backend was mounted at | [default to &quot;cert&quot;]
 
 ### Other Parameters
 
@@ -8166,7 +8043,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**certMountPath** | **string** | Path that the backend was mounted at | [default to &quot;cert&quot;]
 
 ### Other Parameters
 
@@ -8229,7 +8105,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | The name of the certificate | 
-**certMountPath** | **string** | Path that the backend was mounted at | [default to &quot;cert&quot;]
 
 ### Other Parameters
 
@@ -8296,7 +8171,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | The name of the certificate | 
-**certMountPath** | **string** | Path that the backend was mounted at | [default to &quot;cert&quot;]
 
 ### Other Parameters
 
@@ -8364,7 +8238,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | The name of the certificate | 
-**certMountPath** | **string** | Path that the backend was mounted at | [default to &quot;cert&quot;]
 
 ### Other Parameters
 
@@ -8429,7 +8302,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**cfMountPath** | **string** | Path that the backend was mounted at | [default to &quot;cf&quot;]
 
 ### Other Parameters
 
@@ -8490,7 +8362,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**cfMountPath** | **string** | Path that the backend was mounted at | [default to &quot;cf&quot;]
 
 ### Other Parameters
 
@@ -8553,7 +8424,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **role** | **string** | The name of the role. | 
-**cfMountPath** | **string** | Path that the backend was mounted at | [default to &quot;cf&quot;]
 
 ### Other Parameters
 
@@ -8614,7 +8484,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**cfMountPath** | **string** | Path that the backend was mounted at | [default to &quot;cf&quot;]
 
 ### Other Parameters
 
@@ -8678,7 +8547,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**cfMountPath** | **string** | Path that the backend was mounted at | [default to &quot;cf&quot;]
 
 ### Other Parameters
 
@@ -8739,7 +8607,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**cfMountPath** | **string** | Path that the backend was mounted at | [default to &quot;cf&quot;]
 
 ### Other Parameters
 
@@ -8802,7 +8669,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **role** | **string** | The name of the role. | 
-**cfMountPath** | **string** | Path that the backend was mounted at | [default to &quot;cf&quot;]
 
 ### Other Parameters
 
@@ -8869,7 +8735,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **role** | **string** | The name of the role. | 
-**cfMountPath** | **string** | Path that the backend was mounted at | [default to &quot;cf&quot;]
 
 ### Other Parameters
 
@@ -8934,7 +8799,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**githubMountPath** | **string** | Path that the backend was mounted at | [default to &quot;github&quot;]
 
 ### Other Parameters
 
@@ -8998,7 +8862,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **key** | **string** | Key for the teams mapping | 
-**githubMountPath** | **string** | Path that the backend was mounted at | [default to &quot;github&quot;]
 
 ### Other Parameters
 
@@ -9062,7 +8925,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **key** | **string** | Key for the users mapping | 
-**githubMountPath** | **string** | Path that the backend was mounted at | [default to &quot;github&quot;]
 
 ### Other Parameters
 
@@ -9126,7 +8988,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**githubMountPath** | **string** | Path that the backend was mounted at | [default to &quot;github&quot;]
 
 ### Other Parameters
 
@@ -9187,7 +9048,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**githubMountPath** | **string** | Path that the backend was mounted at | [default to &quot;github&quot;]
 
 ### Other Parameters
 
@@ -9250,7 +9110,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **key** | **string** | Key for the teams mapping | 
-**githubMountPath** | **string** | Path that the backend was mounted at | [default to &quot;github&quot;]
 
 ### Other Parameters
 
@@ -9311,7 +9170,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**githubMountPath** | **string** | Path that the backend was mounted at | [default to &quot;github&quot;]
 
 ### Other Parameters
 
@@ -9375,7 +9233,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **key** | **string** | Key for the users mapping | 
-**githubMountPath** | **string** | Path that the backend was mounted at | [default to &quot;github&quot;]
 
 ### Other Parameters
 
@@ -9436,7 +9293,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**githubMountPath** | **string** | Path that the backend was mounted at | [default to &quot;github&quot;]
 
 ### Other Parameters
 
@@ -9503,7 +9359,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **key** | **string** | Key for the teams mapping | 
-**githubMountPath** | **string** | Path that the backend was mounted at | [default to &quot;github&quot;]
 
 ### Other Parameters
 
@@ -9571,7 +9426,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **key** | **string** | Key for the users mapping | 
-**githubMountPath** | **string** | Path that the backend was mounted at | [default to &quot;github&quot;]
 
 ### Other Parameters
 
@@ -9636,7 +9490,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**gcpMountPath** | **string** | Path that the backend was mounted at | [default to &quot;gcp&quot;]
 
 ### Other Parameters
 
@@ -9700,7 +9553,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the role. | 
-**gcpMountPath** | **string** | Path that the backend was mounted at | [default to &quot;gcp&quot;]
 
 ### Other Parameters
 
@@ -9767,7 +9619,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the role. | 
-**gcpMountPath** | **string** | Path that the backend was mounted at | [default to &quot;gcp&quot;]
 
 ### Other Parameters
 
@@ -9835,7 +9686,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the role. | 
-**gcpMountPath** | **string** | Path that the backend was mounted at | [default to &quot;gcp&quot;]
 
 ### Other Parameters
 
@@ -9897,7 +9747,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**gcpMountPath** | **string** | Path that the backend was mounted at | [default to &quot;gcp&quot;]
 
 ### Other Parameters
 
@@ -9961,7 +9810,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**gcpMountPath** | **string** | Path that the backend was mounted at | [default to &quot;gcp&quot;]
 
 ### Other Parameters
 
@@ -10022,7 +9870,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**gcpMountPath** | **string** | Path that the backend was mounted at | [default to &quot;gcp&quot;]
 
 ### Other Parameters
 
@@ -10085,7 +9932,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the role. | 
-**gcpMountPath** | **string** | Path that the backend was mounted at | [default to &quot;gcp&quot;]
 
 ### Other Parameters
 
@@ -10152,7 +9998,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the role. | 
-**gcpMountPath** | **string** | Path that the backend was mounted at | [default to &quot;gcp&quot;]
 
 ### Other Parameters
 
@@ -10219,7 +10064,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**jwtMountPath** | **string** | Path that the backend was mounted at | [default to &quot;jwt&quot;]
 
 ### Other Parameters
 
@@ -10283,7 +10127,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the role. | 
-**jwtMountPath** | **string** | Path that the backend was mounted at | [default to &quot;jwt&quot;]
 
 ### Other Parameters
 
@@ -10346,7 +10189,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**jwtMountPath** | **string** | Path that the backend was mounted at | [default to &quot;jwt&quot;]
 
 ### Other Parameters
 
@@ -10410,7 +10252,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**jwtMountPath** | **string** | Path that the backend was mounted at | [default to &quot;jwt&quot;]
 
 ### Other Parameters
 
@@ -10471,7 +10312,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**jwtMountPath** | **string** | Path that the backend was mounted at | [default to &quot;jwt&quot;]
 
 ### Other Parameters
 
@@ -10534,7 +10374,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**jwtMountPath** | **string** | Path that the backend was mounted at | [default to &quot;jwt&quot;]
 
 ### Other Parameters
 
@@ -10598,7 +10437,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**jwtMountPath** | **string** | Path that the backend was mounted at | [default to &quot;jwt&quot;]
 
 ### Other Parameters
 
@@ -10659,7 +10497,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**jwtMountPath** | **string** | Path that the backend was mounted at | [default to &quot;jwt&quot;]
 
 ### Other Parameters
 
@@ -10722,7 +10559,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the role. | 
-**jwtMountPath** | **string** | Path that the backend was mounted at | [default to &quot;jwt&quot;]
 
 ### Other Parameters
 
@@ -10791,7 +10627,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the role. | 
-**jwtMountPath** | **string** | Path that the backend was mounted at | [default to &quot;jwt&quot;]
 
 ### Other Parameters
 
@@ -10856,7 +10691,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**kerberosMountPath** | **string** | Path that the backend was mounted at | [default to &quot;kerberos&quot;]
 
 ### Other Parameters
 
@@ -10920,7 +10754,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**kerberosMountPath** | **string** | Path that the backend was mounted at | [default to &quot;kerberos&quot;]
 
 ### Other Parameters
 
@@ -10984,7 +10817,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the LDAP group. | 
-**kerberosMountPath** | **string** | Path that the backend was mounted at | [default to &quot;kerberos&quot;]
 
 ### Other Parameters
 
@@ -11045,7 +10877,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**kerberosMountPath** | **string** | Path that the backend was mounted at | [default to &quot;kerberos&quot;]
 
 ### Other Parameters
 
@@ -11109,7 +10940,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**kerberosMountPath** | **string** | Path that the backend was mounted at | [default to &quot;kerberos&quot;]
 
 ### Other Parameters
 
@@ -11170,7 +11000,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**kerberosMountPath** | **string** | Path that the backend was mounted at | [default to &quot;kerberos&quot;]
 
 ### Other Parameters
 
@@ -11233,7 +11062,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the LDAP group. | 
-**kerberosMountPath** | **string** | Path that the backend was mounted at | [default to &quot;kerberos&quot;]
 
 ### Other Parameters
 
@@ -11294,7 +11122,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**kerberosMountPath** | **string** | Path that the backend was mounted at | [default to &quot;kerberos&quot;]
 
 ### Other Parameters
 
@@ -11360,7 +11187,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the LDAP group. | 
-**kerberosMountPath** | **string** | Path that the backend was mounted at | [default to &quot;kerberos&quot;]
 
 ### Other Parameters
 
@@ -11425,7 +11251,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**kubernetesMountPath** | **string** | Path that the backend was mounted at | [default to &quot;kubernetes&quot;]
 
 ### Other Parameters
 
@@ -11489,7 +11314,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the role. | 
-**kubernetesMountPath** | **string** | Path that the backend was mounted at | [default to &quot;kubernetes&quot;]
 
 ### Other Parameters
 
@@ -11550,7 +11374,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**kubernetesMountPath** | **string** | Path that the backend was mounted at | [default to &quot;kubernetes&quot;]
 
 ### Other Parameters
 
@@ -11614,7 +11437,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**kubernetesMountPath** | **string** | Path that the backend was mounted at | [default to &quot;kubernetes&quot;]
 
 ### Other Parameters
 
@@ -11675,7 +11497,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**kubernetesMountPath** | **string** | Path that the backend was mounted at | [default to &quot;kubernetes&quot;]
 
 ### Other Parameters
 
@@ -11738,7 +11559,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the role. | 
-**kubernetesMountPath** | **string** | Path that the backend was mounted at | [default to &quot;kubernetes&quot;]
 
 ### Other Parameters
 
@@ -11805,7 +11625,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the role. | 
-**kubernetesMountPath** | **string** | Path that the backend was mounted at | [default to &quot;kubernetes&quot;]
 
 ### Other Parameters
 
@@ -11870,7 +11689,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**ldapMountPath** | **string** | Path that the backend was mounted at | [default to &quot;ldap&quot;]
 
 ### Other Parameters
 
@@ -11934,7 +11752,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the LDAP group. | 
-**ldapMountPath** | **string** | Path that the backend was mounted at | [default to &quot;ldap&quot;]
 
 ### Other Parameters
 
@@ -11998,7 +11815,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the LDAP user. | 
-**ldapMountPath** | **string** | Path that the backend was mounted at | [default to &quot;ldap&quot;]
 
 ### Other Parameters
 
@@ -12059,7 +11875,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**ldapMountPath** | **string** | Path that the backend was mounted at | [default to &quot;ldap&quot;]
 
 ### Other Parameters
 
@@ -12120,7 +11935,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**ldapMountPath** | **string** | Path that the backend was mounted at | [default to &quot;ldap&quot;]
 
 ### Other Parameters
 
@@ -12187,7 +12001,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **username** | **string** | DN (distinguished name) to be used for login. | 
-**ldapMountPath** | **string** | Path that the backend was mounted at | [default to &quot;ldap&quot;]
 
 ### Other Parameters
 
@@ -12249,7 +12062,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**ldapMountPath** | **string** | Path that the backend was mounted at | [default to &quot;ldap&quot;]
 
 ### Other Parameters
 
@@ -12312,7 +12124,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the LDAP group. | 
-**ldapMountPath** | **string** | Path that the backend was mounted at | [default to &quot;ldap&quot;]
 
 ### Other Parameters
 
@@ -12376,7 +12187,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the LDAP user. | 
-**ldapMountPath** | **string** | Path that the backend was mounted at | [default to &quot;ldap&quot;]
 
 ### Other Parameters
 
@@ -12443,7 +12253,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the LDAP group. | 
-**ldapMountPath** | **string** | Path that the backend was mounted at | [default to &quot;ldap&quot;]
 
 ### Other Parameters
 
@@ -12511,7 +12320,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the LDAP user. | 
-**ldapMountPath** | **string** | Path that the backend was mounted at | [default to &quot;ldap&quot;]
 
 ### Other Parameters
 
@@ -12576,7 +12384,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**ociMountPath** | **string** | Path that the backend was mounted at | [default to &quot;oci&quot;]
 
 ### Other Parameters
 
@@ -12637,7 +12444,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**ociMountPath** | **string** | Path that the backend was mounted at | [default to &quot;oci&quot;]
 
 ### Other Parameters
 
@@ -12700,7 +12506,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **role** | **string** | Name of the role. | 
-**ociMountPath** | **string** | Path that the backend was mounted at | [default to &quot;oci&quot;]
 
 ### Other Parameters
 
@@ -12761,7 +12566,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**ociMountPath** | **string** | Path that the backend was mounted at | [default to &quot;oci&quot;]
 
 ### Other Parameters
 
@@ -12828,7 +12632,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **role** | **string** | Name of the role. | 
-**ociMountPath** | **string** | Path that the backend was mounted at | [default to &quot;oci&quot;]
 
 ### Other Parameters
 
@@ -12890,7 +12693,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**ociMountPath** | **string** | Path that the backend was mounted at | [default to &quot;oci&quot;]
 
 ### Other Parameters
 
@@ -12953,7 +12755,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **role** | **string** | Name of the role. | 
-**ociMountPath** | **string** | Path that the backend was mounted at | [default to &quot;oci&quot;]
 
 ### Other Parameters
 
@@ -13020,7 +12821,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **role** | **string** | Name of the role. | 
-**ociMountPath** | **string** | Path that the backend was mounted at | [default to &quot;oci&quot;]
 
 ### Other Parameters
 
@@ -13085,7 +12885,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**oktaMountPath** | **string** | Path that the backend was mounted at | [default to &quot;okta&quot;]
 
 ### Other Parameters
 
@@ -13149,7 +12948,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the Okta group. | 
-**oktaMountPath** | **string** | Path that the backend was mounted at | [default to &quot;okta&quot;]
 
 ### Other Parameters
 
@@ -13213,7 +13011,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the user. | 
-**oktaMountPath** | **string** | Path that the backend was mounted at | [default to &quot;okta&quot;]
 
 ### Other Parameters
 
@@ -13274,7 +13071,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**oktaMountPath** | **string** | Path that the backend was mounted at | [default to &quot;okta&quot;]
 
 ### Other Parameters
 
@@ -13335,7 +13131,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**oktaMountPath** | **string** | Path that the backend was mounted at | [default to &quot;okta&quot;]
 
 ### Other Parameters
 
@@ -13402,7 +13197,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **username** | **string** | Username to be used for login. | 
-**oktaMountPath** | **string** | Path that the backend was mounted at | [default to &quot;okta&quot;]
 
 ### Other Parameters
 
@@ -13464,7 +13258,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**oktaMountPath** | **string** | Path that the backend was mounted at | [default to &quot;okta&quot;]
 
 ### Other Parameters
 
@@ -13527,7 +13320,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the Okta group. | 
-**oktaMountPath** | **string** | Path that the backend was mounted at | [default to &quot;okta&quot;]
 
 ### Other Parameters
 
@@ -13591,7 +13383,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the user. | 
-**oktaMountPath** | **string** | Path that the backend was mounted at | [default to &quot;okta&quot;]
 
 ### Other Parameters
 
@@ -13655,7 +13446,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **nonce** | **string** | Nonce provided during a login request to retrieve the number verification challenge for the matching request. | 
-**oktaMountPath** | **string** | Path that the backend was mounted at | [default to &quot;okta&quot;]
 
 ### Other Parameters
 
@@ -13722,7 +13512,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the Okta group. | 
-**oktaMountPath** | **string** | Path that the backend was mounted at | [default to &quot;okta&quot;]
 
 ### Other Parameters
 
@@ -13790,7 +13579,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the user. | 
-**oktaMountPath** | **string** | Path that the backend was mounted at | [default to &quot;okta&quot;]
 
 ### Other Parameters
 
@@ -13855,7 +13643,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**radiusMountPath** | **string** | Path that the backend was mounted at | [default to &quot;radius&quot;]
 
 ### Other Parameters
 
@@ -13919,7 +13706,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the RADIUS user. | 
-**radiusMountPath** | **string** | Path that the backend was mounted at | [default to &quot;radius&quot;]
 
 ### Other Parameters
 
@@ -13980,7 +13766,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**radiusMountPath** | **string** | Path that the backend was mounted at | [default to &quot;radius&quot;]
 
 ### Other Parameters
 
@@ -14044,7 +13829,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**radiusMountPath** | **string** | Path that the backend was mounted at | [default to &quot;radius&quot;]
 
 ### Other Parameters
 
@@ -14111,7 +13895,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **urlusername** | **string** | Username to be used for login. (URL parameter) | 
-**radiusMountPath** | **string** | Path that the backend was mounted at | [default to &quot;radius&quot;]
 
 ### Other Parameters
 
@@ -14173,7 +13956,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**radiusMountPath** | **string** | Path that the backend was mounted at | [default to &quot;radius&quot;]
 
 ### Other Parameters
 
@@ -14236,7 +14018,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the RADIUS user. | 
-**radiusMountPath** | **string** | Path that the backend was mounted at | [default to &quot;radius&quot;]
 
 ### Other Parameters
 
@@ -14303,7 +14084,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the RADIUS user. | 
-**radiusMountPath** | **string** | Path that the backend was mounted at | [default to &quot;radius&quot;]
 
 ### Other Parameters
 
@@ -15475,7 +15255,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **username** | **string** | Username for this user. | 
-**userpassMountPath** | **string** | Path that the backend was mounted at | [default to &quot;userpass&quot;]
 
 ### Other Parameters
 
@@ -15536,7 +15315,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**userpassMountPath** | **string** | Path that the backend was mounted at | [default to &quot;userpass&quot;]
 
 ### Other Parameters
 
@@ -15603,7 +15381,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **username** | **string** | Username of the user. | 
-**userpassMountPath** | **string** | Path that the backend was mounted at | [default to &quot;userpass&quot;]
 
 ### Other Parameters
 
@@ -15668,7 +15445,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **username** | **string** | Username for this user. | 
-**userpassMountPath** | **string** | Path that the backend was mounted at | [default to &quot;userpass&quot;]
 
 ### Other Parameters
 
@@ -15735,7 +15511,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **username** | **string** | Username for this user. | 
-**userpassMountPath** | **string** | Path that the backend was mounted at | [default to &quot;userpass&quot;]
 
 ### Other Parameters
 
@@ -15803,7 +15578,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **username** | **string** | Username for this user. | 
-**userpassMountPath** | **string** | Path that the backend was mounted at | [default to &quot;userpass&quot;]
 
 ### Other Parameters
 
@@ -15871,7 +15645,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **username** | **string** | Username for this user. | 
-**userpassMountPath** | **string** | Path that the backend was mounted at | [default to &quot;userpass&quot;]
 
 ### Other Parameters
 

--- a/docs/SecretsApi.md
+++ b/docs/SecretsApi.md
@@ -383,7 +383,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**alicloudMountPath** | **string** | Path that the backend was mounted at | [default to &quot;alicloud&quot;]
 
 ### Other Parameters
 
@@ -444,7 +443,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**alicloudMountPath** | **string** | Path that the backend was mounted at | [default to &quot;alicloud&quot;]
 
 ### Other Parameters
 
@@ -507,7 +505,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | The name of the role. | 
-**alicloudMountPath** | **string** | Path that the backend was mounted at | [default to &quot;alicloud&quot;]
 
 ### Other Parameters
 
@@ -571,7 +568,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | The name of the role. | 
-**alicloudMountPath** | **string** | Path that the backend was mounted at | [default to &quot;alicloud&quot;]
 
 ### Other Parameters
 
@@ -632,7 +628,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**alicloudMountPath** | **string** | Path that the backend was mounted at | [default to &quot;alicloud&quot;]
 
 ### Other Parameters
 
@@ -693,7 +688,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**alicloudMountPath** | **string** | Path that the backend was mounted at | [default to &quot;alicloud&quot;]
 
 ### Other Parameters
 
@@ -756,7 +750,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | The name of the role. | 
-**alicloudMountPath** | **string** | Path that the backend was mounted at | [default to &quot;alicloud&quot;]
 
 ### Other Parameters
 
@@ -823,7 +816,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | The name of the role. | 
-**alicloudMountPath** | **string** | Path that the backend was mounted at | [default to &quot;alicloud&quot;]
 
 ### Other Parameters
 
@@ -888,7 +880,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**awsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;aws&quot;]
 
 ### Other Parameters
 
@@ -952,7 +943,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**awsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;aws&quot;]
 
 ### Other Parameters
 
@@ -1016,7 +1006,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the policy | 
-**awsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;aws&quot;]
 
 ### Other Parameters
 
@@ -1080,7 +1069,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the role | 
-**awsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;aws&quot;]
 
 ### Other Parameters
 
@@ -1144,7 +1132,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the role | 
-**awsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;aws&quot;]
 
 ### Other Parameters
 
@@ -1205,7 +1192,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**awsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;aws&quot;]
 
 ### Other Parameters
 
@@ -1266,7 +1252,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**awsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;aws&quot;]
 
 ### Other Parameters
 
@@ -1329,7 +1314,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the policy | 
-**awsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;aws&quot;]
 
 ### Other Parameters
 
@@ -1390,7 +1374,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**awsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;aws&quot;]
 
 ### Other Parameters
 
@@ -1450,7 +1433,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**awsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;aws&quot;]
 
 ### Other Parameters
 
@@ -1516,7 +1498,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the policy | 
-**awsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;aws&quot;]
 
 ### Other Parameters
 
@@ -1581,7 +1562,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**azureMountPath** | **string** | Path that the backend was mounted at | [default to &quot;azure&quot;]
 
 ### Other Parameters
 
@@ -1642,7 +1622,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**azureMountPath** | **string** | Path that the backend was mounted at | [default to &quot;azure&quot;]
 
 ### Other Parameters
 
@@ -1705,7 +1684,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the role. | 
-**azureMountPath** | **string** | Path that the backend was mounted at | [default to &quot;azure&quot;]
 
 ### Other Parameters
 
@@ -1766,7 +1744,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**azureMountPath** | **string** | Path that the backend was mounted at | [default to &quot;azure&quot;]
 
 ### Other Parameters
 
@@ -1827,7 +1804,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**azureMountPath** | **string** | Path that the backend was mounted at | [default to &quot;azure&quot;]
 
 ### Other Parameters
 
@@ -1890,7 +1866,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the role. | 
-**azureMountPath** | **string** | Path that the backend was mounted at | [default to &quot;azure&quot;]
 
 ### Other Parameters
 
@@ -1954,7 +1929,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **role** | **string** | Name of the Vault role | 
-**azureMountPath** | **string** | Path that the backend was mounted at | [default to &quot;azure&quot;]
 
 ### Other Parameters
 
@@ -2015,7 +1989,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**azureMountPath** | **string** | Path that the backend was mounted at | [default to &quot;azure&quot;]
 
 ### Other Parameters
 
@@ -2081,7 +2054,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the role. | 
-**azureMountPath** | **string** | Path that the backend was mounted at | [default to &quot;azure&quot;]
 
 ### Other Parameters
 
@@ -2146,7 +2118,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**consulMountPath** | **string** | Path that the backend was mounted at | [default to &quot;consul&quot;]
 
 ### Other Parameters
 
@@ -2210,7 +2181,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the role. | 
-**consulMountPath** | **string** | Path that the backend was mounted at | [default to &quot;consul&quot;]
 
 ### Other Parameters
 
@@ -2274,7 +2244,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **role** | **string** | Name of the role. | 
-**consulMountPath** | **string** | Path that the backend was mounted at | [default to &quot;consul&quot;]
 
 ### Other Parameters
 
@@ -2335,7 +2304,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**consulMountPath** | **string** | Path that the backend was mounted at | [default to &quot;consul&quot;]
 
 ### Other Parameters
 
@@ -2396,7 +2364,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**consulMountPath** | **string** | Path that the backend was mounted at | [default to &quot;consul&quot;]
 
 ### Other Parameters
 
@@ -2459,7 +2426,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the role. | 
-**consulMountPath** | **string** | Path that the backend was mounted at | [default to &quot;consul&quot;]
 
 ### Other Parameters
 
@@ -2526,7 +2492,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the role. | 
-**consulMountPath** | **string** | Path that the backend was mounted at | [default to &quot;consul&quot;]
 
 ### Other Parameters
 
@@ -2778,7 +2743,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of this database connection | 
-**databaseMountPath** | **string** | Path that the backend was mounted at | [default to &quot;database&quot;]
 
 ### Other Parameters
 
@@ -2843,7 +2807,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of this database connection | 
-**databaseMountPath** | **string** | Path that the backend was mounted at | [default to &quot;database&quot;]
 
 ### Other Parameters
 
@@ -2907,7 +2870,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the role. | 
-**databaseMountPath** | **string** | Path that the backend was mounted at | [default to &quot;database&quot;]
 
 ### Other Parameters
 
@@ -2971,7 +2933,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the role. | 
-**databaseMountPath** | **string** | Path that the backend was mounted at | [default to &quot;database&quot;]
 
 ### Other Parameters
 
@@ -3035,7 +2996,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the role. | 
-**databaseMountPath** | **string** | Path that the backend was mounted at | [default to &quot;database&quot;]
 
 ### Other Parameters
 
@@ -3096,7 +3056,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**databaseMountPath** | **string** | Path that the backend was mounted at | [default to &quot;database&quot;]
 
 ### Other Parameters
 
@@ -3157,7 +3116,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**databaseMountPath** | **string** | Path that the backend was mounted at | [default to &quot;database&quot;]
 
 ### Other Parameters
 
@@ -3218,7 +3176,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**databaseMountPath** | **string** | Path that the backend was mounted at | [default to &quot;database&quot;]
 
 ### Other Parameters
 
@@ -3282,7 +3239,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of this database connection | 
-**databaseMountPath** | **string** | Path that the backend was mounted at | [default to &quot;database&quot;]
 
 ### Other Parameters
 
@@ -3346,7 +3302,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the role. | 
-**databaseMountPath** | **string** | Path that the backend was mounted at | [default to &quot;database&quot;]
 
 ### Other Parameters
 
@@ -3410,7 +3365,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the role. | 
-**databaseMountPath** | **string** | Path that the backend was mounted at | [default to &quot;database&quot;]
 
 ### Other Parameters
 
@@ -3474,7 +3428,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the static role. | 
-**databaseMountPath** | **string** | Path that the backend was mounted at | [default to &quot;database&quot;]
 
 ### Other Parameters
 
@@ -3538,7 +3491,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of this database connection | 
-**databaseMountPath** | **string** | Path that the backend was mounted at | [default to &quot;database&quot;]
 
 ### Other Parameters
 
@@ -3602,7 +3554,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of this database connection | 
-**databaseMountPath** | **string** | Path that the backend was mounted at | [default to &quot;database&quot;]
 
 ### Other Parameters
 
@@ -3666,7 +3617,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the static role | 
-**databaseMountPath** | **string** | Path that the backend was mounted at | [default to &quot;database&quot;]
 
 ### Other Parameters
 
@@ -3733,7 +3683,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the role. | 
-**databaseMountPath** | **string** | Path that the backend was mounted at | [default to &quot;database&quot;]
 
 ### Other Parameters
 
@@ -3801,7 +3750,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the role. | 
-**databaseMountPath** | **string** | Path that the backend was mounted at | [default to &quot;database&quot;]
 
 ### Other Parameters
 
@@ -3866,7 +3814,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**gcpMountPath** | **string** | Path that the backend was mounted at | [default to &quot;gcp&quot;]
 
 ### Other Parameters
 
@@ -3930,7 +3877,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Required. Name to refer to this impersonated account in Vault. Cannot be updated. | 
-**gcpMountPath** | **string** | Path that the backend was mounted at | [default to &quot;gcp&quot;]
 
 ### Other Parameters
 
@@ -3994,7 +3940,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Required. Name of the role. | 
-**gcpMountPath** | **string** | Path that the backend was mounted at | [default to &quot;gcp&quot;]
 
 ### Other Parameters
 
@@ -4058,7 +4003,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Required. Name to refer to this static account in Vault. Cannot be updated. | 
-**gcpMountPath** | **string** | Path that the backend was mounted at | [default to &quot;gcp&quot;]
 
 ### Other Parameters
 
@@ -4122,7 +4066,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Required. Name of the impersonated account. | 
-**gcpMountPath** | **string** | Path that the backend was mounted at | [default to &quot;gcp&quot;]
 
 ### Other Parameters
 
@@ -4186,7 +4129,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **roleset** | **string** | Required. Name of the role set. | 
-**gcpMountPath** | **string** | Path that the backend was mounted at | [default to &quot;gcp&quot;]
 
 ### Other Parameters
 
@@ -4250,7 +4192,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **roleset** | **string** | Required. Name of the role set. | 
-**gcpMountPath** | **string** | Path that the backend was mounted at | [default to &quot;gcp&quot;]
 
 ### Other Parameters
 
@@ -4314,7 +4255,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **roleset** | **string** | Required. Name of the role set. | 
-**gcpMountPath** | **string** | Path that the backend was mounted at | [default to &quot;gcp&quot;]
 
 ### Other Parameters
 
@@ -4381,7 +4321,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **roleset** | **string** | Required. Name of the role set. | 
-**gcpMountPath** | **string** | Path that the backend was mounted at | [default to &quot;gcp&quot;]
 
 ### Other Parameters
 
@@ -4446,7 +4385,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Required. Name of the static account. | 
-**gcpMountPath** | **string** | Path that the backend was mounted at | [default to &quot;gcp&quot;]
 
 ### Other Parameters
 
@@ -4510,7 +4448,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Required. Name of the static account. | 
-**gcpMountPath** | **string** | Path that the backend was mounted at | [default to &quot;gcp&quot;]
 
 ### Other Parameters
 
@@ -4574,7 +4511,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Required. Name of the static account. | 
-**gcpMountPath** | **string** | Path that the backend was mounted at | [default to &quot;gcp&quot;]
 
 ### Other Parameters
 
@@ -4641,7 +4577,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Required. Name of the static account. | 
-**gcpMountPath** | **string** | Path that the backend was mounted at | [default to &quot;gcp&quot;]
 
 ### Other Parameters
 
@@ -4706,7 +4641,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**gcpkmsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;gcpkms&quot;]
 
 ### Other Parameters
 
@@ -4773,7 +4707,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **key** | **string** | Name of the key in Vault. | 
-**gcpkmsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;gcpkms&quot;]
 
 ### Other Parameters
 
@@ -4841,7 +4774,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **key** | **string** | Name of the key in Vault to use for decryption. This key must already exist in Vault and must map back to a Google Cloud KMS key. | 
-**gcpkmsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;gcpkms&quot;]
 
 ### Other Parameters
 
@@ -4903,7 +4835,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**gcpkmsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;gcpkms&quot;]
 
 ### Other Parameters
 
@@ -4966,7 +4897,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **key** | **string** | Name of the key in Vault. | 
-**gcpkmsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;gcpkms&quot;]
 
 ### Other Parameters
 
@@ -5030,7 +4960,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **key** | **string** | Name of the key to deregister in Vault. If the key exists in Google Cloud KMS, it will be left untouched. | 
-**gcpkmsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;gcpkms&quot;]
 
 ### Other Parameters
 
@@ -5097,7 +5026,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **key** | **string** | Name of the key in Vault to use for encryption. This key must already exist in Vault and must map back to a Google Cloud KMS key. | 
-**gcpkmsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;gcpkms&quot;]
 
 ### Other Parameters
 
@@ -5159,7 +5087,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**gcpkmsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;gcpkms&quot;]
 
 ### Other Parameters
 
@@ -5220,7 +5147,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**gcpkmsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;gcpkms&quot;]
 
 ### Other Parameters
 
@@ -5283,7 +5209,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **key** | **string** | Name of the key in Vault. | 
-**gcpkmsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;gcpkms&quot;]
 
 ### Other Parameters
 
@@ -5347,7 +5272,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **key** | **string** | Name of the key in Vault. | 
-**gcpkmsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;gcpkms&quot;]
 
 ### Other Parameters
 
@@ -5414,7 +5338,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **key** | **string** | Name of the key to use for encryption. This key must already exist in Vault and Google Cloud KMS. | 
-**gcpkmsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;gcpkms&quot;]
 
 ### Other Parameters
 
@@ -5482,7 +5405,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **key** | **string** | Name of the key to register in Vault. This will be the named used to refer to the underlying crypto key when encrypting or decrypting data. | 
-**gcpkmsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;gcpkms&quot;]
 
 ### Other Parameters
 
@@ -5547,7 +5469,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **key** | **string** | Name of the key for which to get the public key. This key must already exist in Vault and Google Cloud KMS. | 
-**gcpkmsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;gcpkms&quot;]
 
 ### Other Parameters
 
@@ -5611,7 +5532,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **key** | **string** | Name of the key to rotate. This key must already be registered with Vault and point to a valid Google Cloud KMS crypto key. | 
-**gcpkmsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;gcpkms&quot;]
 
 ### Other Parameters
 
@@ -5678,7 +5598,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **key** | **string** | Name of the key in Vault to use for signing. This key must already exist in Vault and must map back to a Google Cloud KMS key. | 
-**gcpkmsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;gcpkms&quot;]
 
 ### Other Parameters
 
@@ -5743,7 +5662,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **key** | **string** | Name of the key in Vault. | 
-**gcpkmsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;gcpkms&quot;]
 
 ### Other Parameters
 
@@ -5810,7 +5728,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **key** | **string** | Name of the key in Vault to use for verification. This key must already exist in Vault and must map back to a Google Cloud KMS key. | 
-**gcpkmsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;gcpkms&quot;]
 
 ### Other Parameters
 
@@ -5878,7 +5795,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **key** | **string** | Name of the key in Vault. | 
-**gcpkmsMountPath** | **string** | Path that the backend was mounted at | [default to &quot;gcpkms&quot;]
 
 ### Other Parameters
 
@@ -5940,7 +5856,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**gcpMountPath** | **string** | Path that the backend was mounted at | [default to &quot;gcp&quot;]
 
 ### Other Parameters
 
@@ -6001,7 +5916,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**gcpMountPath** | **string** | Path that the backend was mounted at | [default to &quot;gcp&quot;]
 
 ### Other Parameters
 
@@ -6062,7 +5976,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**gcpMountPath** | **string** | Path that the backend was mounted at | [default to &quot;gcp&quot;]
 
 ### Other Parameters
 
@@ -6123,7 +6036,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**gcpMountPath** | **string** | Path that the backend was mounted at | [default to &quot;gcp&quot;]
 
 ### Other Parameters
 
@@ -6186,7 +6098,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Required. Name to refer to this impersonated account in Vault. Cannot be updated. | 
-**gcpMountPath** | **string** | Path that the backend was mounted at | [default to &quot;gcp&quot;]
 
 ### Other Parameters
 
@@ -6250,7 +6161,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Required. Name of the role. | 
-**gcpMountPath** | **string** | Path that the backend was mounted at | [default to &quot;gcp&quot;]
 
 ### Other Parameters
 
@@ -6314,7 +6224,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Required. Name to refer to this static account in Vault. Cannot be updated. | 
-**gcpMountPath** | **string** | Path that the backend was mounted at | [default to &quot;gcp&quot;]
 
 ### Other Parameters
 
@@ -6378,7 +6287,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the role. | 
-**gcpMountPath** | **string** | Path that the backend was mounted at | [default to &quot;gcp&quot;]
 
 ### Other Parameters
 
@@ -6442,7 +6350,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the role. | 
-**gcpMountPath** | **string** | Path that the backend was mounted at | [default to &quot;gcp&quot;]
 
 ### Other Parameters
 
@@ -6503,7 +6410,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**gcpMountPath** | **string** | Path that the backend was mounted at | [default to &quot;gcp&quot;]
 
 ### Other Parameters
 
@@ -6566,7 +6472,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the account. | 
-**gcpMountPath** | **string** | Path that the backend was mounted at | [default to &quot;gcp&quot;]
 
 ### Other Parameters
 
@@ -6633,7 +6538,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Required. Name to refer to this impersonated account in Vault. Cannot be updated. | 
-**gcpMountPath** | **string** | Path that the backend was mounted at | [default to &quot;gcp&quot;]
 
 ### Other Parameters
 
@@ -6701,7 +6605,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Required. Name of the role. | 
-**gcpMountPath** | **string** | Path that the backend was mounted at | [default to &quot;gcp&quot;]
 
 ### Other Parameters
 
@@ -6769,7 +6672,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Required. Name to refer to this static account in Vault. Cannot be updated. | 
-**gcpMountPath** | **string** | Path that the backend was mounted at | [default to &quot;gcp&quot;]
 
 ### Other Parameters
 
@@ -6831,7 +6733,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**kubernetesMountPath** | **string** | Path that the backend was mounted at | [default to &quot;kubernetes&quot;]
 
 ### Other Parameters
 
@@ -6894,7 +6795,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**kubernetesMountPath** | **string** | Path that the backend was mounted at | [default to &quot;kubernetes&quot;]
 
 ### Other Parameters
 
@@ -6955,7 +6855,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**kubernetesMountPath** | **string** | Path that the backend was mounted at | [default to &quot;kubernetes&quot;]
 
 ### Other Parameters
 
@@ -7018,7 +6917,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the role | 
-**kubernetesMountPath** | **string** | Path that the backend was mounted at | [default to &quot;kubernetes&quot;]
 
 ### Other Parameters
 
@@ -7085,7 +6983,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the Vault role | 
-**kubernetesMountPath** | **string** | Path that the backend was mounted at | [default to &quot;kubernetes&quot;]
 
 ### Other Parameters
 
@@ -7147,7 +7044,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**kubernetesMountPath** | **string** | Path that the backend was mounted at | [default to &quot;kubernetes&quot;]
 
 ### Other Parameters
 
@@ -7208,7 +7104,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**kubernetesMountPath** | **string** | Path that the backend was mounted at | [default to &quot;kubernetes&quot;]
 
 ### Other Parameters
 
@@ -7271,7 +7166,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the role | 
-**kubernetesMountPath** | **string** | Path that the backend was mounted at | [default to &quot;kubernetes&quot;]
 
 ### Other Parameters
 
@@ -7338,7 +7232,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the role | 
-**kubernetesMountPath** | **string** | Path that the backend was mounted at | [default to &quot;kubernetes&quot;]
 
 ### Other Parameters
 
@@ -7403,7 +7296,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **path** | **string** | Location of the secret. | 
-**kvV1MountPath** | **string** | Path that the backend was mounted at | [default to &quot;kv-v1&quot;]
 
 ### Other Parameters
 
@@ -7467,7 +7359,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **path** | **string** | Location of the secret. | 
-**kvV1MountPath** | **string** | Path that the backend was mounted at | [default to &quot;kv-v1&quot;]
 
 ### Other Parameters
 
@@ -7532,7 +7423,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **path** | **string** | Location of the secret. | 
-**kvV1MountPath** | **string** | Path that the backend was mounted at | [default to &quot;kv-v1&quot;]
 
 ### Other Parameters
 
@@ -7596,7 +7486,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**kvV2MountPath** | **string** | Path that the backend was mounted at | [default to &quot;kv-v2&quot;]
 
 ### Other Parameters
 
@@ -7660,7 +7549,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **path** | **string** | Location of the secret. | 
-**kvV2MountPath** | **string** | Path that the backend was mounted at | [default to &quot;kv-v2&quot;]
 
 ### Other Parameters
 
@@ -7724,7 +7612,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **path** | **string** | Location of the secret. | 
-**kvV2MountPath** | **string** | Path that the backend was mounted at | [default to &quot;kv-v2&quot;]
 
 ### Other Parameters
 
@@ -7791,7 +7678,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **path** | **string** | Location of the secret. | 
-**kvV2MountPath** | **string** | Path that the backend was mounted at | [default to &quot;kv-v2&quot;]
 
 ### Other Parameters
 
@@ -7859,7 +7745,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **path** | **string** | Location of the secret. | 
-**kvV2MountPath** | **string** | Path that the backend was mounted at | [default to &quot;kv-v2&quot;]
 
 ### Other Parameters
 
@@ -7924,7 +7809,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **path** | **string** | Location of the secret. | 
-**kvV2MountPath** | **string** | Path that the backend was mounted at | [default to &quot;kv-v2&quot;]
 
 ### Other Parameters
 
@@ -7985,7 +7869,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**kvV2MountPath** | **string** | Path that the backend was mounted at | [default to &quot;kv-v2&quot;]
 
 ### Other Parameters
 
@@ -8048,7 +7931,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **path** | **string** | Location of the secret. | 
-**kvV2MountPath** | **string** | Path that the backend was mounted at | [default to &quot;kv-v2&quot;]
 
 ### Other Parameters
 
@@ -8113,7 +7995,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **path** | **string** | Location of the secret. | 
-**kvV2MountPath** | **string** | Path that the backend was mounted at | [default to &quot;kv-v2&quot;]
 
 ### Other Parameters
 
@@ -8180,7 +8061,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **path** | **string** | Location of the secret. | 
-**kvV2MountPath** | **string** | Path that the backend was mounted at | [default to &quot;kv-v2&quot;]
 
 ### Other Parameters
 
@@ -8248,7 +8128,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **path** | **string** | Location of the secret. | 
-**kvV2MountPath** | **string** | Path that the backend was mounted at | [default to &quot;kv-v2&quot;]
 
 ### Other Parameters
 
@@ -8316,7 +8195,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **path** | **string** | Location of the secret. | 
-**kvV2MountPath** | **string** | Path that the backend was mounted at | [default to &quot;kv-v2&quot;]
 
 ### Other Parameters
 
@@ -8381,7 +8259,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**ldapMountPath** | **string** | Path that the backend was mounted at | [default to &quot;ldap&quot;]
 
 ### Other Parameters
 
@@ -8442,7 +8319,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**ldapMountPath** | **string** | Path that the backend was mounted at | [default to &quot;ldap&quot;]
 
 ### Other Parameters
 
@@ -8505,7 +8381,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the role (lowercase) | 
-**ldapMountPath** | **string** | Path that the backend was mounted at | [default to &quot;ldap&quot;]
 
 ### Other Parameters
 
@@ -8569,7 +8444,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the role | 
-**ldapMountPath** | **string** | Path that the backend was mounted at | [default to &quot;ldap&quot;]
 
 ### Other Parameters
 
@@ -8636,7 +8510,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the set. | 
-**ldapMountPath** | **string** | Path that the backend was mounted at | [default to &quot;ldap&quot;]
 
 ### Other Parameters
 
@@ -8704,7 +8577,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the set | 
-**ldapMountPath** | **string** | Path that the backend was mounted at | [default to &quot;ldap&quot;]
 
 ### Other Parameters
 
@@ -8769,7 +8641,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the set. | 
-**ldapMountPath** | **string** | Path that the backend was mounted at | [default to &quot;ldap&quot;]
 
 ### Other Parameters
 
@@ -8836,7 +8707,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the set. | 
-**ldapMountPath** | **string** | Path that the backend was mounted at | [default to &quot;ldap&quot;]
 
 ### Other Parameters
 
@@ -8901,7 +8771,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the set. | 
-**ldapMountPath** | **string** | Path that the backend was mounted at | [default to &quot;ldap&quot;]
 
 ### Other Parameters
 
@@ -8968,7 +8837,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the set. | 
-**ldapMountPath** | **string** | Path that the backend was mounted at | [default to &quot;ldap&quot;]
 
 ### Other Parameters
 
@@ -9030,7 +8898,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**ldapMountPath** | **string** | Path that the backend was mounted at | [default to &quot;ldap&quot;]
 
 ### Other Parameters
 
@@ -9094,7 +8961,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the set. | 
-**ldapMountPath** | **string** | Path that the backend was mounted at | [default to &quot;ldap&quot;]
 
 ### Other Parameters
 
@@ -9155,7 +9021,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**ldapMountPath** | **string** | Path that the backend was mounted at | [default to &quot;ldap&quot;]
 
 ### Other Parameters
 
@@ -9216,7 +9081,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**ldapMountPath** | **string** | Path that the backend was mounted at | [default to &quot;ldap&quot;]
 
 ### Other Parameters
 
@@ -9277,7 +9141,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**ldapMountPath** | **string** | Path that the backend was mounted at | [default to &quot;ldap&quot;]
 
 ### Other Parameters
 
@@ -9340,7 +9203,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the role (lowercase) | 
-**ldapMountPath** | **string** | Path that the backend was mounted at | [default to &quot;ldap&quot;]
 
 ### Other Parameters
 
@@ -9404,7 +9266,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the role | 
-**ldapMountPath** | **string** | Path that the backend was mounted at | [default to &quot;ldap&quot;]
 
 ### Other Parameters
 
@@ -9468,7 +9329,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the dynamic role. | 
-**ldapMountPath** | **string** | Path that the backend was mounted at | [default to &quot;ldap&quot;]
 
 ### Other Parameters
 
@@ -9532,7 +9392,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the static role. | 
-**ldapMountPath** | **string** | Path that the backend was mounted at | [default to &quot;ldap&quot;]
 
 ### Other Parameters
 
@@ -9593,7 +9452,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**ldapMountPath** | **string** | Path that the backend was mounted at | [default to &quot;ldap&quot;]
 
 ### Other Parameters
 
@@ -9656,7 +9514,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the static role | 
-**ldapMountPath** | **string** | Path that the backend was mounted at | [default to &quot;ldap&quot;]
 
 ### Other Parameters
 
@@ -9723,7 +9580,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the role (lowercase) | 
-**ldapMountPath** | **string** | Path that the backend was mounted at | [default to &quot;ldap&quot;]
 
 ### Other Parameters
 
@@ -9791,7 +9647,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the role | 
-**ldapMountPath** | **string** | Path that the backend was mounted at | [default to &quot;ldap&quot;]
 
 ### Other Parameters
 
@@ -9856,7 +9711,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**mongodbatlasMountPath** | **string** | Path that the backend was mounted at | [default to &quot;mongodbatlas&quot;]
 
 ### Other Parameters
 
@@ -9920,7 +9774,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the Roles | 
-**mongodbatlasMountPath** | **string** | Path that the backend was mounted at | [default to &quot;mongodbatlas&quot;]
 
 ### Other Parameters
 
@@ -9984,7 +9837,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the role | 
-**mongodbatlasMountPath** | **string** | Path that the backend was mounted at | [default to &quot;mongodbatlas&quot;]
 
 ### Other Parameters
 
@@ -10045,7 +9897,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**mongodbatlasMountPath** | **string** | Path that the backend was mounted at | [default to &quot;mongodbatlas&quot;]
 
 ### Other Parameters
 
@@ -10106,7 +9957,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**mongodbatlasMountPath** | **string** | Path that the backend was mounted at | [default to &quot;mongodbatlas&quot;]
 
 ### Other Parameters
 
@@ -10169,7 +10019,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the Roles | 
-**mongodbatlasMountPath** | **string** | Path that the backend was mounted at | [default to &quot;mongodbatlas&quot;]
 
 ### Other Parameters
 
@@ -10236,7 +10085,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the Roles | 
-**mongodbatlasMountPath** | **string** | Path that the backend was mounted at | [default to &quot;mongodbatlas&quot;]
 
 ### Other Parameters
 
@@ -10301,7 +10149,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**nomadMountPath** | **string** | Path that the backend was mounted at | [default to &quot;nomad&quot;]
 
 ### Other Parameters
 
@@ -10365,7 +10212,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**nomadMountPath** | **string** | Path that the backend was mounted at | [default to &quot;nomad&quot;]
 
 ### Other Parameters
 
@@ -10426,7 +10272,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**nomadMountPath** | **string** | Path that the backend was mounted at | [default to &quot;nomad&quot;]
 
 ### Other Parameters
 
@@ -10486,7 +10331,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**nomadMountPath** | **string** | Path that the backend was mounted at | [default to &quot;nomad&quot;]
 
 ### Other Parameters
 
@@ -10549,7 +10393,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the role | 
-**nomadMountPath** | **string** | Path that the backend was mounted at | [default to &quot;nomad&quot;]
 
 ### Other Parameters
 
@@ -10613,7 +10456,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the role | 
-**nomadMountPath** | **string** | Path that the backend was mounted at | [default to &quot;nomad&quot;]
 
 ### Other Parameters
 
@@ -10674,7 +10516,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**nomadMountPath** | **string** | Path that the backend was mounted at | [default to &quot;nomad&quot;]
 
 ### Other Parameters
 
@@ -10735,7 +10576,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**nomadMountPath** | **string** | Path that the backend was mounted at | [default to &quot;nomad&quot;]
 
 ### Other Parameters
 
@@ -10795,7 +10635,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**nomadMountPath** | **string** | Path that the backend was mounted at | [default to &quot;nomad&quot;]
 
 ### Other Parameters
 
@@ -10858,7 +10697,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the role | 
-**nomadMountPath** | **string** | Path that the backend was mounted at | [default to &quot;nomad&quot;]
 
 ### Other Parameters
 
@@ -10925,7 +10763,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the role | 
-**nomadMountPath** | **string** | Path that the backend was mounted at | [default to &quot;nomad&quot;]
 
 ### Other Parameters
 
@@ -10990,7 +10827,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -11054,7 +10890,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -11118,7 +10953,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -11182,7 +11016,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -11246,7 +11079,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -11310,7 +11142,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -11374,7 +11205,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -11438,7 +11268,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -11502,7 +11331,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **issuerRef** | **string** | Reference to a existing issuer; either \&quot;default\&quot; for the configured default issuer, an identifier or the name assigned to the issuer. | [default to &quot;default&quot;]
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -11566,7 +11394,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **keyRef** | **string** | Reference to key; either \&quot;default\&quot; for the configured default key, an identifier of a key, or the name assigned to the key. | [default to &quot;default&quot;]
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -11630,7 +11457,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the role | 
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -11691,7 +11517,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -11754,7 +11579,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -11821,7 +11645,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **exported** | **string** | Must be \&quot;internal\&quot;, \&quot;exported\&quot; or \&quot;kms\&quot;. If set to \&quot;exported\&quot;, the generated private key will be returned. This is your *only* chance to retrieve the private key! | 
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -11886,7 +11709,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -11950,7 +11772,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -12017,7 +11838,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **exported** | **string** | Must be \&quot;internal\&quot;, \&quot;exported\&quot; or \&quot;kms\&quot;. If set to \&quot;exported\&quot;, the generated private key will be returned. This is your *only* chance to retrieve the private key! | 
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -12082,7 +11902,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -12149,7 +11968,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **role** | **string** | The desired role with configuration for this request | 
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -12220,7 +12038,6 @@ Name | Type | Description  | Notes
 **ctx** | **context.Context** | context for request cancellation 
 **issuerRef** | **string** | Reference to a existing issuer; either \&quot;default\&quot; for the configured default issuer, an identifier or the name assigned to the issuer. | [default to &quot;default&quot;]
 **role** | **string** | The desired role with configuration for this request | 
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -12286,7 +12103,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **issuerRef** | **string** | Reference to a existing issuer; either \&quot;default\&quot; for the configured default issuer, an identifier or the name assigned to the issuer. | [default to &quot;default&quot;]
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -12350,7 +12166,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **issuerRef** | **string** | Reference to a existing issuer; either \&quot;default\&quot; for the configured default issuer, an identifier or the name assigned to the issuer. | [default to &quot;default&quot;]
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -12414,7 +12229,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **issuerRef** | **string** | Reference to a existing issuer; either \&quot;default\&quot; for the configured default issuer, an identifier or the name assigned to the issuer. | [default to &quot;default&quot;]
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -12478,7 +12292,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **issuerRef** | **string** | Reference to a existing issuer; either \&quot;default\&quot; for the configured default issuer, an identifier or the name assigned to the issuer. | [default to &quot;default&quot;]
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -12542,7 +12355,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **issuerRef** | **string** | Reference to a existing issuer; either \&quot;default\&quot; for the configured default issuer, an identifier or the name assigned to the issuer. | [default to &quot;default&quot;]
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -12606,7 +12418,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **issuerRef** | **string** | Reference to a existing issuer; either \&quot;default\&quot; for the configured default issuer, an identifier or the name assigned to the issuer. | [default to &quot;default&quot;]
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -12673,7 +12484,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **issuerRef** | **string** | Reference to a existing issuer; either \&quot;default\&quot; for the configured default issuer, an identifier or the name assigned to the issuer. | [default to &quot;default&quot;]
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -12741,7 +12551,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **issuerRef** | **string** | Reference to a existing issuer; either \&quot;default\&quot; for the configured default issuer, an identifier or the name assigned to the issuer. | [default to &quot;default&quot;]
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -12809,7 +12618,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **issuerRef** | **string** | Reference to a existing issuer; either \&quot;default\&quot; for the configured default issuer, an identifier or the name assigned to the issuer. | [default to &quot;default&quot;]
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -12877,7 +12685,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **issuerRef** | **string** | Reference to a existing issuer; either \&quot;default\&quot; for the configured default issuer, an identifier or the name assigned to the issuer. | [default to &quot;default&quot;]
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -12945,7 +12752,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **issuerRef** | **string** | Reference to a existing issuer; either \&quot;default\&quot; for the configured default issuer, an identifier or the name assigned to the issuer. | [default to &quot;default&quot;]
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -13016,7 +12822,6 @@ Name | Type | Description  | Notes
 **ctx** | **context.Context** | context for request cancellation 
 **issuerRef** | **string** | Reference to a existing issuer; either \&quot;default\&quot; for the configured default issuer, an identifier or the name assigned to the issuer. | [default to &quot;default&quot;]
 **role** | **string** | The desired role with configuration for this request | 
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -13088,7 +12893,6 @@ Name | Type | Description  | Notes
 **ctx** | **context.Context** | context for request cancellation 
 **issuerRef** | **string** | Reference to a existing issuer; either \&quot;default\&quot; for the configured default issuer, an identifier or the name assigned to the issuer. | [default to &quot;default&quot;]
 **role** | **string** | The desired role with configuration for this request | 
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -13157,7 +12961,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **exported** | **string** | Must be \&quot;internal\&quot;, \&quot;exported\&quot; or \&quot;kms\&quot;. If set to \&quot;exported\&quot;, the generated private key will be returned. This is your *only* chance to retrieve the private key! | 
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -13225,7 +13028,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **exported** | **string** | Must be \&quot;internal\&quot;, \&quot;exported\&quot; or \&quot;kms\&quot;. If set to \&quot;exported\&quot;, the generated private key will be returned. This is your *only* chance to retrieve the private key! | 
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -13290,7 +13092,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -13354,7 +13155,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -13421,7 +13221,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **exported** | **string** | Must be \&quot;internal\&quot;, \&quot;exported\&quot; or \&quot;kms\&quot;. If set to \&quot;exported\&quot;, the generated private key will be returned. This is your *only* chance to retrieve the private key! | 
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -13483,7 +13282,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -13544,7 +13342,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -13605,7 +13402,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -13666,7 +13462,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -13727,7 +13522,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -13788,7 +13582,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -13851,7 +13644,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **req** | **string** | base-64 encoded ocsp request | 
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -13912,7 +13704,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -13972,7 +13763,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -14032,7 +13822,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -14092,7 +13881,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -14155,7 +13943,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **serial** | **string** | Certificate serial number, in colon- or hyphen-separated octal | 
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -14216,7 +14003,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -14276,7 +14062,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -14336,7 +14121,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -14399,7 +14183,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **serial** | **string** | Certificate serial number, in colon- or hyphen-separated octal | 
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -14463,7 +14246,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **serial** | **string** | Certificate serial number, in colon- or hyphen-separated octal | 
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -14524,7 +14306,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -14584,7 +14365,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -14644,7 +14424,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -14704,7 +14483,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -14764,7 +14542,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -14824,7 +14601,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -14887,7 +14663,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **issuerRef** | **string** | Reference to a existing issuer; either \&quot;default\&quot; for the configured default issuer, an identifier or the name assigned to the issuer. | [default to &quot;default&quot;]
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -14951,7 +14726,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **issuerRef** | **string** | Reference to a existing issuer; either \&quot;default\&quot; for the configured default issuer, an identifier or the name assigned to the issuer. | [default to &quot;default&quot;]
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -15015,7 +14789,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **issuerRef** | **string** | Reference to a existing issuer; either \&quot;default\&quot; for the configured default issuer, an identifier or the name assigned to the issuer. | [default to &quot;default&quot;]
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -15079,7 +14852,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **issuerRef** | **string** | Reference to a existing issuer; either \&quot;default\&quot; for the configured default issuer, an identifier or the name assigned to the issuer. | [default to &quot;default&quot;]
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -15140,7 +14912,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -15203,7 +14974,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **keyRef** | **string** | Reference to key; either \&quot;default\&quot; for the configured default key, an identifier of a key, or the name assigned to the key. | [default to &quot;default&quot;]
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -15264,7 +15034,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -15327,7 +15096,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the role | 
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -15388,7 +15156,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -15451,7 +15218,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -15515,7 +15281,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -15579,7 +15344,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **issuerRef** | **string** | Reference to a existing issuer; either \&quot;default\&quot; for the configured default issuer, an identifier or the name assigned to the issuer. | [default to &quot;default&quot;]
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -15643,7 +15407,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -15707,7 +15470,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -15771,7 +15533,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -15832,7 +15593,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -15892,7 +15652,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -15955,7 +15714,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -16019,7 +15777,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -16086,7 +15843,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **role** | **string** | The desired role with configuration for this request | 
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -16154,7 +15910,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **role** | **string** | The desired role with configuration for this request | 
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -16219,7 +15974,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -16280,7 +16034,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -16340,7 +16093,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -16406,7 +16158,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **issuerRef** | **string** | Reference to a existing issuer; either \&quot;default\&quot; for the configured default issuer, an identifier or the name assigned to the issuer. | [default to &quot;default&quot;]
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -16474,7 +16225,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **keyRef** | **string** | Reference to key; either \&quot;default\&quot; for the configured default key, an identifier of a key, or the name assigned to the key. | [default to &quot;default&quot;]
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -16542,7 +16292,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the role | 
-**pkiMountPath** | **string** | Path that the backend was mounted at | [default to &quot;pki&quot;]
 
 ### Other Parameters
 
@@ -16607,7 +16356,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**rabbitmqMountPath** | **string** | Path that the backend was mounted at | [default to &quot;rabbitmq&quot;]
 
 ### Other Parameters
 
@@ -16671,7 +16419,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**rabbitmqMountPath** | **string** | Path that the backend was mounted at | [default to &quot;rabbitmq&quot;]
 
 ### Other Parameters
 
@@ -16735,7 +16482,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the role. | 
-**rabbitmqMountPath** | **string** | Path that the backend was mounted at | [default to &quot;rabbitmq&quot;]
 
 ### Other Parameters
 
@@ -16796,7 +16542,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**rabbitmqMountPath** | **string** | Path that the backend was mounted at | [default to &quot;rabbitmq&quot;]
 
 ### Other Parameters
 
@@ -16857,7 +16602,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**rabbitmqMountPath** | **string** | Path that the backend was mounted at | [default to &quot;rabbitmq&quot;]
 
 ### Other Parameters
 
@@ -16920,7 +16664,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the role. | 
-**rabbitmqMountPath** | **string** | Path that the backend was mounted at | [default to &quot;rabbitmq&quot;]
 
 ### Other Parameters
 
@@ -16984,7 +16727,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the role. | 
-**rabbitmqMountPath** | **string** | Path that the backend was mounted at | [default to &quot;rabbitmq&quot;]
 
 ### Other Parameters
 
@@ -17051,7 +16793,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the role. | 
-**rabbitmqMountPath** | **string** | Path that the backend was mounted at | [default to &quot;rabbitmq&quot;]
 
 ### Other Parameters
 
@@ -17116,7 +16857,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**sshMountPath** | **string** | Path that the backend was mounted at | [default to &quot;ssh&quot;]
 
 ### Other Parameters
 
@@ -17180,7 +16920,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**sshMountPath** | **string** | Path that the backend was mounted at | [default to &quot;ssh&quot;]
 
 ### Other Parameters
 
@@ -17241,7 +16980,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**sshMountPath** | **string** | Path that the backend was mounted at | [default to &quot;ssh&quot;]
 
 ### Other Parameters
 
@@ -17304,7 +17042,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **role** | **string** | [Required for all types] Name of the role being created. | 
-**sshMountPath** | **string** | Path that the backend was mounted at | [default to &quot;ssh&quot;]
 
 ### Other Parameters
 
@@ -17365,7 +17102,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**sshMountPath** | **string** | Path that the backend was mounted at | [default to &quot;ssh&quot;]
 
 ### Other Parameters
 
@@ -17431,7 +17167,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **role** | **string** | [Required] Name of the role | 
-**sshMountPath** | **string** | Path that the backend was mounted at | [default to &quot;ssh&quot;]
 
 ### Other Parameters
 
@@ -17499,7 +17234,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **role** | **string** | The desired role with configuration for this request. | 
-**sshMountPath** | **string** | Path that the backend was mounted at | [default to &quot;ssh&quot;]
 
 ### Other Parameters
 
@@ -17561,7 +17295,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**sshMountPath** | **string** | Path that the backend was mounted at | [default to &quot;ssh&quot;]
 
 ### Other Parameters
 
@@ -17625,7 +17358,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**sshMountPath** | **string** | Path that the backend was mounted at | [default to &quot;ssh&quot;]
 
 ### Other Parameters
 
@@ -17686,7 +17418,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**sshMountPath** | **string** | Path that the backend was mounted at | [default to &quot;ssh&quot;]
 
 ### Other Parameters
 
@@ -17746,7 +17477,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**sshMountPath** | **string** | Path that the backend was mounted at | [default to &quot;ssh&quot;]
 
 ### Other Parameters
 
@@ -17809,7 +17539,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **role** | **string** | [Required for all types] Name of the role being created. | 
-**sshMountPath** | **string** | Path that the backend was mounted at | [default to &quot;ssh&quot;]
 
 ### Other Parameters
 
@@ -17870,7 +17599,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**sshMountPath** | **string** | Path that the backend was mounted at | [default to &quot;ssh&quot;]
 
 ### Other Parameters
 
@@ -17936,7 +17664,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **role** | **string** | The desired role with configuration for this request. | 
-**sshMountPath** | **string** | Path that the backend was mounted at | [default to &quot;ssh&quot;]
 
 ### Other Parameters
 
@@ -17998,7 +17725,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**sshMountPath** | **string** | Path that the backend was mounted at | [default to &quot;ssh&quot;]
 
 ### Other Parameters
 
@@ -18061,7 +17787,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**sshMountPath** | **string** | Path that the backend was mounted at | [default to &quot;ssh&quot;]
 
 ### Other Parameters
 
@@ -18128,7 +17853,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **role** | **string** | [Required for all types] Name of the role being created. | 
-**sshMountPath** | **string** | Path that the backend was mounted at | [default to &quot;ssh&quot;]
 
 ### Other Parameters
 
@@ -18193,7 +17917,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**terraformMountPath** | **string** | Path that the backend was mounted at | [default to &quot;terraform&quot;]
 
 ### Other Parameters
 
@@ -18254,7 +17977,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**terraformMountPath** | **string** | Path that the backend was mounted at | [default to &quot;terraform&quot;]
 
 ### Other Parameters
 
@@ -18317,7 +18039,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the role | 
-**terraformMountPath** | **string** | Path that the backend was mounted at | [default to &quot;terraform&quot;]
 
 ### Other Parameters
 
@@ -18381,7 +18102,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the role | 
-**terraformMountPath** | **string** | Path that the backend was mounted at | [default to &quot;terraform&quot;]
 
 ### Other Parameters
 
@@ -18442,7 +18162,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**terraformMountPath** | **string** | Path that the backend was mounted at | [default to &quot;terraform&quot;]
 
 ### Other Parameters
 
@@ -18503,7 +18222,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**terraformMountPath** | **string** | Path that the backend was mounted at | [default to &quot;terraform&quot;]
 
 ### Other Parameters
 
@@ -18566,7 +18284,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the role | 
-**terraformMountPath** | **string** | Path that the backend was mounted at | [default to &quot;terraform&quot;]
 
 ### Other Parameters
 
@@ -18630,7 +18347,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the team or organization role | 
-**terraformMountPath** | **string** | Path that the backend was mounted at | [default to &quot;terraform&quot;]
 
 ### Other Parameters
 
@@ -18697,7 +18413,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the role | 
-**terraformMountPath** | **string** | Path that the backend was mounted at | [default to &quot;terraform&quot;]
 
 ### Other Parameters
 
@@ -18765,7 +18480,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the key. | 
-**totpMountPath** | **string** | Path that the backend was mounted at | [default to &quot;totp&quot;]
 
 ### Other Parameters
 
@@ -18830,7 +18544,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the key. | 
-**totpMountPath** | **string** | Path that the backend was mounted at | [default to &quot;totp&quot;]
 
 ### Other Parameters
 
@@ -18894,7 +18607,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the key. | 
-**totpMountPath** | **string** | Path that the backend was mounted at | [default to &quot;totp&quot;]
 
 ### Other Parameters
 
@@ -18955,7 +18667,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**totpMountPath** | **string** | Path that the backend was mounted at | [default to &quot;totp&quot;]
 
 ### Other Parameters
 
@@ -19019,7 +18730,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the key. | 
-**totpMountPath** | **string** | Path that the backend was mounted at | [default to &quot;totp&quot;]
 
 ### Other Parameters
 
@@ -19086,7 +18796,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the key. | 
-**totpMountPath** | **string** | Path that the backend was mounted at | [default to &quot;totp&quot;]
 
 ### Other Parameters
 
@@ -19151,7 +18860,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the key | 
-**transitMountPath** | **string** | Path that the backend was mounted at | [default to &quot;transit&quot;]
 
 ### Other Parameters
 
@@ -19215,7 +18923,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**transitMountPath** | **string** | Path that the backend was mounted at | [default to &quot;transit&quot;]
 
 ### Other Parameters
 
@@ -19282,7 +18989,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the key | 
-**transitMountPath** | **string** | Path that the backend was mounted at | [default to &quot;transit&quot;]
 
 ### Other Parameters
 
@@ -19347,7 +19053,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**transitMountPath** | **string** | Path that the backend was mounted at | [default to &quot;transit&quot;]
 
 ### Other Parameters
 
@@ -19414,7 +19119,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the key | 
-**transitMountPath** | **string** | Path that the backend was mounted at | [default to &quot;transit&quot;]
 
 ### Other Parameters
 
@@ -19482,7 +19186,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the key | 
-**transitMountPath** | **string** | Path that the backend was mounted at | [default to &quot;transit&quot;]
 
 ### Other Parameters
 
@@ -19547,7 +19250,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the key | 
-**transitMountPath** | **string** | Path that the backend was mounted at | [default to &quot;transit&quot;]
 
 ### Other Parameters
 
@@ -19614,7 +19316,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the key | 
-**transitMountPath** | **string** | Path that the backend was mounted at | [default to &quot;transit&quot;]
 
 ### Other Parameters
 
@@ -19682,7 +19383,6 @@ Name | Type | Description  | Notes
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the key | 
 **type_** | **string** | Type of key to export (encryption-key, signing-key, hmac-key) | 
-**transitMountPath** | **string** | Path that the backend was mounted at | [default to &quot;transit&quot;]
 
 ### Other Parameters
 
@@ -19753,7 +19453,6 @@ Name | Type | Description  | Notes
 **name** | **string** | Name of the key | 
 **type_** | **string** | Type of key to export (encryption-key, signing-key, hmac-key) | 
 **version** | **string** | Version of the key | 
-**transitMountPath** | **string** | Path that the backend was mounted at | [default to &quot;transit&quot;]
 
 ### Other Parameters
 
@@ -19825,7 +19524,6 @@ Name | Type | Description  | Notes
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | The backend key used for encrypting the data key | 
 **plaintext** | **string** | \&quot;plaintext\&quot; will return the key in both plaintext and ciphertext; \&quot;wrapped\&quot; will return the ciphertext only. | 
-**transitMountPath** | **string** | Path that the backend was mounted at | [default to &quot;transit&quot;]
 
 ### Other Parameters
 
@@ -19894,7 +19592,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | The key to use for the HMAC function | 
-**transitMountPath** | **string** | Path that the backend was mounted at | [default to &quot;transit&quot;]
 
 ### Other Parameters
 
@@ -19965,7 +19662,6 @@ Name | Type | Description  | Notes
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | The key to use for the HMAC function | 
 **urlalgorithm** | **string** | Algorithm to use (POST URL parameter) | 
-**transitMountPath** | **string** | Path that the backend was mounted at | [default to &quot;transit&quot;]
 
 ### Other Parameters
 
@@ -20031,7 +19727,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**transitMountPath** | **string** | Path that the backend was mounted at | [default to &quot;transit&quot;]
 
 ### Other Parameters
 
@@ -20098,7 +19793,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **urlbytes** | **string** | The number of bytes to generate (POST URL parameter) | 
-**transitMountPath** | **string** | Path that the backend was mounted at | [default to &quot;transit&quot;]
 
 ### Other Parameters
 
@@ -20166,7 +19860,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **source** | **string** | Which system to source random data from, ether \&quot;platform\&quot;, \&quot;seal\&quot;, or \&quot;all\&quot;. | [default to &quot;platform&quot;]
-**transitMountPath** | **string** | Path that the backend was mounted at | [default to &quot;transit&quot;]
 
 ### Other Parameters
 
@@ -20237,7 +19930,6 @@ Name | Type | Description  | Notes
 **ctx** | **context.Context** | context for request cancellation 
 **source** | **string** | Which system to source random data from, ether \&quot;platform\&quot;, \&quot;seal\&quot;, or \&quot;all\&quot;. | [default to &quot;platform&quot;]
 **urlbytes** | **string** | The number of bytes to generate (POST URL parameter) | 
-**transitMountPath** | **string** | Path that the backend was mounted at | [default to &quot;transit&quot;]
 
 ### Other Parameters
 
@@ -20303,7 +19995,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**transitMountPath** | **string** | Path that the backend was mounted at | [default to &quot;transit&quot;]
 
 ### Other Parameters
 
@@ -20370,7 +20061,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **urlalgorithm** | **string** | Algorithm to use (POST URL parameter) | 
-**transitMountPath** | **string** | Path that the backend was mounted at | [default to &quot;transit&quot;]
 
 ### Other Parameters
 
@@ -20438,7 +20128,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | The name of the key | 
-**transitMountPath** | **string** | Path that the backend was mounted at | [default to &quot;transit&quot;]
 
 ### Other Parameters
 
@@ -20506,7 +20195,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | The name of the key | 
-**transitMountPath** | **string** | Path that the backend was mounted at | [default to &quot;transit&quot;]
 
 ### Other Parameters
 
@@ -20568,7 +20256,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**transitMountPath** | **string** | Path that the backend was mounted at | [default to &quot;transit&quot;]
 
 ### Other Parameters
 
@@ -20629,7 +20316,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**transitMountPath** | **string** | Path that the backend was mounted at | [default to &quot;transit&quot;]
 
 ### Other Parameters
 
@@ -20692,7 +20378,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the key | 
-**transitMountPath** | **string** | Path that the backend was mounted at | [default to &quot;transit&quot;]
 
 ### Other Parameters
 
@@ -20753,7 +20438,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**transitMountPath** | **string** | Path that the backend was mounted at | [default to &quot;transit&quot;]
 
 ### Other Parameters
 
@@ -20813,7 +20497,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**transitMountPath** | **string** | Path that the backend was mounted at | [default to &quot;transit&quot;]
 
 ### Other Parameters
 
@@ -20879,7 +20562,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | If set, this will be the name of the restored key. | 
-**transitMountPath** | **string** | Path that the backend was mounted at | [default to &quot;transit&quot;]
 
 ### Other Parameters
 
@@ -20944,7 +20626,6 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
-**transitMountPath** | **string** | Path that the backend was mounted at | [default to &quot;transit&quot;]
 
 ### Other Parameters
 
@@ -21011,7 +20692,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the key | 
-**transitMountPath** | **string** | Path that the backend was mounted at | [default to &quot;transit&quot;]
 
 ### Other Parameters
 
@@ -21079,7 +20759,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the key | 
-**transitMountPath** | **string** | Path that the backend was mounted at | [default to &quot;transit&quot;]
 
 ### Other Parameters
 
@@ -21147,7 +20826,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | The key to use | 
-**transitMountPath** | **string** | Path that the backend was mounted at | [default to &quot;transit&quot;]
 
 ### Other Parameters
 
@@ -21218,7 +20896,6 @@ Name | Type | Description  | Notes
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | The key to use | 
 **urlalgorithm** | **string** | Hash algorithm to use (POST URL parameter) | 
-**transitMountPath** | **string** | Path that the backend was mounted at | [default to &quot;transit&quot;]
 
 ### Other Parameters
 
@@ -21287,7 +20964,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | Name of the key | 
-**transitMountPath** | **string** | Path that the backend was mounted at | [default to &quot;transit&quot;]
 
 ### Other Parameters
 
@@ -21355,7 +21031,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | The key to use | 
-**transitMountPath** | **string** | Path that the backend was mounted at | [default to &quot;transit&quot;]
 
 ### Other Parameters
 
@@ -21426,7 +21101,6 @@ Name | Type | Description  | Notes
 **ctx** | **context.Context** | context for request cancellation 
 **name** | **string** | The key to use | 
 **urlalgorithm** | **string** | Hash algorithm to use (POST URL parameter) | 
-**transitMountPath** | **string** | Path that the backend was mounted at | [default to &quot;transit&quot;]
 
 ### Other Parameters
 

--- a/generate/templates/api_doc.handlebars
+++ b/generate/templates/api_doc.handlebars
@@ -62,8 +62,8 @@ func main() {
 {{#unless allParams}}This endpoint does not require any parameters.{{/unless}}{{#each pathParams}}{{#if @last}}
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
-**ctx** | **context.Context** | context for request cancellation {{/if}}{{/each}}{{#each pathParams}}{{#with required}}
-**{{paramName}}** | {{#unless isPrimitiveType}}{{#unless isFile}}[{{/unless}}{{/unless}}**{{dataType}}**{{#unless isPrimitiveType}}{{#unless isFile}}]({{baseType}}.md){{/unless}}{{/unless}} | {{description}} | {{#with defaultValue}}[default to {{.}}]{{/with}}{{/with}}{{/each}}
+**ctx** | **context.Context** | context for request cancellation {{/if}}{{/each}}{{#each pathParams}}{{#endsWith baseName "_mount_path"}}{{else}}
+**{{paramName}}** | {{#unless isPrimitiveType}}{{#unless isFile}}[{{/unless}}{{/unless}}**{{dataType}}**{{#unless isPrimitiveType}}{{#unless isFile}}]({{baseType}}.md){{/unless}}{{/unless}} | {{description}} | {{#with defaultValue}}[default to {{.}}]{{/with}}{{/endsWith}}{{/each}}
 
 ### Other Parameters
 


### PR DESCRIPTION
## Description

I missed a few mount-path related entries in #161, cleaning them up here.
