### PR TITLE
Fix query params being double-encoded

### DIFF
--- a/api_auth.go
+++ b/api_auth.go
@@ -3893,9 +3893,9 @@ func (a *Auth) JwtOidcCallback(ctx context.Context, clientNonce string, code str
 	requestPath = strings.Replace(requestPath, "{"+"jwt_mount_path"+"}", url.PathEscape(requestModifiers.mountPathOr("jwt")), -1)
 
 	requestQueryParameters := requestModifiers.customQueryParametersOrDefault()
-	requestQueryParameters.Add("client_nonce", url.QueryEscape(parameterToString(clientNonce)))
-	requestQueryParameters.Add("code", url.QueryEscape(parameterToString(code)))
-	requestQueryParameters.Add("state", url.QueryEscape(parameterToString(state)))
+	requestQueryParameters.Add("client_nonce", parameterToString(clientNonce))
+	requestQueryParameters.Add("code", parameterToString(code))
+	requestQueryParameters.Add("state", parameterToString(state))
 
 	return sendRequestParseResponse[map[string]interface{}](
 		ctx,

--- a/api_identity.go
+++ b/api_identity.go
@@ -1850,7 +1850,7 @@ func (i *Identity) OidcListProviders(ctx context.Context, allowedClientId string
 	requestPath := "/v1/identity/oidc/provider/"
 
 	requestQueryParameters := requestModifiers.customQueryParametersOrDefault()
-	requestQueryParameters.Add("allowed_client_id", url.QueryEscape(parameterToString(allowedClientId)))
+	requestQueryParameters.Add("allowed_client_id", parameterToString(allowedClientId))
 	requestQueryParameters.Add("list", "true")
 
 	return sendRequestParseResponse[schema.StandardListResponse](
@@ -1931,15 +1931,15 @@ func (i *Identity) OidcProviderAuthorize(ctx context.Context, name string, clien
 	requestPath = strings.Replace(requestPath, "{"+"name"+"}", url.PathEscape(name), -1)
 
 	requestQueryParameters := requestModifiers.customQueryParametersOrDefault()
-	requestQueryParameters.Add("client_id", url.QueryEscape(parameterToString(clientId)))
-	requestQueryParameters.Add("code_challenge", url.QueryEscape(parameterToString(codeChallenge)))
-	requestQueryParameters.Add("code_challenge_method", url.QueryEscape(parameterToString(codeChallengeMethod)))
-	requestQueryParameters.Add("max_age", url.QueryEscape(parameterToString(maxAge)))
-	requestQueryParameters.Add("nonce", url.QueryEscape(parameterToString(nonce)))
-	requestQueryParameters.Add("redirect_uri", url.QueryEscape(parameterToString(redirectUri)))
-	requestQueryParameters.Add("response_type", url.QueryEscape(parameterToString(responseType)))
-	requestQueryParameters.Add("scope", url.QueryEscape(parameterToString(scope)))
-	requestQueryParameters.Add("state", url.QueryEscape(parameterToString(state)))
+	requestQueryParameters.Add("client_id", parameterToString(clientId))
+	requestQueryParameters.Add("code_challenge", parameterToString(codeChallenge))
+	requestQueryParameters.Add("code_challenge_method", parameterToString(codeChallengeMethod))
+	requestQueryParameters.Add("max_age", parameterToString(maxAge))
+	requestQueryParameters.Add("nonce", parameterToString(nonce))
+	requestQueryParameters.Add("redirect_uri", parameterToString(redirectUri))
+	requestQueryParameters.Add("response_type", parameterToString(responseType))
+	requestQueryParameters.Add("scope", parameterToString(scope))
+	requestQueryParameters.Add("state", parameterToString(state))
 
 	return sendRequestParseResponse[map[string]interface{}](
 		ctx,

--- a/api_secrets.go
+++ b/api_secrets.go
@@ -324,9 +324,9 @@ func (s *Secrets) AwsGenerateCredentials(ctx context.Context, name string, roleA
 	requestPath = strings.Replace(requestPath, "{"+"name"+"}", url.PathEscape(name), -1)
 
 	requestQueryParameters := requestModifiers.customQueryParametersOrDefault()
-	requestQueryParameters.Add("role_arn", url.QueryEscape(parameterToString(roleArn)))
-	requestQueryParameters.Add("role_session_name", url.QueryEscape(parameterToString(roleSessionName)))
-	requestQueryParameters.Add("ttl", url.QueryEscape(parameterToString(ttl)))
+	requestQueryParameters.Add("role_arn", parameterToString(roleArn))
+	requestQueryParameters.Add("role_session_name", parameterToString(roleSessionName))
+	requestQueryParameters.Add("ttl", parameterToString(ttl))
 
 	return sendRequestParseResponse[map[string]interface{}](
 		ctx,
@@ -380,9 +380,9 @@ func (s *Secrets) AwsGenerateStsCredentials(ctx context.Context, name string, ro
 	requestPath = strings.Replace(requestPath, "{"+"name"+"}", url.PathEscape(name), -1)
 
 	requestQueryParameters := requestModifiers.customQueryParametersOrDefault()
-	requestQueryParameters.Add("role_arn", url.QueryEscape(parameterToString(roleArn)))
-	requestQueryParameters.Add("role_session_name", url.QueryEscape(parameterToString(roleSessionName)))
-	requestQueryParameters.Add("ttl", url.QueryEscape(parameterToString(ttl)))
+	requestQueryParameters.Add("role_arn", parameterToString(roleArn))
+	requestQueryParameters.Add("role_session_name", parameterToString(roleSessionName))
+	requestQueryParameters.Add("ttl", parameterToString(ttl))
 
 	return sendRequestParseResponse[map[string]interface{}](
 		ctx,

--- a/api_system.go
+++ b/api_system.go
@@ -947,8 +947,8 @@ func (s *System) InternalGenerateOpenApiDocument(ctx context.Context, context st
 	requestPath := "/v1/sys/internal/specs/openapi"
 
 	requestQueryParameters := requestModifiers.customQueryParametersOrDefault()
-	requestQueryParameters.Add("context", url.QueryEscape(parameterToString(context)))
-	requestQueryParameters.Add("generic_mount_paths", url.QueryEscape(parameterToString(genericMountPaths)))
+	requestQueryParameters.Add("context", parameterToString(context))
+	requestQueryParameters.Add("generic_mount_paths", parameterToString(genericMountPaths))
 
 	return sendRequestParseResponse[map[string]interface{}](
 		ctx,
@@ -1614,7 +1614,7 @@ func (s *System) Metrics(ctx context.Context, format string, options ...RequestO
 	requestPath := "/v1/sys/metrics"
 
 	requestQueryParameters := requestModifiers.customQueryParametersOrDefault()
-	requestQueryParameters.Add("format", url.QueryEscape(parameterToString(format)))
+	requestQueryParameters.Add("format", parameterToString(format))
 
 	return sendRequestParseResponse[map[string]interface{}](
 		ctx,
@@ -1661,8 +1661,8 @@ func (s *System) Monitor(ctx context.Context, logFormat string, logLevel string,
 	requestPath := "/v1/sys/monitor"
 
 	requestQueryParameters := requestModifiers.customQueryParametersOrDefault()
-	requestQueryParameters.Add("log_format", url.QueryEscape(parameterToString(logFormat)))
-	requestQueryParameters.Add("log_level", url.QueryEscape(parameterToString(logLevel)))
+	requestQueryParameters.Add("log_format", parameterToString(logFormat))
+	requestQueryParameters.Add("log_level", parameterToString(logLevel))
 
 	return sendRequestParseResponse[map[string]interface{}](
 		ctx,

--- a/generate/templates/api.handlebars
+++ b/generate/templates/api.handlebars
@@ -38,9 +38,14 @@ func ({{lower (substring classname 0 1)}} *{{cut classname "Api"}}) {{nickname}}
 	requestPath = strings.Replace(requestPath, "{"+"{{baseName}}"+"}", url.PathEscape(requestModifiers.mountPathOr({{#with defaultValue}}{{{.}}}{{/with}})), -1){{/endsWith}}{{/each}}{{#each pathParams}}{{#endsWith baseName "_mount_path"}}{{else}}
     requestPath = strings.Replace(requestPath, "{"+"{{baseName}}"+"}", url.PathEscape({{paramName}}), -1){{/endsWith}}{{/each}}
 
-	requestQueryParameters := requestModifiers.customQueryParametersOrDefault(){{#each queryParams}}{{#eq paramName "list"}}
-	requestQueryParameters.Add("{{baseName}}", "true"){{/eq}}{{#neq paramName "list"}}
-	requestQueryParameters.Add("{{baseName}}", url.QueryEscape(parameterToString({{paramName}}))){{/neq}}{{/each}}
+	requestQueryParameters := requestModifiers.customQueryParametersOrDefault()
+{{~#each queryParams}}
+{{~#eq paramName "list"}}
+	requestQueryParameters.Add("{{baseName}}", "true")
+{{~else}}
+	requestQueryParameters.Add("{{baseName}}", parameterToString({{paramName}}))
+{{~/eq}}
+{{~/each}}
 
 {{#each bodyParams}}
 	return sendStructuredRequestParseResponse[{{#with returnType}}schema.{{{.}}}{{/with}}{{#unless returnType}}map[string]interface{}{{/unless}}](


### PR DESCRIPTION
It is inappropriate to be encoding them in the templated code. They get
passed into the HTTP client which encodes them again!

Also, restructure the affected chunk of Handlebars to be easier to read.
