### PR TITLE
Sync OpenAPI: Changes to PKI sign responses

### DIFF
--- a/docs/PkiIssuerSignVerbatimResponse.md
+++ b/docs/PkiIssuerSignVerbatimResponse.md
@@ -9,8 +9,6 @@ Name | Type | Description | Notes
 **Certificate** | Pointer to **string** | Certificate | [optional] 
 **Expiration** | Pointer to **int64** | Time of expiration | [optional] 
 **IssuingCa** | Pointer to **string** | Issuing Certificate Authority | [optional] 
-**PrivateKey** | Pointer to **string** | Private key | [optional] 
-**PrivateKeyType** | Pointer to **string** | Private key type | [optional] 
 **SerialNumber** | Pointer to **string** | Serial Number | [optional] 
 
 

--- a/docs/PkiIssuerSignVerbatimWithRoleResponse.md
+++ b/docs/PkiIssuerSignVerbatimWithRoleResponse.md
@@ -9,8 +9,6 @@ Name | Type | Description | Notes
 **Certificate** | Pointer to **string** | Certificate | [optional] 
 **Expiration** | Pointer to **int64** | Time of expiration | [optional] 
 **IssuingCa** | Pointer to **string** | Issuing Certificate Authority | [optional] 
-**PrivateKey** | Pointer to **string** | Private key | [optional] 
-**PrivateKeyType** | Pointer to **string** | Private key type | [optional] 
 **SerialNumber** | Pointer to **string** | Serial Number | [optional] 
 
 

--- a/docs/PkiIssuerSignWithRoleResponse.md
+++ b/docs/PkiIssuerSignWithRoleResponse.md
@@ -9,8 +9,6 @@ Name | Type | Description | Notes
 **Certificate** | Pointer to **string** | Certificate | [optional] 
 **Expiration** | Pointer to **int64** | Time of expiration | [optional] 
 **IssuingCa** | Pointer to **string** | Issuing Certificate Authority | [optional] 
-**PrivateKey** | Pointer to **string** | Private key | [optional] 
-**PrivateKeyType** | Pointer to **string** | Private key type | [optional] 
 **SerialNumber** | Pointer to **string** | Serial Number | [optional] 
 
 

--- a/docs/PkiSignVerbatimResponse.md
+++ b/docs/PkiSignVerbatimResponse.md
@@ -9,8 +9,6 @@ Name | Type | Description | Notes
 **Certificate** | Pointer to **string** | Certificate | [optional] 
 **Expiration** | Pointer to **int64** | Time of expiration | [optional] 
 **IssuingCa** | Pointer to **string** | Issuing Certificate Authority | [optional] 
-**PrivateKey** | Pointer to **string** | Private key | [optional] 
-**PrivateKeyType** | Pointer to **string** | Private key type | [optional] 
 **SerialNumber** | Pointer to **string** | Serial Number | [optional] 
 
 

--- a/docs/PkiSignVerbatimWithRoleResponse.md
+++ b/docs/PkiSignVerbatimWithRoleResponse.md
@@ -9,8 +9,6 @@ Name | Type | Description | Notes
 **Certificate** | Pointer to **string** | Certificate | [optional] 
 **Expiration** | Pointer to **int64** | Time of expiration | [optional] 
 **IssuingCa** | Pointer to **string** | Issuing Certificate Authority | [optional] 
-**PrivateKey** | Pointer to **string** | Private key | [optional] 
-**PrivateKeyType** | Pointer to **string** | Private key type | [optional] 
 **SerialNumber** | Pointer to **string** | Serial Number | [optional] 
 
 

--- a/docs/PkiSignWithRoleResponse.md
+++ b/docs/PkiSignWithRoleResponse.md
@@ -9,8 +9,6 @@ Name | Type | Description | Notes
 **Certificate** | Pointer to **string** | Certificate | [optional] 
 **Expiration** | Pointer to **int64** | Time of expiration | [optional] 
 **IssuingCa** | Pointer to **string** | Issuing Certificate Authority | [optional] 
-**PrivateKey** | Pointer to **string** | Private key | [optional] 
-**PrivateKeyType** | Pointer to **string** | Private key type | [optional] 
 **SerialNumber** | Pointer to **string** | Serial Number | [optional] 
 
 

--- a/openapi.json
+++ b/openapi.json
@@ -41558,14 +41558,6 @@
             "type": "string",
             "description": "Issuing Certificate Authority"
           },
-          "private_key": {
-            "type": "string",
-            "description": "Private key"
-          },
-          "private_key_type": {
-            "type": "string",
-            "description": "Private key type"
-          },
           "serial_number": {
             "type": "string",
             "description": "Serial Number"
@@ -41752,14 +41744,6 @@
             "type": "string",
             "description": "Issuing Certificate Authority"
           },
-          "private_key": {
-            "type": "string",
-            "description": "Private key"
-          },
-          "private_key_type": {
-            "type": "string",
-            "description": "Private key type"
-          },
           "serial_number": {
             "type": "string",
             "description": "Serial Number"
@@ -41905,14 +41889,6 @@
           "issuing_ca": {
             "type": "string",
             "description": "Issuing Certificate Authority"
-          },
-          "private_key": {
-            "type": "string",
-            "description": "Private key"
-          },
-          "private_key_type": {
-            "type": "string",
-            "description": "Private key type"
           },
           "serial_number": {
             "type": "string",
@@ -44858,14 +44834,6 @@
             "type": "string",
             "description": "Issuing Certificate Authority"
           },
-          "private_key": {
-            "type": "string",
-            "description": "Private key"
-          },
-          "private_key_type": {
-            "type": "string",
-            "description": "Private key type"
-          },
           "serial_number": {
             "type": "string",
             "description": "Serial Number"
@@ -45057,14 +45025,6 @@
             "type": "string",
             "description": "Issuing Certificate Authority"
           },
-          "private_key": {
-            "type": "string",
-            "description": "Private key"
-          },
-          "private_key_type": {
-            "type": "string",
-            "description": "Private key type"
-          },
           "serial_number": {
             "type": "string",
             "description": "Serial Number"
@@ -45215,14 +45175,6 @@
           "issuing_ca": {
             "type": "string",
             "description": "Issuing Certificate Authority"
-          },
-          "private_key": {
-            "type": "string",
-            "description": "Private key"
-          },
-          "private_key_type": {
-            "type": "string",
-            "description": "Private key type"
           },
           "serial_number": {
             "type": "string",

--- a/schema/model_pki_issuer_sign_verbatim_response.go
+++ b/schema/model_pki_issuer_sign_verbatim_response.go
@@ -19,12 +19,6 @@ type PkiIssuerSignVerbatimResponse struct {
 	// Issuing Certificate Authority
 	IssuingCa string `json:"issuing_ca,omitempty"`
 
-	// Private key
-	PrivateKey string `json:"private_key,omitempty"`
-
-	// Private key type
-	PrivateKeyType string `json:"private_key_type,omitempty"`
-
 	// Serial Number
 	SerialNumber string `json:"serial_number,omitempty"`
 }

--- a/schema/model_pki_issuer_sign_verbatim_with_role_response.go
+++ b/schema/model_pki_issuer_sign_verbatim_with_role_response.go
@@ -19,12 +19,6 @@ type PkiIssuerSignVerbatimWithRoleResponse struct {
 	// Issuing Certificate Authority
 	IssuingCa string `json:"issuing_ca,omitempty"`
 
-	// Private key
-	PrivateKey string `json:"private_key,omitempty"`
-
-	// Private key type
-	PrivateKeyType string `json:"private_key_type,omitempty"`
-
 	// Serial Number
 	SerialNumber string `json:"serial_number,omitempty"`
 }

--- a/schema/model_pki_issuer_sign_with_role_response.go
+++ b/schema/model_pki_issuer_sign_with_role_response.go
@@ -19,12 +19,6 @@ type PkiIssuerSignWithRoleResponse struct {
 	// Issuing Certificate Authority
 	IssuingCa string `json:"issuing_ca,omitempty"`
 
-	// Private key
-	PrivateKey string `json:"private_key,omitempty"`
-
-	// Private key type
-	PrivateKeyType string `json:"private_key_type,omitempty"`
-
 	// Serial Number
 	SerialNumber string `json:"serial_number,omitempty"`
 }

--- a/schema/model_pki_sign_verbatim_response.go
+++ b/schema/model_pki_sign_verbatim_response.go
@@ -19,12 +19,6 @@ type PkiSignVerbatimResponse struct {
 	// Issuing Certificate Authority
 	IssuingCa string `json:"issuing_ca,omitempty"`
 
-	// Private key
-	PrivateKey string `json:"private_key,omitempty"`
-
-	// Private key type
-	PrivateKeyType string `json:"private_key_type,omitempty"`
-
 	// Serial Number
 	SerialNumber string `json:"serial_number,omitempty"`
 }

--- a/schema/model_pki_sign_verbatim_with_role_response.go
+++ b/schema/model_pki_sign_verbatim_with_role_response.go
@@ -19,12 +19,6 @@ type PkiSignVerbatimWithRoleResponse struct {
 	// Issuing Certificate Authority
 	IssuingCa string `json:"issuing_ca,omitempty"`
 
-	// Private key
-	PrivateKey string `json:"private_key,omitempty"`
-
-	// Private key type
-	PrivateKeyType string `json:"private_key_type,omitempty"`
-
 	// Serial Number
 	SerialNumber string `json:"serial_number,omitempty"`
 }

--- a/schema/model_pki_sign_with_role_response.go
+++ b/schema/model_pki_sign_with_role_response.go
@@ -19,12 +19,6 @@ type PkiSignWithRoleResponse struct {
 	// Issuing Certificate Authority
 	IssuingCa string `json:"issuing_ca,omitempty"`
 
-	// Private key
-	PrivateKey string `json:"private_key,omitempty"`
-
-	// Private key type
-	PrivateKeyType string `json:"private_key_type,omitempty"`
-
 	// Serial Number
 	SerialNumber string `json:"serial_number,omitempty"`
 }


### PR DESCRIPTION
Removes an incorrect field from some responses, from
hashicorp/vault#22053.
