### PR TITLE
Update README getting-started with correct mount-paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,19 +83,20 @@ func main() {
 	}
 
 	// write a secret
-	_, err = client.Secrets.KvV2Write(ctx, "my-secret", schema.KvV2WriteRequest{
+	_, err = client.Secrets.KvV2Write(ctx, "foo", schema.KvV2WriteRequest{
 		Data: map[string]any{
 			"password1": "abc123",
 			"password2": "correct horse battery staple",
-		},
-	})
+		}},
+		vault.WithMountPath("secret"),
+	)
 	if err != nil {
 		log.Fatal(err)
 	}
 	log.Println("secret written successfully")
 
-	// read a secret
-	s, err := client.Secrets.KvV2Read(ctx, "my-secret")
+	// read the secret
+	s, err := client.Secrets.KvV2Read(ctx, "foo", vault.WithMountPath("secret"))
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
## Description

https://github.com/hashicorp/vault/pull/21563 changed the default mount path for KVv2 to `"kv-v2"`.