### PR TITLE
Sync OpenAPI; PkiConfigureAcmeRequest += AllowRoleExtKeyUsage

### DIFF
--- a/docs/PkiConfigureAcmeRequest.md
+++ b/docs/PkiConfigureAcmeRequest.md
@@ -5,6 +5,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
+**AllowRoleExtKeyUsage** | Pointer to **bool** | whether the ExtKeyUsage field from a role is used, defaults to false meaning that certificate will be signed with ServerAuth. | [optional] [default to false]
 **AllowedIssuers** | Pointer to **[]string** | which issuers are allowed for use with ACME; by default, this will only be the primary (default) issuer | [optional] [default to ["*"]]
 **AllowedRoles** | Pointer to **[]string** | which roles are allowed for use with ACME; by default via &#x27;*&#x27;, these will be all roles including sign-verbatim; when concrete role names are specified, any default_directory_policy role must be included to allow usage of the default acme directories under /pki/acme/directory and /pki/issuer/:issuer_id/acme/directory. | [optional] [default to ["*"]]
 **DefaultDirectoryPolicy** | Pointer to **string** | the policy to be used for non-role-qualified ACME requests; by default ACME issuance will be otherwise unrestricted, equivalent to the sign-verbatim endpoint; one may also specify a role to use as this policy, as \&quot;role:&lt;role_name&gt;\&quot;, the specified role must be allowed by allowed_roles | [optional] [default to "sign-verbatim"]

--- a/openapi.json
+++ b/openapi.json
@@ -348,6 +348,7 @@
     },
     "/auth/token/revoke-orphan": {
       "description": "This endpoint will delete the token and orphan its child tokens.",
+      "x-vault-sudo": true,
       "post": {
         "summary": "This endpoint will delete the token and orphan its child tokens.",
         "operationId": "token-revoke-orphan",
@@ -14970,6 +14971,7 @@
     },
     "/sys/seal": {
       "description": "Seals the Vault.",
+      "x-vault-sudo": true,
       "post": {
         "summary": "Seal the Vault.",
         "operationId": "seal",
@@ -15031,6 +15033,7 @@
       }
     },
     "/sys/step-down": {
+      "x-vault-sudo": true,
       "post": {
         "summary": "Cause the node to give up active status.",
         "description": "This endpoint forces the node to give up active status. If the node does not have active status, this endpoint does nothing. Note that the node will sleep for ten seconds before attempting to grab the active lock again, but if no standby nodes grab the active lock in the interim, the same node may become the active node again.",
@@ -28299,7 +28302,6 @@
           "required": true
         }
       ],
-      "x-vault-createSupported": true,
       "get": {
         "summary": "Returns the size of the active cache",
         "operationId": "transit-read-cache-configuration",
@@ -38437,6 +38439,11 @@
       "PkiConfigureAcmeRequest": {
         "type": "object",
         "properties": {
+          "allow_role_ext_key_usage": {
+            "type": "boolean",
+            "description": "whether the ExtKeyUsage field from a role is used, defaults to false meaning that certificate will be signed with ServerAuth.",
+            "default": false
+          },
           "allowed_issuers": {
             "type": "array",
             "description": "which issuers are allowed for use with ACME; by default, this will only be the primary (default) issuer",

--- a/schema/model_pki_configure_acme_request.go
+++ b/schema/model_pki_configure_acme_request.go
@@ -7,6 +7,9 @@ package schema
 
 // PkiConfigureAcmeRequest struct for PkiConfigureAcmeRequest
 type PkiConfigureAcmeRequest struct {
+	// whether the ExtKeyUsage field from a role is used, defaults to false meaning that certificate will be signed with ServerAuth.
+	AllowRoleExtKeyUsage bool `json:"allow_role_ext_key_usage,omitempty"`
+
 	// which issuers are allowed for use with ACME; by default, this will only be the primary (default) issuer
 	AllowedIssuers []string `json:"allowed_issuers,omitempty"`
 


### PR DESCRIPTION
Also some corrections to x-vault-sudo and x-vault-createSupported
metadata in the OpenAPI document that do not influence generation.

Normally I wouldn't bother creating a separate PR just for this, but
I have a few open Vault PRs that will result in larger cross-cutting
changes to the generated OpenAPI, so I thought it best to do this minor
sync first, so that these changes are not mingled with those upcoming
changes.
