### PR TITLE
Improve exclusion of operation IDs

### DIFF
--- a/.openapi-generator-ignore
+++ b/.openapi-generator-ignore
@@ -4,12 +4,18 @@ api/openapi.yaml
 
 README.md
 
+# We exclude some operations from the generated library by ID. openapi-generator does not have a way for us to do that
+# directly, so we must do it by filename here, and also separately by Handlebars expressions in the
+# partial_filter_operation template.
+
 model_*2_request.go
 model_*2_response.go
 model_*3_request.go
 model_*3_response.go
 model_*4_request.go
 model_*4_response.go
+model_enterprise_stub*_request.go
+model_enterprise_stub*_response.go
 
 docs/*2Request.md
 docs/*2Response.md
@@ -17,6 +23,8 @@ docs/*3Request.md
 docs/*3Response.md
 docs/*4Request.md
 docs/*4Response.md
+docs/EnterpriseStub*Request.md
+docs/EnterpriseStub*Response.md
 
 configuration.go
 response.go

--- a/generate/templates/api.handlebars
+++ b/generate/templates/api.handlebars
@@ -17,10 +17,7 @@ type {{cut classname "Api"}} struct {
 	client *Client
 }
 {{#each operation}}
-{{#endsWith nickname "2"}}{{else}}
-{{#endsWith nickname "3"}}{{else}}
-{{#endsWith nickname "4"}}{{else}}
-
+{{#>partial_filter_operation}}
 {{#if isDeprecated}}
 // Deprecated{{/if}}
 // {{operationId}} {{#if summary}}{{{summary}}}{{/if}}{{#if notes}}
@@ -70,8 +67,6 @@ func ({{lower (substring classname 0 1)}} *{{cut classname "Api"}}) {{nickname}}
 	)
 {{/unless}}
 }
-{{/endsWith}}
-{{/endsWith}}
-{{/endsWith}}
+{{/partial_filter_operation}}
 {{/each}}
 {{/with}}

--- a/generate/templates/api_doc.handlebars
+++ b/generate/templates/api_doc.handlebars
@@ -6,22 +6,14 @@ Method | HTTP request | Description
 ------------- | ------------- | -------------
 {{#with operations ~}}
 {{#each operation ~}}
-{{#endsWith operationId "2"}}{{else ~}}
-{{#endsWith operationId "3"}}{{else ~}}
-{{#endsWith operationId "4"}}{{else ~}}
-[**{{operationId}}**]({{classname}}.md#{{operationId}}) | **{{httpMethod}}** {{path}} | {{#if summary}}{{summary}}{{/if}}
-{{/endsWith ~}}
-{{/endsWith ~}}
-{{/endsWith ~}}
-{{/each ~}}
+{{#>partial_filter_operation}}[**{{operationId}}**]({{classname}}.md#{{operationId}}) | **{{httpMethod}}** {{path}} | {{#if summary}}{{summary}}{{/if}}
+{{/partial_filter_operation}}
+{{~/each ~}}
 {{/with ~}}
 
 {{#with operations}}
 {{#each operation ~}}
-{{#endsWith operationId "2"}}{{else ~}}
-{{#endsWith operationId "3"}}{{else ~}}
-{{#endsWith operationId "4"}}{{else ~}}
-## {{{operationId}}}
+{{#>partial_filter_operation}}## {{{operationId}}}
 
 {{#if summary}}{{{summary}}}{{/if}}{{#if notes}}
 
@@ -87,8 +79,6 @@ Name | Type | Description  | Notes
 [[Back to top]](#)
 [[Back to README]](../README.md)
 
-{{/endsWith ~}}
-{{/endsWith ~}}
-{{/endsWith ~}}
-{{/each ~}}
+{{/partial_filter_operation}}
+{{~/each ~}}
 {{/with ~}}

--- a/generate/templates/partial_filter_operation.handlebars
+++ b/generate/templates/partial_filter_operation.handlebars
@@ -1,0 +1,8 @@
+{{#not (or
+               (endsWith operationId "2")
+               (endsWith operationId "3")
+               (endsWith operationId "4")
+               (startsWith operationId "EnterpriseStub")
+       ) ~}}
+{{> @partial-block }}
+{{~/not ~}}


### PR DESCRIPTION
Add enterprise-stub as an excluded prefix.

Refactor the exclusion so the exclusion list only needs to be maintained
in one Handlebars template.

(The actual OpenAPI spec sync to make use of this will follow in
a separate PR, to avoid conflicts, and avoid mixing human-authored and
autogenerated changes too much.)
