### PR TITLE
0.3.2 Release Notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to
 
 ## Unreleased ([diff][unreleased-diff])
 
+## [0.3.2][] ([diff][0.3.2-diff]) - 2023-05-16
+
+### Added
+
+- Added support for custom query parameters
+
+### Deprecated
+
+- Deprecated ReadWithParameters
+- Deprecated ReadRawWithParameters
+- Deprecated DeleteWithParameters 
+
 ## [0.3.1][] ([diff][0.3.1-diff]) - 2023-05-10
 
 ### Changed
@@ -81,7 +93,9 @@ and this project adheres to
 <!-- diffs -->
 
 [unreleased-diff]:
-  https://github.com/hashicorp/vault-client-go/compare/v0.3.1...HEAD
+  https://github.com/hashicorp/vault-client-go/compare/v0.3.2...HEAD
+[0.3.2-diff]:
+  https://github.com/hashicorp/vault-client-go/compare/v0.3.1...v0.3.2
 [0.3.1-diff]:
   https://github.com/hashicorp/vault-client-go/compare/v0.3.0...v0.3.1
 [0.3.0-diff]:
@@ -95,6 +109,7 @@ and this project adheres to
 
 <!-- releases -->
 
+[0.3.2]: https://github.com/hashicorp/vault-client-go/releases/tag/v0.3.2
 [0.3.1]: https://github.com/hashicorp/vault-client-go/releases/tag/v0.3.1
 [0.3.0]: https://github.com/hashicorp/vault-client-go/releases/tag/v0.3.0
 [0.2.0]: https://github.com/hashicorp/vault-client-go/releases/tag/v0.2.0

--- a/client.go
+++ b/client.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/go-retryablehttp"
 )
 
-const ClientVersion = "0.3.1"
+const ClientVersion = "0.3.2"
 
 // Client manages communication with Vault, initialize it with vault.New(...)
 type Client struct {

--- a/generate/config.yaml
+++ b/generate/config.yaml
@@ -3,5 +3,5 @@
 
 additionalProperties:
   packageName: vault
-  packageVersion: 0.3.1
+  packageVersion: 0.3.2
 


### PR DESCRIPTION
## [0.3.2][] ([diff][0.3.2-diff]) - 2023-05-16

### Added

- Added support for custom query parameters

### Deprecated

- Deprecated ReadWithParameters
- Deprecated ReadRawWithParameters
- Deprecated DeleteWithParameters 

[0.3.2-diff]:
  https://github.com/hashicorp/vault-client-go/compare/v0.3.1...v0.3.2
[0.3.2]: https://github.com/hashicorp/vault-client-go/releases/tag/v0.3.2


