### PR TITLE
Fix templates to deal with arbitrary input APIs

### DIFF
--- a/generate/templates/api.handlebars
+++ b/generate/templates/api.handlebars
@@ -29,7 +29,7 @@ type {{cut classname "Api"}} struct {
 // {{paramName}}: {{.}}{{/with}}{{/endsWith}}{{/each}}{{#each bodyParams}}{{#with description}}
 // {{paramName}}: {{.}}{{/with}}{{/each}}{{#each queryParams}}{{#neq paramName "list"}}{{#with description}}
 // {{paramName}}: {{.}}{{/with}}{{/neq}}{{/each}}
-func ({{lower (substring classname 0 1)}} *{{cut classname "Api"}}) {{nickname}}(ctx context.Context{{#each pathParams}}{{#endsWith baseName "_mount_path"}}{{else}}, {{paramName}} {{{dataType}}}{{/endsWith}}{{/each}}{{#each bodyParams}}, request schema.{{{dataType}}}{{/each}}{{#each queryParams}}{{#neq paramName "list"}}, {{paramName}} {{{dataType}}}{{/neq}}{{/each}}, options ...RequestOption) (*Response[{{#with returnType}}schema.{{{.}}}{{/with}}{{#unless returnType}}map[string]interface{}{{/unless}}], error) {
+func ({{lower (substring classname 0 1)}} *{{cut classname "Api"}}) {{nickname}}(ctx context.Context{{#each pathParams}}{{#endsWith baseName "_mount_path"}}{{else}}, {{paramName}} {{{dataType}}}{{/endsWith}}{{/each}}{{#each bodyParams}}, request {{#if isModel}}schema.{{/if}}{{{dataType}}}{{/each}}{{#each queryParams}}{{#neq paramName "list"}}, {{paramName}} {{{dataType}}}{{/neq}}{{/each}}, options ...RequestOption) (*Response[{{#with returnType}}schema.{{{.}}}{{/with}}{{#unless returnType}}map[string]interface{}{{/unless}}], error) {
 	requestModifiers, err := requestOptionsToRequestModifiers(options)
 	if err != nil {
 		return nil, err

--- a/generate/templates/api_doc.handlebars
+++ b/generate/templates/api_doc.handlebars
@@ -26,7 +26,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/hashicorp/vault-client-go"{{#each bodyParams}}{{#if @first}}
+	"github.com/hashicorp/vault-client-go"{{#each bodyParams}}{{#if isModel}}
 	"github.com/hashicorp/vault-client-go/schema"{{/if}}{{/each}}
 )
 


### PR DESCRIPTION
Contributes to fixing #201

These template changes make no difference to the code right now, but
combined with the incoming OpenAPI changes in hashicorp/vault#22027 and
hashicorp/vault-plugin-secrets-kv#114 will effect the fix.
