### PR TITLE
Consolidate /sys/health error checks

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -65,8 +65,12 @@ func isResponseError(req *http.Request, resp *http.Response) *ResponseError {
 	//  - 473 if performance standby
 	//
 	// See: https://developer.hashicorp.com/vault/api-docs/system/health
-	if req.URL.Path == "/v1/sys/health" && slices.Contains([]int{429, 472, 473}, resp.StatusCode) {
-		return nil
+	if req.URL.Path == "/v1/sys/health" {
+		switch resp.StatusCode {
+		case 429, 472, 473:
+			return nil
+		}
+	}
 	}
 
 	responseError := &ResponseError{

--- a/errors.go
+++ b/errors.go
@@ -55,19 +55,13 @@ func isResponseError(req *http.Request, resp *http.Response) *ResponseError {
 		return nil
 	}
 
-	// /v1/sys/health returns a few special 4xx status codes that should not be
-	// treated as errors:
-	//
-	//  - 429 if unsealed and standby
-	//  - 472 if disaster recovery mode replication secondary and active
-	//  - 473 if performance standby
+	// /v1/sys/health returns a few special 4xx and 5xx status codes that
+	// should not be treated as errors; the response will contain valuable
+	// health status information.
 	//
 	// See: https://developer.hashicorp.com/vault/api-docs/system/health
-	if req.URL.Path == "/v1/sys/health" {
-		switch resp.StatusCode {
-		case 429, 472, 473:
-			return nil
-		}
+	if req.URL.Path == "/v1/sys/health" && resp != nil {
+		return nil
 	}
 
 	responseError := &ResponseError{

--- a/errors.go
+++ b/errors.go
@@ -56,7 +56,7 @@ func isResponseError(req *http.Request, resp *http.Response) *ResponseError {
 	}
 
 	// /v1/sys/health returns a few special 4xx and 5xx status codes that
-	// should not be treated as errors; the response will contain valuable
+	// should not be treated as errors; the response body will contain valuable
 	// health status information.
 	//
 	// See: https://developer.hashicorp.com/vault/api-docs/system/health

--- a/errors.go
+++ b/errors.go
@@ -69,7 +69,6 @@ func isResponseError(req *http.Request, resp *http.Response) *ResponseError {
 			return nil
 		}
 	}
-	}
 
 	responseError := &ResponseError{
 		StatusCode:      resp.StatusCode,

--- a/errors.go
+++ b/errors.go
@@ -10,8 +10,6 @@ import (
 	"io"
 	"net/http"
 	"strings"
-
-	"golang.org/x/exp/slices"
 )
 
 // IsErrorStatus returns true if the given error is either a ResponseError or a


### PR DESCRIPTION
## Description

https://github.com/hashicorp/vault-client-go/pull/220 introduced a couple more corner cases for /sys/health error checks. Wrapping them into the original if check per https://github.com/hashicorp/vault-client-go/pull/220#issuecomment-1656026608.
