### PR TITLE
Send query parameters to the Vault API using correct names

### DIFF
--- a/api_identity.go
+++ b/api_identity.go
@@ -1850,7 +1850,7 @@ func (i *Identity) OidcListProviders(ctx context.Context, allowedClientId string
 	requestPath := "/v1/identity/oidc/provider/"
 
 	requestQueryParameters := requestModifiers.customQueryParametersOrDefault()
-	requestQueryParameters.Add("allowedClientId", url.QueryEscape(parameterToString(allowedClientId)))
+	requestQueryParameters.Add("allowed_client_id", url.QueryEscape(parameterToString(allowedClientId)))
 	requestQueryParameters.Add("list", "true")
 
 	return sendRequestParseResponse[map[string]interface{}](

--- a/api_system.go
+++ b/api_system.go
@@ -946,7 +946,7 @@ func (s *System) InternalGenerateOpenApiDocument(ctx context.Context, genericMou
 	requestPath := "/v1/sys/internal/specs/openapi"
 
 	requestQueryParameters := requestModifiers.customQueryParametersOrDefault()
-	requestQueryParameters.Add("genericMountPaths", url.QueryEscape(parameterToString(genericMountPaths)))
+	requestQueryParameters.Add("generic_mount_paths", url.QueryEscape(parameterToString(genericMountPaths)))
 
 	return sendRequestParseResponse[map[string]interface{}](
 		ctx,
@@ -970,7 +970,7 @@ func (s *System) InternalGenerateOpenApiDocumentWithParameters(ctx context.Conte
 	requestPath := "/v1/sys/internal/specs/openapi"
 
 	requestQueryParameters := requestModifiers.customQueryParametersOrDefault()
-	requestQueryParameters.Add("genericMountPaths", url.QueryEscape(parameterToString(genericMountPaths)))
+	requestQueryParameters.Add("generic_mount_paths", url.QueryEscape(parameterToString(genericMountPaths)))
 
 	return sendStructuredRequestParseResponse[map[string]interface{}](
 		ctx,
@@ -1661,8 +1661,8 @@ func (s *System) Monitor(ctx context.Context, logFormat string, logLevel string,
 	requestPath := "/v1/sys/monitor"
 
 	requestQueryParameters := requestModifiers.customQueryParametersOrDefault()
-	requestQueryParameters.Add("logFormat", url.QueryEscape(parameterToString(logFormat)))
-	requestQueryParameters.Add("logLevel", url.QueryEscape(parameterToString(logLevel)))
+	requestQueryParameters.Add("log_format", url.QueryEscape(parameterToString(logFormat)))
+	requestQueryParameters.Add("log_level", url.QueryEscape(parameterToString(logLevel)))
 
 	return sendRequestParseResponse[map[string]interface{}](
 		ctx,

--- a/generate/templates/api.handlebars
+++ b/generate/templates/api.handlebars
@@ -40,8 +40,8 @@ func ({{lower (substring classname 0 1)}} *{{cut classname "Api"}}) {{nickname}}
     requestPath = strings.Replace(requestPath, "{"+"{{baseName}}"+"}", url.PathEscape({{paramName}}), -1){{/endsWith}}{{/each}}
 
 	requestQueryParameters := requestModifiers.customQueryParametersOrDefault(){{#each queryParams}}{{#eq paramName "list"}}
-	requestQueryParameters.Add("{{paramName}}", "true"){{/eq}}{{#neq paramName "list"}}
-	requestQueryParameters.Add("{{paramName}}", url.QueryEscape(parameterToString({{paramName}}))){{/neq}}{{/each}}
+	requestQueryParameters.Add("{{baseName}}", "true"){{/eq}}{{#neq paramName "list"}}
+	requestQueryParameters.Add("{{baseName}}", url.QueryEscape(parameterToString({{paramName}}))){{/neq}}{{/each}}
 
 {{#each bodyParams}}
 	return sendStructuredRequestParseResponse[{{#with returnType}}schema.{{{.}}}{{/with}}{{#unless returnType}}map[string]interface{}{{/unless}}](


### PR DESCRIPTION
They were incorrectly being rendered converted to camelCase instead of
Vault's native snake_case.
