### PR TITLE
In the generated docs, add missing `schema.` to code samples

### DIFF
--- a/docs/AuthApi.md
+++ b/docs/AuthApi.md
@@ -396,7 +396,7 @@ func main() {
 
 	resp, err := client.Auth.AliCloudLogin(
 		context.Background(),
-		AliCloudLoginRequest{ /* populate request parameters */ },
+		schema.AliCloudLoginRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("alicloud"),
 	)
@@ -519,7 +519,7 @@ func main() {
 	resp, err := client.Auth.AliCloudWriteAuthRole(
 		context.Background(),
 		role,
-		AliCloudWriteAuthRoleRequest{ /* populate request parameters */ },
+		schema.AliCloudWriteAuthRoleRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("alicloud"),
 	)
@@ -1315,7 +1315,7 @@ func main() {
 	resp, err := client.Auth.AppRoleDestroySecretId(
 		context.Background(),
 		roleName,
-		AppRoleDestroySecretIdRequest{ /* populate request parameters */ },
+		schema.AppRoleDestroySecretIdRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("approle"),
 	)
@@ -1379,7 +1379,7 @@ func main() {
 	resp, err := client.Auth.AppRoleDestroySecretIdByAccessor(
 		context.Background(),
 		roleName,
-		AppRoleDestroySecretIdByAccessorRequest{ /* populate request parameters */ },
+		schema.AppRoleDestroySecretIdByAccessorRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("approle"),
 	)
@@ -1561,7 +1561,7 @@ func main() {
 
 	resp, err := client.Auth.AppRoleLogin(
 		context.Background(),
-		AppRoleLoginRequest{ /* populate request parameters */ },
+		schema.AppRoleLoginRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("approle"),
 	)
@@ -1623,7 +1623,7 @@ func main() {
 	resp, err := client.Auth.AppRoleLookUpSecretId(
 		context.Background(),
 		roleName,
-		AppRoleLookUpSecretIdRequest{ /* populate request parameters */ },
+		schema.AppRoleLookUpSecretIdRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("approle"),
 	)
@@ -1687,7 +1687,7 @@ func main() {
 	resp, err := client.Auth.AppRoleLookUpSecretIdByAccessor(
 		context.Background(),
 		roleName,
-		AppRoleLookUpSecretIdByAccessorRequest{ /* populate request parameters */ },
+		schema.AppRoleLookUpSecretIdByAccessorRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("approle"),
 	)
@@ -2662,7 +2662,7 @@ func main() {
 	resp, err := client.Auth.AppRoleWriteBindSecretId(
 		context.Background(),
 		roleName,
-		AppRoleWriteBindSecretIdRequest{ /* populate request parameters */ },
+		schema.AppRoleWriteBindSecretIdRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("approle"),
 	)
@@ -2726,7 +2726,7 @@ func main() {
 	resp, err := client.Auth.AppRoleWriteBoundCidrList(
 		context.Background(),
 		roleName,
-		AppRoleWriteBoundCidrListRequest{ /* populate request parameters */ },
+		schema.AppRoleWriteBoundCidrListRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("approle"),
 	)
@@ -2790,7 +2790,7 @@ func main() {
 	resp, err := client.Auth.AppRoleWriteCustomSecretId(
 		context.Background(),
 		roleName,
-		AppRoleWriteCustomSecretIdRequest{ /* populate request parameters */ },
+		schema.AppRoleWriteCustomSecretIdRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("approle"),
 	)
@@ -2854,7 +2854,7 @@ func main() {
 	resp, err := client.Auth.AppRoleWritePeriod(
 		context.Background(),
 		roleName,
-		AppRoleWritePeriodRequest{ /* populate request parameters */ },
+		schema.AppRoleWritePeriodRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("approle"),
 	)
@@ -2918,7 +2918,7 @@ func main() {
 	resp, err := client.Auth.AppRoleWritePolicies(
 		context.Background(),
 		roleName,
-		AppRoleWritePoliciesRequest{ /* populate request parameters */ },
+		schema.AppRoleWritePoliciesRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("approle"),
 	)
@@ -2982,7 +2982,7 @@ func main() {
 	resp, err := client.Auth.AppRoleWriteRole(
 		context.Background(),
 		roleName,
-		AppRoleWriteRoleRequest{ /* populate request parameters */ },
+		schema.AppRoleWriteRoleRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("approle"),
 	)
@@ -3046,7 +3046,7 @@ func main() {
 	resp, err := client.Auth.AppRoleWriteRoleId(
 		context.Background(),
 		roleName,
-		AppRoleWriteRoleIdRequest{ /* populate request parameters */ },
+		schema.AppRoleWriteRoleIdRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("approle"),
 	)
@@ -3110,7 +3110,7 @@ func main() {
 	resp, err := client.Auth.AppRoleWriteSecretId(
 		context.Background(),
 		roleName,
-		AppRoleWriteSecretIdRequest{ /* populate request parameters */ },
+		schema.AppRoleWriteSecretIdRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("approle"),
 	)
@@ -3174,7 +3174,7 @@ func main() {
 	resp, err := client.Auth.AppRoleWriteSecretIdBoundCidrs(
 		context.Background(),
 		roleName,
-		AppRoleWriteSecretIdBoundCidrsRequest{ /* populate request parameters */ },
+		schema.AppRoleWriteSecretIdBoundCidrsRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("approle"),
 	)
@@ -3238,7 +3238,7 @@ func main() {
 	resp, err := client.Auth.AppRoleWriteSecretIdNumUses(
 		context.Background(),
 		roleName,
-		AppRoleWriteSecretIdNumUsesRequest{ /* populate request parameters */ },
+		schema.AppRoleWriteSecretIdNumUsesRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("approle"),
 	)
@@ -3302,7 +3302,7 @@ func main() {
 	resp, err := client.Auth.AppRoleWriteSecretIdTtl(
 		context.Background(),
 		roleName,
-		AppRoleWriteSecretIdTtlRequest{ /* populate request parameters */ },
+		schema.AppRoleWriteSecretIdTtlRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("approle"),
 	)
@@ -3366,7 +3366,7 @@ func main() {
 	resp, err := client.Auth.AppRoleWriteTokenBoundCidrs(
 		context.Background(),
 		roleName,
-		AppRoleWriteTokenBoundCidrsRequest{ /* populate request parameters */ },
+		schema.AppRoleWriteTokenBoundCidrsRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("approle"),
 	)
@@ -3430,7 +3430,7 @@ func main() {
 	resp, err := client.Auth.AppRoleWriteTokenMaxTtl(
 		context.Background(),
 		roleName,
-		AppRoleWriteTokenMaxTtlRequest{ /* populate request parameters */ },
+		schema.AppRoleWriteTokenMaxTtlRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("approle"),
 	)
@@ -3494,7 +3494,7 @@ func main() {
 	resp, err := client.Auth.AppRoleWriteTokenNumUses(
 		context.Background(),
 		roleName,
-		AppRoleWriteTokenNumUsesRequest{ /* populate request parameters */ },
+		schema.AppRoleWriteTokenNumUsesRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("approle"),
 	)
@@ -3558,7 +3558,7 @@ func main() {
 	resp, err := client.Auth.AppRoleWriteTokenTtl(
 		context.Background(),
 		roleName,
-		AppRoleWriteTokenTtlRequest{ /* populate request parameters */ },
+		schema.AppRoleWriteTokenTtlRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("approle"),
 	)
@@ -3622,7 +3622,7 @@ func main() {
 	resp, err := client.Auth.AwsConfigureCertificate(
 		context.Background(),
 		certName,
-		AwsConfigureCertificateRequest{ /* populate request parameters */ },
+		schema.AwsConfigureCertificateRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("aws"),
 	)
@@ -3684,7 +3684,7 @@ func main() {
 
 	resp, err := client.Auth.AwsConfigureClient(
 		context.Background(),
-		AwsConfigureClientRequest{ /* populate request parameters */ },
+		schema.AwsConfigureClientRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("aws"),
 	)
@@ -3744,7 +3744,7 @@ func main() {
 
 	resp, err := client.Auth.AwsConfigureIdentityAccessListTidyOperation(
 		context.Background(),
-		AwsConfigureIdentityAccessListTidyOperationRequest{ /* populate request parameters */ },
+		schema.AwsConfigureIdentityAccessListTidyOperationRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("aws"),
 	)
@@ -3804,7 +3804,7 @@ func main() {
 
 	resp, err := client.Auth.AwsConfigureIdentityIntegration(
 		context.Background(),
-		AwsConfigureIdentityIntegrationRequest{ /* populate request parameters */ },
+		schema.AwsConfigureIdentityIntegrationRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("aws"),
 	)
@@ -3864,7 +3864,7 @@ func main() {
 
 	resp, err := client.Auth.AwsConfigureIdentityWhitelistTidyOperation(
 		context.Background(),
-		AwsConfigureIdentityWhitelistTidyOperationRequest{ /* populate request parameters */ },
+		schema.AwsConfigureIdentityWhitelistTidyOperationRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("aws"),
 	)
@@ -3924,7 +3924,7 @@ func main() {
 
 	resp, err := client.Auth.AwsConfigureRoleTagBlacklistTidyOperation(
 		context.Background(),
-		AwsConfigureRoleTagBlacklistTidyOperationRequest{ /* populate request parameters */ },
+		schema.AwsConfigureRoleTagBlacklistTidyOperationRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("aws"),
 	)
@@ -3984,7 +3984,7 @@ func main() {
 
 	resp, err := client.Auth.AwsConfigureRoleTagDenyListTidyOperation(
 		context.Background(),
-		AwsConfigureRoleTagDenyListTidyOperationRequest{ /* populate request parameters */ },
+		schema.AwsConfigureRoleTagDenyListTidyOperationRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("aws"),
 	)
@@ -5162,7 +5162,7 @@ func main() {
 
 	resp, err := client.Auth.AwsLogin(
 		context.Background(),
-		AwsLoginRequest{ /* populate request parameters */ },
+		schema.AwsLoginRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("aws"),
 	)
@@ -6048,7 +6048,7 @@ func main() {
 
 	resp, err := client.Auth.AwsTidyIdentityAccessList(
 		context.Background(),
-		AwsTidyIdentityAccessListRequest{ /* populate request parameters */ },
+		schema.AwsTidyIdentityAccessListRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("aws"),
 	)
@@ -6108,7 +6108,7 @@ func main() {
 
 	resp, err := client.Auth.AwsTidyIdentityWhitelist(
 		context.Background(),
-		AwsTidyIdentityWhitelistRequest{ /* populate request parameters */ },
+		schema.AwsTidyIdentityWhitelistRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("aws"),
 	)
@@ -6168,7 +6168,7 @@ func main() {
 
 	resp, err := client.Auth.AwsTidyRoleTagBlacklist(
 		context.Background(),
-		AwsTidyRoleTagBlacklistRequest{ /* populate request parameters */ },
+		schema.AwsTidyRoleTagBlacklistRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("aws"),
 	)
@@ -6228,7 +6228,7 @@ func main() {
 
 	resp, err := client.Auth.AwsTidyRoleTagDenyList(
 		context.Background(),
-		AwsTidyRoleTagDenyListRequest{ /* populate request parameters */ },
+		schema.AwsTidyRoleTagDenyListRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("aws"),
 	)
@@ -6290,7 +6290,7 @@ func main() {
 	resp, err := client.Auth.AwsWriteAuthRole(
 		context.Background(),
 		role,
-		AwsWriteAuthRoleRequest{ /* populate request parameters */ },
+		schema.AwsWriteAuthRoleRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("aws"),
 	)
@@ -6354,7 +6354,7 @@ func main() {
 	resp, err := client.Auth.AwsWriteRoleTag(
 		context.Background(),
 		role,
-		AwsWriteRoleTagRequest{ /* populate request parameters */ },
+		schema.AwsWriteRoleTagRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("aws"),
 	)
@@ -6540,7 +6540,7 @@ func main() {
 	resp, err := client.Auth.AwsWriteStsRole(
 		context.Background(),
 		accountId,
-		AwsWriteStsRoleRequest{ /* populate request parameters */ },
+		schema.AwsWriteStsRoleRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("aws"),
 	)
@@ -6602,7 +6602,7 @@ func main() {
 
 	resp, err := client.Auth.AzureConfigureAuth(
 		context.Background(),
-		AzureConfigureAuthRequest{ /* populate request parameters */ },
+		schema.AzureConfigureAuthRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("azure"),
 	)
@@ -6838,7 +6838,7 @@ func main() {
 
 	resp, err := client.Auth.AzureLogin(
 		context.Background(),
-		AzureLoginRequest{ /* populate request parameters */ },
+		schema.AzureLoginRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("azure"),
 	)
@@ -7075,7 +7075,7 @@ func main() {
 	resp, err := client.Auth.AzureWriteAuthRole(
 		context.Background(),
 		name,
-		AzureWriteAuthRoleRequest{ /* populate request parameters */ },
+		schema.AzureWriteAuthRoleRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("azure"),
 	)
@@ -7137,7 +7137,7 @@ func main() {
 
 	resp, err := client.Auth.CentrifyConfigure(
 		context.Background(),
-		CentrifyConfigureRequest{ /* populate request parameters */ },
+		schema.CentrifyConfigureRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("centrify"),
 	)
@@ -7197,7 +7197,7 @@ func main() {
 
 	resp, err := client.Auth.CentrifyLogin(
 		context.Background(),
-		CentrifyLoginRequest{ /* populate request parameters */ },
+		schema.CentrifyLoginRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("centrify"),
 	)
@@ -7314,7 +7314,7 @@ func main() {
 
 	resp, err := client.Auth.CertConfigure(
 		context.Background(),
-		CertConfigureRequest{ /* populate request parameters */ },
+		schema.CertConfigureRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("cert"),
 	)
@@ -7612,7 +7612,7 @@ func main() {
 
 	resp, err := client.Auth.CertLogin(
 		context.Background(),
-		CertLoginRequest{ /* populate request parameters */ },
+		schema.CertLoginRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("cert"),
 	)
@@ -7853,7 +7853,7 @@ func main() {
 	resp, err := client.Auth.CertWriteCertificate(
 		context.Background(),
 		name,
-		CertWriteCertificateRequest{ /* populate request parameters */ },
+		schema.CertWriteCertificateRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("cert"),
 	)
@@ -7917,7 +7917,7 @@ func main() {
 	resp, err := client.Auth.CertWriteCrl(
 		context.Background(),
 		name,
-		CertWriteCrlRequest{ /* populate request parameters */ },
+		schema.CertWriteCrlRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("cert"),
 	)
@@ -7979,7 +7979,7 @@ func main() {
 
 	resp, err := client.Auth.CloudFoundryConfigure(
 		context.Background(),
-		CloudFoundryConfigureRequest{ /* populate request parameters */ },
+		schema.CloudFoundryConfigureRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("cf"),
 	)
@@ -8215,7 +8215,7 @@ func main() {
 
 	resp, err := client.Auth.CloudFoundryLogin(
 		context.Background(),
-		CloudFoundryLoginRequest{ /* populate request parameters */ },
+		schema.CloudFoundryLoginRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("cf"),
 	)
@@ -8395,7 +8395,7 @@ func main() {
 	resp, err := client.Auth.CloudFoundryWriteRole(
 		context.Background(),
 		role,
-		CloudFoundryWriteRoleRequest{ /* populate request parameters */ },
+		schema.CloudFoundryWriteRoleRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("cf"),
 	)
@@ -8457,7 +8457,7 @@ func main() {
 
 	resp, err := client.Auth.GithubConfigure(
 		context.Background(),
-		GithubConfigureRequest{ /* populate request parameters */ },
+		schema.GithubConfigureRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("github"),
 	)
@@ -8755,7 +8755,7 @@ func main() {
 
 	resp, err := client.Auth.GithubLogin(
 		context.Background(),
-		GithubLoginRequest{ /* populate request parameters */ },
+		schema.GithubLoginRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("github"),
 	)
@@ -8996,7 +8996,7 @@ func main() {
 	resp, err := client.Auth.GithubWriteTeamMapping(
 		context.Background(),
 		key,
-		GithubWriteTeamMappingRequest{ /* populate request parameters */ },
+		schema.GithubWriteTeamMappingRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("github"),
 	)
@@ -9060,7 +9060,7 @@ func main() {
 	resp, err := client.Auth.GithubWriteUserMapping(
 		context.Background(),
 		key,
-		GithubWriteUserMappingRequest{ /* populate request parameters */ },
+		schema.GithubWriteUserMappingRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("github"),
 	)
@@ -9122,7 +9122,7 @@ func main() {
 
 	resp, err := client.Auth.GoogleCloudConfigureAuth(
 		context.Background(),
-		GoogleCloudConfigureAuthRequest{ /* populate request parameters */ },
+		schema.GoogleCloudConfigureAuthRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("gcp"),
 	)
@@ -9245,7 +9245,7 @@ func main() {
 	resp, err := client.Auth.GoogleCloudEditLabelsForRole(
 		context.Background(),
 		name,
-		GoogleCloudEditLabelsForRoleRequest{ /* populate request parameters */ },
+		schema.GoogleCloudEditLabelsForRoleRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("gcp"),
 	)
@@ -9309,7 +9309,7 @@ func main() {
 	resp, err := client.Auth.GoogleCloudEditServiceAccountsForRole(
 		context.Background(),
 		name,
-		GoogleCloudEditServiceAccountsForRoleRequest{ /* populate request parameters */ },
+		schema.GoogleCloudEditServiceAccountsForRoleRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("gcp"),
 	)
@@ -9429,7 +9429,7 @@ func main() {
 
 	resp, err := client.Auth.GoogleCloudLogin(
 		context.Background(),
-		GoogleCloudLoginRequest{ /* populate request parameters */ },
+		schema.GoogleCloudLoginRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("gcp"),
 	)
@@ -9609,7 +9609,7 @@ func main() {
 	resp, err := client.Auth.GoogleCloudWriteRole(
 		context.Background(),
 		name,
-		GoogleCloudWriteRoleRequest{ /* populate request parameters */ },
+		schema.GoogleCloudWriteRoleRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("gcp"),
 	)
@@ -9676,7 +9676,7 @@ func main() {
 
 	resp, err := client.Auth.JwtConfigure(
 		context.Background(),
-		JwtConfigureRequest{ /* populate request parameters */ },
+		schema.JwtConfigureRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("jwt"),
 	)
@@ -9857,7 +9857,7 @@ func main() {
 
 	resp, err := client.Auth.JwtLogin(
 		context.Background(),
-		JwtLoginRequest{ /* populate request parameters */ },
+		schema.JwtLoginRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("jwt"),
 	)
@@ -9983,7 +9983,7 @@ func main() {
 
 	resp, err := client.Auth.JwtOidcCallbackFormPost(
 		context.Background(),
-		JwtOidcCallbackFormPostRequest{ /* populate request parameters */ },
+		schema.JwtOidcCallbackFormPostRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("jwt"),
 	)
@@ -10043,7 +10043,7 @@ func main() {
 
 	resp, err := client.Auth.JwtOidcRequestAuthorizationUrl(
 		context.Background(),
-		JwtOidcRequestAuthorizationUrlRequest{ /* populate request parameters */ },
+		schema.JwtOidcRequestAuthorizationUrlRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("jwt"),
 	)
@@ -10228,7 +10228,7 @@ func main() {
 	resp, err := client.Auth.JwtWriteRole(
 		context.Background(),
 		name,
-		JwtWriteRoleRequest{ /* populate request parameters */ },
+		schema.JwtWriteRoleRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("jwt"),
 	)
@@ -10290,7 +10290,7 @@ func main() {
 
 	resp, err := client.Auth.KerberosConfigure(
 		context.Background(),
-		KerberosConfigureRequest{ /* populate request parameters */ },
+		schema.KerberosConfigureRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("kerberos"),
 	)
@@ -10350,7 +10350,7 @@ func main() {
 
 	resp, err := client.Auth.KerberosConfigureLdap(
 		context.Background(),
-		KerberosConfigureLdapRequest{ /* populate request parameters */ },
+		schema.KerberosConfigureLdapRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("kerberos"),
 	)
@@ -10529,7 +10529,7 @@ func main() {
 
 	resp, err := client.Auth.KerberosLogin(
 		context.Background(),
-		KerberosLoginRequest{ /* populate request parameters */ },
+		schema.KerberosLoginRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("kerberos"),
 	)
@@ -10766,7 +10766,7 @@ func main() {
 	resp, err := client.Auth.KerberosWriteGroup(
 		context.Background(),
 		name,
-		KerberosWriteGroupRequest{ /* populate request parameters */ },
+		schema.KerberosWriteGroupRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("kerberos"),
 	)
@@ -10828,7 +10828,7 @@ func main() {
 
 	resp, err := client.Auth.KubernetesConfigureAuth(
 		context.Background(),
-		KubernetesConfigureAuthRequest{ /* populate request parameters */ },
+		schema.KubernetesConfigureAuthRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("kubernetes"),
 	)
@@ -11007,7 +11007,7 @@ func main() {
 
 	resp, err := client.Auth.KubernetesLogin(
 		context.Background(),
-		KubernetesLoginRequest{ /* populate request parameters */ },
+		schema.KubernetesLoginRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("kubernetes"),
 	)
@@ -11187,7 +11187,7 @@ func main() {
 	resp, err := client.Auth.KubernetesWriteAuthRole(
 		context.Background(),
 		name,
-		KubernetesWriteAuthRoleRequest{ /* populate request parameters */ },
+		schema.KubernetesWriteAuthRoleRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("kubernetes"),
 	)
@@ -11249,7 +11249,7 @@ func main() {
 
 	resp, err := client.Auth.LdapConfigureAuth(
 		context.Background(),
-		LdapConfigureAuthRequest{ /* populate request parameters */ },
+		schema.LdapConfigureAuthRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("ldap"),
 	)
@@ -11549,7 +11549,7 @@ func main() {
 	resp, err := client.Auth.LdapLogin(
 		context.Background(),
 		username,
-		LdapLoginRequest{ /* populate request parameters */ },
+		schema.LdapLoginRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("ldap"),
 	)
@@ -11792,7 +11792,7 @@ func main() {
 	resp, err := client.Auth.LdapWriteGroup(
 		context.Background(),
 		name,
-		LdapWriteGroupRequest{ /* populate request parameters */ },
+		schema.LdapWriteGroupRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("ldap"),
 	)
@@ -11856,7 +11856,7 @@ func main() {
 	resp, err := client.Auth.LdapWriteUser(
 		context.Background(),
 		name,
-		LdapWriteUserRequest{ /* populate request parameters */ },
+		schema.LdapWriteUserRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("ldap"),
 	)
@@ -11918,7 +11918,7 @@ func main() {
 
 	resp, err := client.Auth.OciConfigure(
 		context.Background(),
-		OciConfigureRequest{ /* populate request parameters */ },
+		schema.OciConfigureRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("oci"),
 	)
@@ -12156,7 +12156,7 @@ func main() {
 	resp, err := client.Auth.OciLogin(
 		context.Background(),
 		role,
-		OciLoginRequest{ /* populate request parameters */ },
+		schema.OciLoginRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("oci"),
 	)
@@ -12338,7 +12338,7 @@ func main() {
 	resp, err := client.Auth.OciWriteRole(
 		context.Background(),
 		role,
-		OciWriteRoleRequest{ /* populate request parameters */ },
+		schema.OciWriteRoleRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("oci"),
 	)
@@ -12400,7 +12400,7 @@ func main() {
 
 	resp, err := client.Auth.OktaConfigure(
 		context.Background(),
-		OktaConfigureRequest{ /* populate request parameters */ },
+		schema.OktaConfigureRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("okta"),
 	)
@@ -12700,7 +12700,7 @@ func main() {
 	resp, err := client.Auth.OktaLogin(
 		context.Background(),
 		username,
-		OktaLoginRequest{ /* populate request parameters */ },
+		schema.OktaLoginRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("okta"),
 	)
@@ -13004,7 +13004,7 @@ func main() {
 	resp, err := client.Auth.OktaWriteGroup(
 		context.Background(),
 		name,
-		OktaWriteGroupRequest{ /* populate request parameters */ },
+		schema.OktaWriteGroupRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("okta"),
 	)
@@ -13068,7 +13068,7 @@ func main() {
 	resp, err := client.Auth.OktaWriteUser(
 		context.Background(),
 		name,
-		OktaWriteUserRequest{ /* populate request parameters */ },
+		schema.OktaWriteUserRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("okta"),
 	)
@@ -13130,7 +13130,7 @@ func main() {
 
 	resp, err := client.Auth.RadiusConfigure(
 		context.Background(),
-		RadiusConfigureRequest{ /* populate request parameters */ },
+		schema.RadiusConfigureRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("radius"),
 	)
@@ -13309,7 +13309,7 @@ func main() {
 
 	resp, err := client.Auth.RadiusLogin(
 		context.Background(),
-		RadiusLoginRequest{ /* populate request parameters */ },
+		schema.RadiusLoginRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("radius"),
 	)
@@ -13371,7 +13371,7 @@ func main() {
 	resp, err := client.Auth.RadiusLoginWithUsername(
 		context.Background(),
 		urlusername,
-		RadiusLoginWithUsernameRequest{ /* populate request parameters */ },
+		schema.RadiusLoginWithUsernameRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("radius"),
 	)
@@ -13553,7 +13553,7 @@ func main() {
 	resp, err := client.Auth.RadiusWriteUser(
 		context.Background(),
 		name,
-		RadiusWriteUserRequest{ /* populate request parameters */ },
+		schema.RadiusWriteUserRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("radius"),
 	)
@@ -13615,7 +13615,7 @@ func main() {
 
 	resp, err := client.Auth.TokenCreate(
 		context.Background(),
-		TokenCreateRequest{ /* populate request parameters */ },
+		schema.TokenCreateRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -13672,7 +13672,7 @@ func main() {
 	resp, err := client.Auth.TokenCreateAgainstRole(
 		context.Background(),
 		roleName,
-		TokenCreateAgainstRoleRequest{ /* populate request parameters */ },
+		schema.TokenCreateAgainstRoleRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -13732,7 +13732,7 @@ func main() {
 
 	resp, err := client.Auth.TokenCreateOrphan(
 		context.Background(),
-		TokenCreateOrphanRequest{ /* populate request parameters */ },
+		schema.TokenCreateOrphanRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -13952,7 +13952,7 @@ func main() {
 
 	resp, err := client.Auth.TokenLookUp(
 		context.Background(),
-		TokenLookUpRequest{ /* populate request parameters */ },
+		schema.TokenLookUpRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -14007,7 +14007,7 @@ func main() {
 
 	resp, err := client.Auth.TokenLookUpAccessor(
 		context.Background(),
-		TokenLookUpAccessorRequest{ /* populate request parameters */ },
+		schema.TokenLookUpAccessorRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -14171,7 +14171,7 @@ func main() {
 
 	resp, err := client.Auth.TokenRenew(
 		context.Background(),
-		TokenRenewRequest{ /* populate request parameters */ },
+		schema.TokenRenewRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -14226,7 +14226,7 @@ func main() {
 
 	resp, err := client.Auth.TokenRenewAccessor(
 		context.Background(),
-		TokenRenewAccessorRequest{ /* populate request parameters */ },
+		schema.TokenRenewAccessorRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -14281,7 +14281,7 @@ func main() {
 
 	resp, err := client.Auth.TokenRenewSelf(
 		context.Background(),
-		TokenRenewSelfRequest{ /* populate request parameters */ },
+		schema.TokenRenewSelfRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -14336,7 +14336,7 @@ func main() {
 
 	resp, err := client.Auth.TokenRevoke(
 		context.Background(),
-		TokenRevokeRequest{ /* populate request parameters */ },
+		schema.TokenRevokeRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -14391,7 +14391,7 @@ func main() {
 
 	resp, err := client.Auth.TokenRevokeAccessor(
 		context.Background(),
-		TokenRevokeAccessorRequest{ /* populate request parameters */ },
+		schema.TokenRevokeAccessorRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -14446,7 +14446,7 @@ func main() {
 
 	resp, err := client.Auth.TokenRevokeOrphan(
 		context.Background(),
-		TokenRevokeOrphanRequest{ /* populate request parameters */ },
+		schema.TokenRevokeOrphanRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -14603,7 +14603,7 @@ func main() {
 	resp, err := client.Auth.TokenWriteRole(
 		context.Background(),
 		roleName,
-		TokenWriteRoleRequest{ /* populate request parameters */ },
+		schema.TokenWriteRoleRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -14784,7 +14784,7 @@ func main() {
 	resp, err := client.Auth.UserpassLogin(
 		context.Background(),
 		username,
-		UserpassLoginRequest{ /* populate request parameters */ },
+		schema.UserpassLoginRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("userpass"),
 	)
@@ -14909,7 +14909,7 @@ func main() {
 	resp, err := client.Auth.UserpassResetPassword(
 		context.Background(),
 		username,
-		UserpassResetPasswordRequest{ /* populate request parameters */ },
+		schema.UserpassResetPasswordRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("userpass"),
 	)
@@ -14973,7 +14973,7 @@ func main() {
 	resp, err := client.Auth.UserpassUpdatePolicies(
 		context.Background(),
 		username,
-		UserpassUpdatePoliciesRequest{ /* populate request parameters */ },
+		schema.UserpassUpdatePoliciesRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("userpass"),
 	)
@@ -15037,7 +15037,7 @@ func main() {
 	resp, err := client.Auth.UserpassWriteUser(
 		context.Background(),
 		username,
-		UserpassWriteUserRequest{ /* populate request parameters */ },
+		schema.UserpassWriteUserRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("userpass"),
 	)

--- a/docs/IdentityApi.md
+++ b/docs/IdentityApi.md
@@ -139,7 +139,7 @@ func main() {
 
 	resp, err := client.Identity.AliasCreate(
 		context.Background(),
-		AliasCreateRequest{ /* populate request parameters */ },
+		schema.AliasCreateRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -367,7 +367,7 @@ func main() {
 	resp, err := client.Identity.AliasUpdateById(
 		context.Background(),
 		id,
-		AliasUpdateByIdRequest{ /* populate request parameters */ },
+		schema.AliasUpdateByIdRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -427,7 +427,7 @@ func main() {
 
 	resp, err := client.Identity.EntityBatchDelete(
 		context.Background(),
-		EntityBatchDeleteRequest{ /* populate request parameters */ },
+		schema.EntityBatchDeleteRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -482,7 +482,7 @@ func main() {
 
 	resp, err := client.Identity.EntityCreate(
 		context.Background(),
-		EntityCreateRequest{ /* populate request parameters */ },
+		schema.EntityCreateRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -537,7 +537,7 @@ func main() {
 
 	resp, err := client.Identity.EntityCreateAlias(
 		context.Background(),
-		EntityCreateAliasRequest{ /* populate request parameters */ },
+		schema.EntityCreateAliasRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -928,7 +928,7 @@ func main() {
 
 	resp, err := client.Identity.EntityLookUp(
 		context.Background(),
-		EntityLookUpRequest{ /* populate request parameters */ },
+		schema.EntityLookUpRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -983,7 +983,7 @@ func main() {
 
 	resp, err := client.Identity.EntityMerge(
 		context.Background(),
-		EntityMergeRequest{ /* populate request parameters */ },
+		schema.EntityMergeRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -1217,7 +1217,7 @@ func main() {
 	resp, err := client.Identity.EntityUpdateAliasById(
 		context.Background(),
 		id,
-		EntityUpdateAliasByIdRequest{ /* populate request parameters */ },
+		schema.EntityUpdateAliasByIdRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -1279,7 +1279,7 @@ func main() {
 	resp, err := client.Identity.EntityUpdateById(
 		context.Background(),
 		id,
-		EntityUpdateByIdRequest{ /* populate request parameters */ },
+		schema.EntityUpdateByIdRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -1341,7 +1341,7 @@ func main() {
 	resp, err := client.Identity.EntityUpdateByName(
 		context.Background(),
 		name,
-		EntityUpdateByNameRequest{ /* populate request parameters */ },
+		schema.EntityUpdateByNameRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -1401,7 +1401,7 @@ func main() {
 
 	resp, err := client.Identity.GroupCreate(
 		context.Background(),
-		GroupCreateRequest{ /* populate request parameters */ },
+		schema.GroupCreateRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -1456,7 +1456,7 @@ func main() {
 
 	resp, err := client.Identity.GroupCreateAlias(
 		context.Background(),
-		GroupCreateAliasRequest{ /* populate request parameters */ },
+		schema.GroupCreateAliasRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -1847,7 +1847,7 @@ func main() {
 
 	resp, err := client.Identity.GroupLookUp(
 		context.Background(),
-		GroupLookUpRequest{ /* populate request parameters */ },
+		schema.GroupLookUpRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -2081,7 +2081,7 @@ func main() {
 	resp, err := client.Identity.GroupUpdateAliasById(
 		context.Background(),
 		id,
-		GroupUpdateAliasByIdRequest{ /* populate request parameters */ },
+		schema.GroupUpdateAliasByIdRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -2143,7 +2143,7 @@ func main() {
 	resp, err := client.Identity.GroupUpdateById(
 		context.Background(),
 		id,
-		GroupUpdateByIdRequest{ /* populate request parameters */ },
+		schema.GroupUpdateByIdRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -2205,7 +2205,7 @@ func main() {
 	resp, err := client.Identity.GroupUpdateByName(
 		context.Background(),
 		name,
-		GroupUpdateByNameRequest{ /* populate request parameters */ },
+		schema.GroupUpdateByNameRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -2265,7 +2265,7 @@ func main() {
 
 	resp, err := client.Identity.MfaAdminDestroyTotpSecret(
 		context.Background(),
-		MfaAdminDestroyTotpSecretRequest{ /* populate request parameters */ },
+		schema.MfaAdminDestroyTotpSecretRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -2320,7 +2320,7 @@ func main() {
 
 	resp, err := client.Identity.MfaAdminGenerateTotpSecret(
 		context.Background(),
-		MfaAdminGenerateTotpSecretRequest{ /* populate request parameters */ },
+		schema.MfaAdminGenerateTotpSecretRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -2375,7 +2375,7 @@ func main() {
 
 	resp, err := client.Identity.MfaCreateDuoMethod(
 		context.Background(),
-		MfaCreateDuoMethodRequest{ /* populate request parameters */ },
+		schema.MfaCreateDuoMethodRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -2430,7 +2430,7 @@ func main() {
 
 	resp, err := client.Identity.MfaCreateOktaMethod(
 		context.Background(),
-		MfaCreateOktaMethodRequest{ /* populate request parameters */ },
+		schema.MfaCreateOktaMethodRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -2485,7 +2485,7 @@ func main() {
 
 	resp, err := client.Identity.MfaCreatePingIdMethod(
 		context.Background(),
-		MfaCreatePingIdMethodRequest{ /* populate request parameters */ },
+		schema.MfaCreatePingIdMethodRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -2540,7 +2540,7 @@ func main() {
 
 	resp, err := client.Identity.MfaCreateTotpMethod(
 		context.Background(),
-		MfaCreateTotpMethodRequest{ /* populate request parameters */ },
+		schema.MfaCreateTotpMethodRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -2890,7 +2890,7 @@ func main() {
 
 	resp, err := client.Identity.MfaGenerateTotpSecret(
 		context.Background(),
-		MfaGenerateTotpSecretRequest{ /* populate request parameters */ },
+		schema.MfaGenerateTotpSecretRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -3619,7 +3619,7 @@ func main() {
 	resp, err := client.Identity.MfaUpdateDuoMethod(
 		context.Background(),
 		methodId,
-		MfaUpdateDuoMethodRequest{ /* populate request parameters */ },
+		schema.MfaUpdateDuoMethodRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -3681,7 +3681,7 @@ func main() {
 	resp, err := client.Identity.MfaUpdateOktaMethod(
 		context.Background(),
 		methodId,
-		MfaUpdateOktaMethodRequest{ /* populate request parameters */ },
+		schema.MfaUpdateOktaMethodRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -3743,7 +3743,7 @@ func main() {
 	resp, err := client.Identity.MfaUpdatePingIdMethod(
 		context.Background(),
 		methodId,
-		MfaUpdatePingIdMethodRequest{ /* populate request parameters */ },
+		schema.MfaUpdatePingIdMethodRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -3805,7 +3805,7 @@ func main() {
 	resp, err := client.Identity.MfaUpdateTotpMethod(
 		context.Background(),
 		methodId,
-		MfaUpdateTotpMethodRequest{ /* populate request parameters */ },
+		schema.MfaUpdateTotpMethodRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -3867,7 +3867,7 @@ func main() {
 	resp, err := client.Identity.MfaWriteLoginEnforcement(
 		context.Background(),
 		name,
-		MfaWriteLoginEnforcementRequest{ /* populate request parameters */ },
+		schema.MfaWriteLoginEnforcementRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -3927,7 +3927,7 @@ func main() {
 
 	resp, err := client.Identity.OidcConfigure(
 		context.Background(),
-		OidcConfigureRequest{ /* populate request parameters */ },
+		schema.OidcConfigureRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -4395,7 +4395,7 @@ func main() {
 
 	resp, err := client.Identity.OidcIntrospect(
 		context.Background(),
-		OidcIntrospectRequest{ /* populate request parameters */ },
+		schema.OidcIntrospectRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -4859,7 +4859,7 @@ func main() {
 	resp, err := client.Identity.OidcProviderAuthorizeWithParameters(
 		context.Background(),
 		name,
-		OidcProviderAuthorizeWithParametersRequest{ /* populate request parameters */ },
+		schema.OidcProviderAuthorizeWithParametersRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -4921,7 +4921,7 @@ func main() {
 	resp, err := client.Identity.OidcProviderToken(
 		context.Background(),
 		name,
-		OidcProviderTokenRequest{ /* populate request parameters */ },
+		schema.OidcProviderTokenRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -5664,7 +5664,7 @@ func main() {
 	resp, err := client.Identity.OidcRotateKey(
 		context.Background(),
 		name,
-		OidcRotateKeyRequest{ /* populate request parameters */ },
+		schema.OidcRotateKeyRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -5726,7 +5726,7 @@ func main() {
 	resp, err := client.Identity.OidcWriteAssignment(
 		context.Background(),
 		name,
-		OidcWriteAssignmentRequest{ /* populate request parameters */ },
+		schema.OidcWriteAssignmentRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -5788,7 +5788,7 @@ func main() {
 	resp, err := client.Identity.OidcWriteClient(
 		context.Background(),
 		name,
-		OidcWriteClientRequest{ /* populate request parameters */ },
+		schema.OidcWriteClientRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -5850,7 +5850,7 @@ func main() {
 	resp, err := client.Identity.OidcWriteKey(
 		context.Background(),
 		name,
-		OidcWriteKeyRequest{ /* populate request parameters */ },
+		schema.OidcWriteKeyRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -5912,7 +5912,7 @@ func main() {
 	resp, err := client.Identity.OidcWriteProvider(
 		context.Background(),
 		name,
-		OidcWriteProviderRequest{ /* populate request parameters */ },
+		schema.OidcWriteProviderRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -5974,7 +5974,7 @@ func main() {
 	resp, err := client.Identity.OidcWriteRole(
 		context.Background(),
 		name,
-		OidcWriteRoleRequest{ /* populate request parameters */ },
+		schema.OidcWriteRoleRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -6036,7 +6036,7 @@ func main() {
 	resp, err := client.Identity.OidcWriteScope(
 		context.Background(),
 		name,
-		OidcWriteScopeRequest{ /* populate request parameters */ },
+		schema.OidcWriteScopeRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -6096,7 +6096,7 @@ func main() {
 
 	resp, err := client.Identity.PersonaCreate(
 		context.Background(),
-		PersonaCreateRequest{ /* populate request parameters */ },
+		schema.PersonaCreateRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -6324,7 +6324,7 @@ func main() {
 	resp, err := client.Identity.PersonaUpdateById(
 		context.Background(),
 		id,
-		PersonaUpdateByIdRequest{ /* populate request parameters */ },
+		schema.PersonaUpdateByIdRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {

--- a/docs/SecretsApi.md
+++ b/docs/SecretsApi.md
@@ -423,7 +423,7 @@ func main() {
 
 	resp, err := client.Secrets.AliCloudConfigure(
 		context.Background(),
-		AliCloudConfigureRequest{ /* populate request parameters */ },
+		schema.AliCloudConfigureRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("alicloud"),
 	)
@@ -840,7 +840,7 @@ func main() {
 	resp, err := client.Secrets.AliCloudWriteRole(
 		context.Background(),
 		name,
-		AliCloudWriteRoleRequest{ /* populate request parameters */ },
+		schema.AliCloudWriteRoleRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("alicloud"),
 	)
@@ -902,7 +902,7 @@ func main() {
 
 	resp, err := client.Secrets.AwsConfigureLease(
 		context.Background(),
-		AwsConfigureLeaseRequest{ /* populate request parameters */ },
+		schema.AwsConfigureLeaseRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("aws"),
 	)
@@ -962,7 +962,7 @@ func main() {
 
 	resp, err := client.Secrets.AwsConfigureRootIamCredentials(
 		context.Background(),
-		AwsConfigureRootIamCredentialsRequest{ /* populate request parameters */ },
+		schema.AwsConfigureRootIamCredentialsRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("aws"),
 	)
@@ -1216,7 +1216,7 @@ func main() {
 	resp, err := client.Secrets.AwsGenerateCredentialsWithParameters(
 		context.Background(),
 		name,
-		AwsGenerateCredentialsWithParametersRequest{ /* populate request parameters */ },
+		schema.AwsGenerateCredentialsWithParametersRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("aws"),
 	)
@@ -1350,7 +1350,7 @@ func main() {
 	resp, err := client.Secrets.AwsGenerateStsCredentialsWithParameters(
 		context.Background(),
 		name,
-		AwsGenerateStsCredentialsWithParametersRequest{ /* populate request parameters */ },
+		schema.AwsGenerateStsCredentialsWithParametersRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("aws"),
 	)
@@ -1826,7 +1826,7 @@ func main() {
 	resp, err := client.Secrets.AwsWriteRole(
 		context.Background(),
 		name,
-		AwsWriteRoleRequest{ /* populate request parameters */ },
+		schema.AwsWriteRoleRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("aws"),
 	)
@@ -1890,7 +1890,7 @@ func main() {
 	resp, err := client.Secrets.AwsWriteStaticRolesName(
 		context.Background(),
 		name,
-		AwsWriteStaticRolesNameRequest{ /* populate request parameters */ },
+		schema.AwsWriteStaticRolesNameRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("aws"),
 	)
@@ -1952,7 +1952,7 @@ func main() {
 
 	resp, err := client.Secrets.AzureConfigure(
 		context.Background(),
-		AzureConfigureRequest{ /* populate request parameters */ },
+		schema.AzureConfigureRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("azure"),
 	)
@@ -2426,7 +2426,7 @@ func main() {
 	resp, err := client.Secrets.AzureWriteRole(
 		context.Background(),
 		name,
-		AzureWriteRoleRequest{ /* populate request parameters */ },
+		schema.AzureWriteRoleRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("azure"),
 	)
@@ -2488,7 +2488,7 @@ func main() {
 
 	resp, err := client.Secrets.ConsulConfigureAccess(
 		context.Background(),
-		ConsulConfigureAccessRequest{ /* populate request parameters */ },
+		schema.ConsulConfigureAccessRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("consul"),
 	)
@@ -2848,7 +2848,7 @@ func main() {
 	resp, err := client.Secrets.ConsulWriteRole(
 		context.Background(),
 		name,
-		ConsulWriteRoleRequest{ /* populate request parameters */ },
+		schema.ConsulWriteRoleRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("consul"),
 	)
@@ -3153,7 +3153,7 @@ func main() {
 	resp, err := client.Secrets.DatabaseConfigureConnection(
 		context.Background(),
 		name,
-		DatabaseConfigureConnectionRequest{ /* populate request parameters */ },
+		schema.DatabaseConfigureConnectionRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("database"),
 	)
@@ -4062,7 +4062,7 @@ func main() {
 	resp, err := client.Secrets.DatabaseWriteRole(
 		context.Background(),
 		name,
-		DatabaseWriteRoleRequest{ /* populate request parameters */ },
+		schema.DatabaseWriteRoleRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("database"),
 	)
@@ -4126,7 +4126,7 @@ func main() {
 	resp, err := client.Secrets.DatabaseWriteStaticRole(
 		context.Background(),
 		name,
-		DatabaseWriteStaticRoleRequest{ /* populate request parameters */ },
+		schema.DatabaseWriteStaticRoleRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("database"),
 	)
@@ -4188,7 +4188,7 @@ func main() {
 
 	resp, err := client.Secrets.GoogleCloudConfigure(
 		context.Background(),
-		GoogleCloudConfigureRequest{ /* populate request parameters */ },
+		schema.GoogleCloudConfigureRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("gcp"),
 	)
@@ -4555,7 +4555,7 @@ func main() {
 	resp, err := client.Secrets.GoogleCloudGenerateRolesetKey(
 		context.Background(),
 		roleset,
-		GoogleCloudGenerateRolesetKeyRequest{ /* populate request parameters */ },
+		schema.GoogleCloudGenerateRolesetKeyRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("gcp"),
 	)
@@ -4680,7 +4680,7 @@ func main() {
 	resp, err := client.Secrets.GoogleCloudGenerateStaticAccountKey(
 		context.Background(),
 		name,
-		GoogleCloudGenerateStaticAccountKeyRequest{ /* populate request parameters */ },
+		schema.GoogleCloudGenerateStaticAccountKeyRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("gcp"),
 	)
@@ -4742,7 +4742,7 @@ func main() {
 
 	resp, err := client.Secrets.GoogleCloudKmsConfigure(
 		context.Background(),
-		GoogleCloudKmsConfigureRequest{ /* populate request parameters */ },
+		schema.GoogleCloudKmsConfigureRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("gcpkms"),
 	)
@@ -4804,7 +4804,7 @@ func main() {
 	resp, err := client.Secrets.GoogleCloudKmsConfigureKey(
 		context.Background(),
 		key,
-		GoogleCloudKmsConfigureKeyRequest{ /* populate request parameters */ },
+		schema.GoogleCloudKmsConfigureKeyRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("gcpkms"),
 	)
@@ -4868,7 +4868,7 @@ func main() {
 	resp, err := client.Secrets.GoogleCloudKmsDecrypt(
 		context.Background(),
 		key,
-		GoogleCloudKmsDecryptRequest{ /* populate request parameters */ },
+		schema.GoogleCloudKmsDecryptRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("gcpkms"),
 	)
@@ -5111,7 +5111,7 @@ func main() {
 	resp, err := client.Secrets.GoogleCloudKmsEncrypt(
 		context.Background(),
 		key,
-		GoogleCloudKmsEncryptRequest{ /* populate request parameters */ },
+		schema.GoogleCloudKmsEncryptRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("gcpkms"),
 	)
@@ -5412,7 +5412,7 @@ func main() {
 	resp, err := client.Secrets.GoogleCloudKmsReencrypt(
 		context.Background(),
 		key,
-		GoogleCloudKmsReencryptRequest{ /* populate request parameters */ },
+		schema.GoogleCloudKmsReencryptRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("gcpkms"),
 	)
@@ -5476,7 +5476,7 @@ func main() {
 	resp, err := client.Secrets.GoogleCloudKmsRegisterKey(
 		context.Background(),
 		key,
-		GoogleCloudKmsRegisterKeyRequest{ /* populate request parameters */ },
+		schema.GoogleCloudKmsRegisterKeyRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("gcpkms"),
 	)
@@ -5662,7 +5662,7 @@ func main() {
 	resp, err := client.Secrets.GoogleCloudKmsSign(
 		context.Background(),
 		key,
-		GoogleCloudKmsSignRequest{ /* populate request parameters */ },
+		schema.GoogleCloudKmsSignRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("gcpkms"),
 	)
@@ -5787,7 +5787,7 @@ func main() {
 	resp, err := client.Secrets.GoogleCloudKmsVerify(
 		context.Background(),
 		key,
-		GoogleCloudKmsVerifyRequest{ /* populate request parameters */ },
+		schema.GoogleCloudKmsVerifyRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("gcpkms"),
 	)
@@ -5851,7 +5851,7 @@ func main() {
 	resp, err := client.Secrets.GoogleCloudKmsWriteKey(
 		context.Background(),
 		key,
-		GoogleCloudKmsWriteKeyRequest{ /* populate request parameters */ },
+		schema.GoogleCloudKmsWriteKeyRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("gcpkms"),
 	)
@@ -6569,7 +6569,7 @@ func main() {
 	resp, err := client.Secrets.GoogleCloudWriteImpersonatedAccount(
 		context.Background(),
 		name,
-		GoogleCloudWriteImpersonatedAccountRequest{ /* populate request parameters */ },
+		schema.GoogleCloudWriteImpersonatedAccountRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("gcp"),
 	)
@@ -6633,7 +6633,7 @@ func main() {
 	resp, err := client.Secrets.GoogleCloudWriteRoleset(
 		context.Background(),
 		name,
-		GoogleCloudWriteRolesetRequest{ /* populate request parameters */ },
+		schema.GoogleCloudWriteRolesetRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("gcp"),
 	)
@@ -6697,7 +6697,7 @@ func main() {
 	resp, err := client.Secrets.GoogleCloudWriteStaticAccount(
 		context.Background(),
 		name,
-		GoogleCloudWriteStaticAccountRequest{ /* populate request parameters */ },
+		schema.GoogleCloudWriteStaticAccountRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("gcp"),
 	)
@@ -6816,7 +6816,7 @@ func main() {
 
 	resp, err := client.Secrets.KubernetesConfigure(
 		context.Background(),
-		KubernetesConfigureRequest{ /* populate request parameters */ },
+		schema.KubernetesConfigureRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("kubernetes"),
 	)
@@ -6996,7 +6996,7 @@ func main() {
 	resp, err := client.Secrets.KubernetesGenerateCredentials(
 		context.Background(),
 		name,
-		KubernetesGenerateCredentialsRequest{ /* populate request parameters */ },
+		schema.KubernetesGenerateCredentialsRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("kubernetes"),
 	)
@@ -7236,7 +7236,7 @@ func main() {
 	resp, err := client.Secrets.KubernetesWriteRole(
 		context.Background(),
 		name,
-		KubernetesWriteRoleRequest{ /* populate request parameters */ },
+		schema.KubernetesWriteRoleRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("kubernetes"),
 	)
@@ -7545,7 +7545,7 @@ func main() {
 
 	resp, err := client.Secrets.KvV2Configure(
 		context.Background(),
-		KvV2ConfigureRequest{ /* populate request parameters */ },
+		schema.KvV2ConfigureRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("kv-v2"),
 	)
@@ -7729,7 +7729,7 @@ func main() {
 	resp, err := client.Secrets.KvV2DeleteVersions(
 		context.Background(),
 		path,
-		KvV2DeleteVersionsRequest{ /* populate request parameters */ },
+		schema.KvV2DeleteVersionsRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("kv-v2"),
 	)
@@ -7793,7 +7793,7 @@ func main() {
 	resp, err := client.Secrets.KvV2DestroyVersions(
 		context.Background(),
 		path,
-		KvV2DestroyVersionsRequest{ /* populate request parameters */ },
+		schema.KvV2DestroyVersionsRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("kv-v2"),
 	)
@@ -8159,7 +8159,7 @@ func main() {
 	resp, err := client.Secrets.KvV2UndeleteVersions(
 		context.Background(),
 		path,
-		KvV2UndeleteVersionsRequest{ /* populate request parameters */ },
+		schema.KvV2UndeleteVersionsRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("kv-v2"),
 	)
@@ -8223,7 +8223,7 @@ func main() {
 	resp, err := client.Secrets.KvV2Write(
 		context.Background(),
 		path,
-		KvV2WriteRequest{ /* populate request parameters */ },
+		schema.KvV2WriteRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("kv-v2"),
 	)
@@ -8287,7 +8287,7 @@ func main() {
 	resp, err := client.Secrets.KvV2WriteMetadata(
 		context.Background(),
 		path,
-		KvV2WriteMetadataRequest{ /* populate request parameters */ },
+		schema.KvV2WriteMetadataRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("kv-v2"),
 	)
@@ -8349,7 +8349,7 @@ func main() {
 
 	resp, err := client.Secrets.LdapConfigure(
 		context.Background(),
-		LdapConfigureRequest{ /* populate request parameters */ },
+		schema.LdapConfigureRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("ldap"),
 	)
@@ -8590,7 +8590,7 @@ func main() {
 	resp, err := client.Secrets.LdapLibraryCheckIn(
 		context.Background(),
 		name,
-		LdapLibraryCheckInRequest{ /* populate request parameters */ },
+		schema.LdapLibraryCheckInRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("ldap"),
 	)
@@ -8654,7 +8654,7 @@ func main() {
 	resp, err := client.Secrets.LdapLibraryCheckOut(
 		context.Background(),
 		name,
-		LdapLibraryCheckOutRequest{ /* populate request parameters */ },
+		schema.LdapLibraryCheckOutRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("ldap"),
 	)
@@ -8779,7 +8779,7 @@ func main() {
 	resp, err := client.Secrets.LdapLibraryConfigure(
 		context.Background(),
 		name,
-		LdapLibraryConfigureRequest{ /* populate request parameters */ },
+		schema.LdapLibraryConfigureRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("ldap"),
 	)
@@ -8904,7 +8904,7 @@ func main() {
 	resp, err := client.Secrets.LdapLibraryForceCheckIn(
 		context.Background(),
 		name,
-		LdapLibraryForceCheckInRequest{ /* populate request parameters */ },
+		schema.LdapLibraryForceCheckInRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("ldap"),
 	)
@@ -9622,7 +9622,7 @@ func main() {
 	resp, err := client.Secrets.LdapWriteDynamicRole(
 		context.Background(),
 		name,
-		LdapWriteDynamicRoleRequest{ /* populate request parameters */ },
+		schema.LdapWriteDynamicRoleRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("ldap"),
 	)
@@ -9686,7 +9686,7 @@ func main() {
 	resp, err := client.Secrets.LdapWriteStaticRole(
 		context.Background(),
 		name,
-		LdapWriteStaticRoleRequest{ /* populate request parameters */ },
+		schema.LdapWriteStaticRoleRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("ldap"),
 	)
@@ -9748,7 +9748,7 @@ func main() {
 
 	resp, err := client.Secrets.MongoDbAtlasConfigure(
 		context.Background(),
-		MongoDbAtlasConfigureRequest{ /* populate request parameters */ },
+		schema.MongoDbAtlasConfigureRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("mongodbatlas"),
 	)
@@ -10108,7 +10108,7 @@ func main() {
 	resp, err := client.Secrets.MongoDbAtlasWriteRole(
 		context.Background(),
 		name,
-		MongoDbAtlasWriteRoleRequest{ /* populate request parameters */ },
+		schema.MongoDbAtlasWriteRoleRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("mongodbatlas"),
 	)
@@ -10170,7 +10170,7 @@ func main() {
 
 	resp, err := client.Secrets.NomadConfigureAccess(
 		context.Background(),
-		NomadConfigureAccessRequest{ /* populate request parameters */ },
+		schema.NomadConfigureAccessRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("nomad"),
 	)
@@ -10230,7 +10230,7 @@ func main() {
 
 	resp, err := client.Secrets.NomadConfigureLease(
 		context.Background(),
-		NomadConfigureLeaseRequest{ /* populate request parameters */ },
+		schema.NomadConfigureLeaseRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("nomad"),
 	)
@@ -10761,7 +10761,7 @@ func main() {
 	resp, err := client.Secrets.NomadWriteRole(
 		context.Background(),
 		name,
-		NomadWriteRoleRequest{ /* populate request parameters */ },
+		schema.NomadWriteRoleRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("nomad"),
 	)
@@ -10823,7 +10823,7 @@ func main() {
 
 	resp, err := client.Secrets.PkiConfigureAcme(
 		context.Background(),
-		PkiConfigureAcmeRequest{ /* populate request parameters */ },
+		schema.PkiConfigureAcmeRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -10883,7 +10883,7 @@ func main() {
 
 	resp, err := client.Secrets.PkiConfigureAutoTidy(
 		context.Background(),
-		PkiConfigureAutoTidyRequest{ /* populate request parameters */ },
+		schema.PkiConfigureAutoTidyRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -10943,7 +10943,7 @@ func main() {
 
 	resp, err := client.Secrets.PkiConfigureCa(
 		context.Background(),
-		PkiConfigureCaRequest{ /* populate request parameters */ },
+		schema.PkiConfigureCaRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -11003,7 +11003,7 @@ func main() {
 
 	resp, err := client.Secrets.PkiConfigureCluster(
 		context.Background(),
-		PkiConfigureClusterRequest{ /* populate request parameters */ },
+		schema.PkiConfigureClusterRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -11063,7 +11063,7 @@ func main() {
 
 	resp, err := client.Secrets.PkiConfigureCrl(
 		context.Background(),
-		PkiConfigureCrlRequest{ /* populate request parameters */ },
+		schema.PkiConfigureCrlRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -11123,7 +11123,7 @@ func main() {
 
 	resp, err := client.Secrets.PkiConfigureIssuers(
 		context.Background(),
-		PkiConfigureIssuersRequest{ /* populate request parameters */ },
+		schema.PkiConfigureIssuersRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -11183,7 +11183,7 @@ func main() {
 
 	resp, err := client.Secrets.PkiConfigureKeys(
 		context.Background(),
-		PkiConfigureKeysRequest{ /* populate request parameters */ },
+		schema.PkiConfigureKeysRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -11243,7 +11243,7 @@ func main() {
 
 	resp, err := client.Secrets.PkiConfigureUrls(
 		context.Background(),
-		PkiConfigureUrlsRequest{ /* populate request parameters */ },
+		schema.PkiConfigureUrlsRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -11303,7 +11303,7 @@ func main() {
 
 	resp, err := client.Secrets.PkiCrossSignIntermediate(
 		context.Background(),
-		PkiCrossSignIntermediateRequest{ /* populate request parameters */ },
+		schema.PkiCrossSignIntermediateRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -11908,7 +11908,7 @@ func main() {
 
 	resp, err := client.Secrets.PkiGenerateExportedKey(
 		context.Background(),
-		PkiGenerateExportedKeyRequest{ /* populate request parameters */ },
+		schema.PkiGenerateExportedKeyRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -11970,7 +11970,7 @@ func main() {
 	resp, err := client.Secrets.PkiGenerateIntermediate(
 		context.Background(),
 		exported,
-		PkiGenerateIntermediateRequest{ /* populate request parameters */ },
+		schema.PkiGenerateIntermediateRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -12032,7 +12032,7 @@ func main() {
 
 	resp, err := client.Secrets.PkiGenerateInternalKey(
 		context.Background(),
-		PkiGenerateInternalKeyRequest{ /* populate request parameters */ },
+		schema.PkiGenerateInternalKeyRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -12092,7 +12092,7 @@ func main() {
 
 	resp, err := client.Secrets.PkiGenerateKmsKey(
 		context.Background(),
-		PkiGenerateKmsKeyRequest{ /* populate request parameters */ },
+		schema.PkiGenerateKmsKeyRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -12154,7 +12154,7 @@ func main() {
 	resp, err := client.Secrets.PkiGenerateRoot(
 		context.Background(),
 		exported,
-		PkiGenerateRootRequest{ /* populate request parameters */ },
+		schema.PkiGenerateRootRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -12216,7 +12216,7 @@ func main() {
 
 	resp, err := client.Secrets.PkiImportKey(
 		context.Background(),
-		PkiImportKeyRequest{ /* populate request parameters */ },
+		schema.PkiImportKeyRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -12278,7 +12278,7 @@ func main() {
 	resp, err := client.Secrets.PkiIssueWithRole(
 		context.Background(),
 		role,
-		PkiIssueWithRoleRequest{ /* populate request parameters */ },
+		schema.PkiIssueWithRoleRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -12344,7 +12344,7 @@ func main() {
 		context.Background(),
 		issuerRef,
 		role,
-		PkiIssuerIssueWithRoleRequest{ /* populate request parameters */ },
+		schema.PkiIssuerIssueWithRoleRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -12776,7 +12776,7 @@ func main() {
 	resp, err := client.Secrets.PkiIssuerResignCrls(
 		context.Background(),
 		issuerRef,
-		PkiIssuerResignCrlsRequest{ /* populate request parameters */ },
+		schema.PkiIssuerResignCrlsRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -12840,7 +12840,7 @@ func main() {
 	resp, err := client.Secrets.PkiIssuerSignIntermediate(
 		context.Background(),
 		issuerRef,
-		PkiIssuerSignIntermediateRequest{ /* populate request parameters */ },
+		schema.PkiIssuerSignIntermediateRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -12904,7 +12904,7 @@ func main() {
 	resp, err := client.Secrets.PkiIssuerSignRevocationList(
 		context.Background(),
 		issuerRef,
-		PkiIssuerSignRevocationListRequest{ /* populate request parameters */ },
+		schema.PkiIssuerSignRevocationListRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -12968,7 +12968,7 @@ func main() {
 	resp, err := client.Secrets.PkiIssuerSignSelfIssued(
 		context.Background(),
 		issuerRef,
-		PkiIssuerSignSelfIssuedRequest{ /* populate request parameters */ },
+		schema.PkiIssuerSignSelfIssuedRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -13032,7 +13032,7 @@ func main() {
 	resp, err := client.Secrets.PkiIssuerSignVerbatim(
 		context.Background(),
 		issuerRef,
-		PkiIssuerSignVerbatimRequest{ /* populate request parameters */ },
+		schema.PkiIssuerSignVerbatimRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -13098,7 +13098,7 @@ func main() {
 		context.Background(),
 		issuerRef,
 		role,
-		PkiIssuerSignVerbatimWithRoleRequest{ /* populate request parameters */ },
+		schema.PkiIssuerSignVerbatimWithRoleRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -13166,7 +13166,7 @@ func main() {
 		context.Background(),
 		issuerRef,
 		role,
-		PkiIssuerSignWithRoleRequest{ /* populate request parameters */ },
+		schema.PkiIssuerSignWithRoleRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -13232,7 +13232,7 @@ func main() {
 	resp, err := client.Secrets.PkiIssuersGenerateIntermediate(
 		context.Background(),
 		exported,
-		PkiIssuersGenerateIntermediateRequest{ /* populate request parameters */ },
+		schema.PkiIssuersGenerateIntermediateRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -13296,7 +13296,7 @@ func main() {
 	resp, err := client.Secrets.PkiIssuersGenerateRoot(
 		context.Background(),
 		exported,
-		PkiIssuersGenerateRootRequest{ /* populate request parameters */ },
+		schema.PkiIssuersGenerateRootRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -13358,7 +13358,7 @@ func main() {
 
 	resp, err := client.Secrets.PkiIssuersImportBundle(
 		context.Background(),
-		PkiIssuersImportBundleRequest{ /* populate request parameters */ },
+		schema.PkiIssuersImportBundleRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -13418,7 +13418,7 @@ func main() {
 
 	resp, err := client.Secrets.PkiIssuersImportCert(
 		context.Background(),
-		PkiIssuersImportCertRequest{ /* populate request parameters */ },
+		schema.PkiIssuersImportCertRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -15950,7 +15950,7 @@ func main() {
 
 	resp, err := client.Secrets.PkiReplaceRoot(
 		context.Background(),
-		PkiReplaceRootRequest{ /* populate request parameters */ },
+		schema.PkiReplaceRootRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -16010,7 +16010,7 @@ func main() {
 
 	resp, err := client.Secrets.PkiRevoke(
 		context.Background(),
-		PkiRevokeRequest{ /* populate request parameters */ },
+		schema.PkiRevokeRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -16131,7 +16131,7 @@ func main() {
 
 	resp, err := client.Secrets.PkiRevokeWithKey(
 		context.Background(),
-		PkiRevokeWithKeyRequest{ /* populate request parameters */ },
+		schema.PkiRevokeWithKeyRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -16191,7 +16191,7 @@ func main() {
 
 	resp, err := client.Secrets.PkiRootSignIntermediate(
 		context.Background(),
-		PkiRootSignIntermediateRequest{ /* populate request parameters */ },
+		schema.PkiRootSignIntermediateRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -16251,7 +16251,7 @@ func main() {
 
 	resp, err := client.Secrets.PkiRootSignSelfIssued(
 		context.Background(),
-		PkiRootSignSelfIssuedRequest{ /* populate request parameters */ },
+		schema.PkiRootSignSelfIssuedRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -16427,7 +16427,7 @@ func main() {
 	resp, err := client.Secrets.PkiRotateRoot(
 		context.Background(),
 		exported,
-		PkiRotateRootRequest{ /* populate request parameters */ },
+		schema.PkiRotateRootRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -16489,7 +16489,7 @@ func main() {
 
 	resp, err := client.Secrets.PkiSetSignedIntermediate(
 		context.Background(),
-		PkiSetSignedIntermediateRequest{ /* populate request parameters */ },
+		schema.PkiSetSignedIntermediateRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -16549,7 +16549,7 @@ func main() {
 
 	resp, err := client.Secrets.PkiSignVerbatim(
 		context.Background(),
-		PkiSignVerbatimRequest{ /* populate request parameters */ },
+		schema.PkiSignVerbatimRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -16611,7 +16611,7 @@ func main() {
 	resp, err := client.Secrets.PkiSignVerbatimWithRole(
 		context.Background(),
 		role,
-		PkiSignVerbatimWithRoleRequest{ /* populate request parameters */ },
+		schema.PkiSignVerbatimWithRoleRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -16675,7 +16675,7 @@ func main() {
 	resp, err := client.Secrets.PkiSignWithRole(
 		context.Background(),
 		role,
-		PkiSignWithRoleRequest{ /* populate request parameters */ },
+		schema.PkiSignWithRoleRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -16737,7 +16737,7 @@ func main() {
 
 	resp, err := client.Secrets.PkiTidy(
 		context.Background(),
-		PkiTidyRequest{ /* populate request parameters */ },
+		schema.PkiTidyRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -16913,7 +16913,7 @@ func main() {
 	resp, err := client.Secrets.PkiWriteAcmeAccountKid(
 		context.Background(),
 		kid,
-		PkiWriteAcmeAccountKidRequest{ /* populate request parameters */ },
+		schema.PkiWriteAcmeAccountKidRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -16977,7 +16977,7 @@ func main() {
 	resp, err := client.Secrets.PkiWriteAcmeAuthorizationAuthId(
 		context.Background(),
 		authId,
-		PkiWriteAcmeAuthorizationAuthIdRequest{ /* populate request parameters */ },
+		schema.PkiWriteAcmeAuthorizationAuthIdRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -17043,7 +17043,7 @@ func main() {
 		context.Background(),
 		authId,
 		challengeType,
-		PkiWriteAcmeChallengeAuthIdChallengeTypeRequest{ /* populate request parameters */ },
+		schema.PkiWriteAcmeChallengeAuthIdChallengeTypeRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -17107,7 +17107,7 @@ func main() {
 
 	resp, err := client.Secrets.PkiWriteAcmeNewAccount(
 		context.Background(),
-		PkiWriteAcmeNewAccountRequest{ /* populate request parameters */ },
+		schema.PkiWriteAcmeNewAccountRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -17167,7 +17167,7 @@ func main() {
 
 	resp, err := client.Secrets.PkiWriteAcmeNewOrder(
 		context.Background(),
-		PkiWriteAcmeNewOrderRequest{ /* populate request parameters */ },
+		schema.PkiWriteAcmeNewOrderRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -17229,7 +17229,7 @@ func main() {
 	resp, err := client.Secrets.PkiWriteAcmeOrderOrderId(
 		context.Background(),
 		orderId,
-		PkiWriteAcmeOrderOrderIdRequest{ /* populate request parameters */ },
+		schema.PkiWriteAcmeOrderOrderIdRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -17293,7 +17293,7 @@ func main() {
 	resp, err := client.Secrets.PkiWriteAcmeOrderOrderIdCert(
 		context.Background(),
 		orderId,
-		PkiWriteAcmeOrderOrderIdCertRequest{ /* populate request parameters */ },
+		schema.PkiWriteAcmeOrderOrderIdCertRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -17357,7 +17357,7 @@ func main() {
 	resp, err := client.Secrets.PkiWriteAcmeOrderOrderIdFinalize(
 		context.Background(),
 		orderId,
-		PkiWriteAcmeOrderOrderIdFinalizeRequest{ /* populate request parameters */ },
+		schema.PkiWriteAcmeOrderOrderIdFinalizeRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -17419,7 +17419,7 @@ func main() {
 
 	resp, err := client.Secrets.PkiWriteAcmeOrders(
 		context.Background(),
-		PkiWriteAcmeOrdersRequest{ /* populate request parameters */ },
+		schema.PkiWriteAcmeOrdersRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -17479,7 +17479,7 @@ func main() {
 
 	resp, err := client.Secrets.PkiWriteAcmeRevokeCert(
 		context.Background(),
-		PkiWriteAcmeRevokeCertRequest{ /* populate request parameters */ },
+		schema.PkiWriteAcmeRevokeCertRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -17541,7 +17541,7 @@ func main() {
 	resp, err := client.Secrets.PkiWriteIssuer(
 		context.Background(),
 		issuerRef,
-		PkiWriteIssuerRequest{ /* populate request parameters */ },
+		schema.PkiWriteIssuerRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -17607,7 +17607,7 @@ func main() {
 		context.Background(),
 		issuerRef,
 		kid,
-		PkiWriteIssuerIssuerRefAcmeAccountKidRequest{ /* populate request parameters */ },
+		schema.PkiWriteIssuerIssuerRefAcmeAccountKidRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -17675,7 +17675,7 @@ func main() {
 		context.Background(),
 		authId,
 		issuerRef,
-		PkiWriteIssuerIssuerRefAcmeAuthorizationAuthIdRequest{ /* populate request parameters */ },
+		schema.PkiWriteIssuerIssuerRefAcmeAuthorizationAuthIdRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -17745,7 +17745,7 @@ func main() {
 		authId,
 		challengeType,
 		issuerRef,
-		PkiWriteIssuerIssuerRefAcmeChallengeAuthIdChallengeTypeRequest{ /* populate request parameters */ },
+		schema.PkiWriteIssuerIssuerRefAcmeChallengeAuthIdChallengeTypeRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -17813,7 +17813,7 @@ func main() {
 	resp, err := client.Secrets.PkiWriteIssuerIssuerRefAcmeNewAccount(
 		context.Background(),
 		issuerRef,
-		PkiWriteIssuerIssuerRefAcmeNewAccountRequest{ /* populate request parameters */ },
+		schema.PkiWriteIssuerIssuerRefAcmeNewAccountRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -17877,7 +17877,7 @@ func main() {
 	resp, err := client.Secrets.PkiWriteIssuerIssuerRefAcmeNewOrder(
 		context.Background(),
 		issuerRef,
-		PkiWriteIssuerIssuerRefAcmeNewOrderRequest{ /* populate request parameters */ },
+		schema.PkiWriteIssuerIssuerRefAcmeNewOrderRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -17943,7 +17943,7 @@ func main() {
 		context.Background(),
 		issuerRef,
 		orderId,
-		PkiWriteIssuerIssuerRefAcmeOrderOrderIdRequest{ /* populate request parameters */ },
+		schema.PkiWriteIssuerIssuerRefAcmeOrderOrderIdRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -18011,7 +18011,7 @@ func main() {
 		context.Background(),
 		issuerRef,
 		orderId,
-		PkiWriteIssuerIssuerRefAcmeOrderOrderIdCertRequest{ /* populate request parameters */ },
+		schema.PkiWriteIssuerIssuerRefAcmeOrderOrderIdCertRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -18079,7 +18079,7 @@ func main() {
 		context.Background(),
 		issuerRef,
 		orderId,
-		PkiWriteIssuerIssuerRefAcmeOrderOrderIdFinalizeRequest{ /* populate request parameters */ },
+		schema.PkiWriteIssuerIssuerRefAcmeOrderOrderIdFinalizeRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -18145,7 +18145,7 @@ func main() {
 	resp, err := client.Secrets.PkiWriteIssuerIssuerRefAcmeOrders(
 		context.Background(),
 		issuerRef,
-		PkiWriteIssuerIssuerRefAcmeOrdersRequest{ /* populate request parameters */ },
+		schema.PkiWriteIssuerIssuerRefAcmeOrdersRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -18209,7 +18209,7 @@ func main() {
 	resp, err := client.Secrets.PkiWriteIssuerIssuerRefAcmeRevokeCert(
 		context.Background(),
 		issuerRef,
-		PkiWriteIssuerIssuerRefAcmeRevokeCertRequest{ /* populate request parameters */ },
+		schema.PkiWriteIssuerIssuerRefAcmeRevokeCertRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -18277,7 +18277,7 @@ func main() {
 		issuerRef,
 		kid,
 		role,
-		PkiWriteIssuerIssuerRefRolesRoleAcmeAccountKidRequest{ /* populate request parameters */ },
+		schema.PkiWriteIssuerIssuerRefRolesRoleAcmeAccountKidRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -18349,7 +18349,7 @@ func main() {
 		authId,
 		issuerRef,
 		role,
-		PkiWriteIssuerIssuerRefRolesRoleAcmeAuthorizationAuthIdRequest{ /* populate request parameters */ },
+		schema.PkiWriteIssuerIssuerRefRolesRoleAcmeAuthorizationAuthIdRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -18423,7 +18423,7 @@ func main() {
 		challengeType,
 		issuerRef,
 		role,
-		PkiWriteIssuerIssuerRefRolesRoleAcmeChallengeAuthIdChallengeTypeRequest{ /* populate request parameters */ },
+		schema.PkiWriteIssuerIssuerRefRolesRoleAcmeChallengeAuthIdChallengeTypeRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -18495,7 +18495,7 @@ func main() {
 		context.Background(),
 		issuerRef,
 		role,
-		PkiWriteIssuerIssuerRefRolesRoleAcmeNewAccountRequest{ /* populate request parameters */ },
+		schema.PkiWriteIssuerIssuerRefRolesRoleAcmeNewAccountRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -18563,7 +18563,7 @@ func main() {
 		context.Background(),
 		issuerRef,
 		role,
-		PkiWriteIssuerIssuerRefRolesRoleAcmeNewOrderRequest{ /* populate request parameters */ },
+		schema.PkiWriteIssuerIssuerRefRolesRoleAcmeNewOrderRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -18633,7 +18633,7 @@ func main() {
 		issuerRef,
 		orderId,
 		role,
-		PkiWriteIssuerIssuerRefRolesRoleAcmeOrderOrderIdRequest{ /* populate request parameters */ },
+		schema.PkiWriteIssuerIssuerRefRolesRoleAcmeOrderOrderIdRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -18705,7 +18705,7 @@ func main() {
 		issuerRef,
 		orderId,
 		role,
-		PkiWriteIssuerIssuerRefRolesRoleAcmeOrderOrderIdCertRequest{ /* populate request parameters */ },
+		schema.PkiWriteIssuerIssuerRefRolesRoleAcmeOrderOrderIdCertRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -18777,7 +18777,7 @@ func main() {
 		issuerRef,
 		orderId,
 		role,
-		PkiWriteIssuerIssuerRefRolesRoleAcmeOrderOrderIdFinalizeRequest{ /* populate request parameters */ },
+		schema.PkiWriteIssuerIssuerRefRolesRoleAcmeOrderOrderIdFinalizeRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -18847,7 +18847,7 @@ func main() {
 		context.Background(),
 		issuerRef,
 		role,
-		PkiWriteIssuerIssuerRefRolesRoleAcmeOrdersRequest{ /* populate request parameters */ },
+		schema.PkiWriteIssuerIssuerRefRolesRoleAcmeOrdersRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -18915,7 +18915,7 @@ func main() {
 		context.Background(),
 		issuerRef,
 		role,
-		PkiWriteIssuerIssuerRefRolesRoleAcmeRevokeCertRequest{ /* populate request parameters */ },
+		schema.PkiWriteIssuerIssuerRefRolesRoleAcmeRevokeCertRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -18981,7 +18981,7 @@ func main() {
 	resp, err := client.Secrets.PkiWriteKey(
 		context.Background(),
 		keyRef,
-		PkiWriteKeyRequest{ /* populate request parameters */ },
+		schema.PkiWriteKeyRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -19045,7 +19045,7 @@ func main() {
 	resp, err := client.Secrets.PkiWriteRole(
 		context.Background(),
 		name,
-		PkiWriteRoleRequest{ /* populate request parameters */ },
+		schema.PkiWriteRoleRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -19111,7 +19111,7 @@ func main() {
 		context.Background(),
 		kid,
 		role,
-		PkiWriteRolesRoleAcmeAccountKidRequest{ /* populate request parameters */ },
+		schema.PkiWriteRolesRoleAcmeAccountKidRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -19179,7 +19179,7 @@ func main() {
 		context.Background(),
 		authId,
 		role,
-		PkiWriteRolesRoleAcmeAuthorizationAuthIdRequest{ /* populate request parameters */ },
+		schema.PkiWriteRolesRoleAcmeAuthorizationAuthIdRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -19249,7 +19249,7 @@ func main() {
 		authId,
 		challengeType,
 		role,
-		PkiWriteRolesRoleAcmeChallengeAuthIdChallengeTypeRequest{ /* populate request parameters */ },
+		schema.PkiWriteRolesRoleAcmeChallengeAuthIdChallengeTypeRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -19317,7 +19317,7 @@ func main() {
 	resp, err := client.Secrets.PkiWriteRolesRoleAcmeNewAccount(
 		context.Background(),
 		role,
-		PkiWriteRolesRoleAcmeNewAccountRequest{ /* populate request parameters */ },
+		schema.PkiWriteRolesRoleAcmeNewAccountRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -19381,7 +19381,7 @@ func main() {
 	resp, err := client.Secrets.PkiWriteRolesRoleAcmeNewOrder(
 		context.Background(),
 		role,
-		PkiWriteRolesRoleAcmeNewOrderRequest{ /* populate request parameters */ },
+		schema.PkiWriteRolesRoleAcmeNewOrderRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -19447,7 +19447,7 @@ func main() {
 		context.Background(),
 		orderId,
 		role,
-		PkiWriteRolesRoleAcmeOrderOrderIdRequest{ /* populate request parameters */ },
+		schema.PkiWriteRolesRoleAcmeOrderOrderIdRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -19515,7 +19515,7 @@ func main() {
 		context.Background(),
 		orderId,
 		role,
-		PkiWriteRolesRoleAcmeOrderOrderIdCertRequest{ /* populate request parameters */ },
+		schema.PkiWriteRolesRoleAcmeOrderOrderIdCertRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -19583,7 +19583,7 @@ func main() {
 		context.Background(),
 		orderId,
 		role,
-		PkiWriteRolesRoleAcmeOrderOrderIdFinalizeRequest{ /* populate request parameters */ },
+		schema.PkiWriteRolesRoleAcmeOrderOrderIdFinalizeRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -19649,7 +19649,7 @@ func main() {
 	resp, err := client.Secrets.PkiWriteRolesRoleAcmeOrders(
 		context.Background(),
 		role,
-		PkiWriteRolesRoleAcmeOrdersRequest{ /* populate request parameters */ },
+		schema.PkiWriteRolesRoleAcmeOrdersRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -19713,7 +19713,7 @@ func main() {
 	resp, err := client.Secrets.PkiWriteRolesRoleAcmeRevokeCert(
 		context.Background(),
 		role,
-		PkiWriteRolesRoleAcmeRevokeCertRequest{ /* populate request parameters */ },
+		schema.PkiWriteRolesRoleAcmeRevokeCertRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("pki"),
 	)
@@ -19775,7 +19775,7 @@ func main() {
 
 	resp, err := client.Secrets.RabbitMqConfigureConnection(
 		context.Background(),
-		RabbitMqConfigureConnectionRequest{ /* populate request parameters */ },
+		schema.RabbitMqConfigureConnectionRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("rabbitmq"),
 	)
@@ -19835,7 +19835,7 @@ func main() {
 
 	resp, err := client.Secrets.RabbitMqConfigureLease(
 		context.Background(),
-		RabbitMqConfigureLeaseRequest{ /* populate request parameters */ },
+		schema.RabbitMqConfigureLeaseRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("rabbitmq"),
 	)
@@ -20195,7 +20195,7 @@ func main() {
 	resp, err := client.Secrets.RabbitMqWriteRole(
 		context.Background(),
 		name,
-		RabbitMqWriteRoleRequest{ /* populate request parameters */ },
+		schema.RabbitMqWriteRoleRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("rabbitmq"),
 	)
@@ -20257,7 +20257,7 @@ func main() {
 
 	resp, err := client.Secrets.SshConfigureCa(
 		context.Background(),
-		SshConfigureCaRequest{ /* populate request parameters */ },
+		schema.SshConfigureCaRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("ssh"),
 	)
@@ -20317,7 +20317,7 @@ func main() {
 
 	resp, err := client.Secrets.SshConfigureZeroAddress(
 		context.Background(),
-		SshConfigureZeroAddressRequest{ /* populate request parameters */ },
+		schema.SshConfigureZeroAddressRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("ssh"),
 	)
@@ -20554,7 +20554,7 @@ func main() {
 	resp, err := client.Secrets.SshGenerateCredentials(
 		context.Background(),
 		role,
-		SshGenerateCredentialsRequest{ /* populate request parameters */ },
+		schema.SshGenerateCredentialsRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("ssh"),
 	)
@@ -20618,7 +20618,7 @@ func main() {
 	resp, err := client.Secrets.SshIssueCertificate(
 		context.Background(),
 		role,
-		SshIssueCertificateRequest{ /* populate request parameters */ },
+		schema.SshIssueCertificateRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("ssh"),
 	)
@@ -20738,7 +20738,7 @@ func main() {
 
 	resp, err := client.Secrets.SshListRolesByIp(
 		context.Background(),
-		SshListRolesByIpRequest{ /* populate request parameters */ },
+		schema.SshListRolesByIpRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("ssh"),
 	)
@@ -21032,7 +21032,7 @@ func main() {
 	resp, err := client.Secrets.SshSignCertificate(
 		context.Background(),
 		role,
-		SshSignCertificateRequest{ /* populate request parameters */ },
+		schema.SshSignCertificateRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("ssh"),
 	)
@@ -21151,7 +21151,7 @@ func main() {
 
 	resp, err := client.Secrets.SshVerifyOtp(
 		context.Background(),
-		SshVerifyOtpRequest{ /* populate request parameters */ },
+		schema.SshVerifyOtpRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("ssh"),
 	)
@@ -21213,7 +21213,7 @@ func main() {
 	resp, err := client.Secrets.SshWriteRole(
 		context.Background(),
 		role,
-		SshWriteRoleRequest{ /* populate request parameters */ },
+		schema.SshWriteRoleRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("ssh"),
 	)
@@ -21275,7 +21275,7 @@ func main() {
 
 	resp, err := client.Secrets.TerraformCloudConfigure(
 		context.Background(),
-		TerraformCloudConfigureRequest{ /* populate request parameters */ },
+		schema.TerraformCloudConfigureRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("terraform"),
 	)
@@ -21753,7 +21753,7 @@ func main() {
 	resp, err := client.Secrets.TerraformCloudWriteRole(
 		context.Background(),
 		name,
-		TerraformCloudWriteRoleRequest{ /* populate request parameters */ },
+		schema.TerraformCloudWriteRoleRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("terraform"),
 	)
@@ -21817,7 +21817,7 @@ func main() {
 	resp, err := client.Secrets.TotpCreateKey(
 		context.Background(),
 		name,
-		TotpCreateKeyRequest{ /* populate request parameters */ },
+		schema.TotpCreateKeyRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("totp"),
 	)
@@ -22122,7 +22122,7 @@ func main() {
 	resp, err := client.Secrets.TotpValidateCode(
 		context.Background(),
 		name,
-		TotpValidateCodeRequest{ /* populate request parameters */ },
+		schema.TotpValidateCodeRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("totp"),
 	)
@@ -22379,7 +22379,7 @@ func main() {
 
 	resp, err := client.Secrets.TransitConfigureCache(
 		context.Background(),
-		TransitConfigureCacheRequest{ /* populate request parameters */ },
+		schema.TransitConfigureCacheRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("transit"),
 	)
@@ -22441,7 +22441,7 @@ func main() {
 	resp, err := client.Secrets.TransitConfigureKey(
 		context.Background(),
 		name,
-		TransitConfigureKeyRequest{ /* populate request parameters */ },
+		schema.TransitConfigureKeyRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("transit"),
 	)
@@ -22503,7 +22503,7 @@ func main() {
 
 	resp, err := client.Secrets.TransitConfigureKeys(
 		context.Background(),
-		TransitConfigureKeysRequest{ /* populate request parameters */ },
+		schema.TransitConfigureKeysRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("transit"),
 	)
@@ -22565,7 +22565,7 @@ func main() {
 	resp, err := client.Secrets.TransitCreateKey(
 		context.Background(),
 		name,
-		TransitCreateKeyRequest{ /* populate request parameters */ },
+		schema.TransitCreateKeyRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("transit"),
 	)
@@ -22629,7 +22629,7 @@ func main() {
 	resp, err := client.Secrets.TransitDecrypt(
 		context.Background(),
 		name,
-		TransitDecryptRequest{ /* populate request parameters */ },
+		schema.TransitDecryptRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("transit"),
 	)
@@ -22754,7 +22754,7 @@ func main() {
 	resp, err := client.Secrets.TransitEncrypt(
 		context.Background(),
 		name,
-		TransitEncryptRequest{ /* populate request parameters */ },
+		schema.TransitEncryptRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("transit"),
 	)
@@ -22954,7 +22954,7 @@ func main() {
 		context.Background(),
 		name,
 		plaintext,
-		TransitGenerateDataKeyRequest{ /* populate request parameters */ },
+		schema.TransitGenerateDataKeyRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("transit"),
 	)
@@ -23020,7 +23020,7 @@ func main() {
 	resp, err := client.Secrets.TransitGenerateHmac(
 		context.Background(),
 		name,
-		TransitGenerateHmacRequest{ /* populate request parameters */ },
+		schema.TransitGenerateHmacRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("transit"),
 	)
@@ -23086,7 +23086,7 @@ func main() {
 		context.Background(),
 		name,
 		urlalgorithm,
-		TransitGenerateHmacWithAlgorithmRequest{ /* populate request parameters */ },
+		schema.TransitGenerateHmacWithAlgorithmRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("transit"),
 	)
@@ -23150,7 +23150,7 @@ func main() {
 
 	resp, err := client.Secrets.TransitGenerateRandom(
 		context.Background(),
-		TransitGenerateRandomRequest{ /* populate request parameters */ },
+		schema.TransitGenerateRandomRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("transit"),
 	)
@@ -23212,7 +23212,7 @@ func main() {
 	resp, err := client.Secrets.TransitGenerateRandomWithBytes(
 		context.Background(),
 		urlbytes,
-		TransitGenerateRandomWithBytesRequest{ /* populate request parameters */ },
+		schema.TransitGenerateRandomWithBytesRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("transit"),
 	)
@@ -23276,7 +23276,7 @@ func main() {
 	resp, err := client.Secrets.TransitGenerateRandomWithSource(
 		context.Background(),
 		source,
-		TransitGenerateRandomWithSourceRequest{ /* populate request parameters */ },
+		schema.TransitGenerateRandomWithSourceRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("transit"),
 	)
@@ -23342,7 +23342,7 @@ func main() {
 		context.Background(),
 		source,
 		urlbytes,
-		TransitGenerateRandomWithSourceAndBytesRequest{ /* populate request parameters */ },
+		schema.TransitGenerateRandomWithSourceAndBytesRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("transit"),
 	)
@@ -23406,7 +23406,7 @@ func main() {
 
 	resp, err := client.Secrets.TransitHash(
 		context.Background(),
-		TransitHashRequest{ /* populate request parameters */ },
+		schema.TransitHashRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("transit"),
 	)
@@ -23468,7 +23468,7 @@ func main() {
 	resp, err := client.Secrets.TransitHashWithAlgorithm(
 		context.Background(),
 		urlalgorithm,
-		TransitHashWithAlgorithmRequest{ /* populate request parameters */ },
+		schema.TransitHashWithAlgorithmRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("transit"),
 	)
@@ -23532,7 +23532,7 @@ func main() {
 	resp, err := client.Secrets.TransitImportKey(
 		context.Background(),
 		name,
-		TransitImportKeyRequest{ /* populate request parameters */ },
+		schema.TransitImportKeyRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("transit"),
 	)
@@ -23596,7 +23596,7 @@ func main() {
 	resp, err := client.Secrets.TransitImportKeyVersion(
 		context.Background(),
 		name,
-		TransitImportKeyVersionRequest{ /* populate request parameters */ },
+		schema.TransitImportKeyVersionRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("transit"),
 	)
@@ -23950,7 +23950,7 @@ func main() {
 	resp, err := client.Secrets.TransitRestoreAndRenameKey(
 		context.Background(),
 		name,
-		TransitRestoreAndRenameKeyRequest{ /* populate request parameters */ },
+		schema.TransitRestoreAndRenameKeyRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("transit"),
 	)
@@ -24012,7 +24012,7 @@ func main() {
 
 	resp, err := client.Secrets.TransitRestoreKey(
 		context.Background(),
-		TransitRestoreKeyRequest{ /* populate request parameters */ },
+		schema.TransitRestoreKeyRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("transit"),
 	)
@@ -24074,7 +24074,7 @@ func main() {
 	resp, err := client.Secrets.TransitRewrap(
 		context.Background(),
 		name,
-		TransitRewrapRequest{ /* populate request parameters */ },
+		schema.TransitRewrapRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("transit"),
 	)
@@ -24138,7 +24138,7 @@ func main() {
 	resp, err := client.Secrets.TransitRotateKey(
 		context.Background(),
 		name,
-		TransitRotateKeyRequest{ /* populate request parameters */ },
+		schema.TransitRotateKeyRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("transit"),
 	)
@@ -24202,7 +24202,7 @@ func main() {
 	resp, err := client.Secrets.TransitSign(
 		context.Background(),
 		name,
-		TransitSignRequest{ /* populate request parameters */ },
+		schema.TransitSignRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("transit"),
 	)
@@ -24268,7 +24268,7 @@ func main() {
 		context.Background(),
 		name,
 		urlalgorithm,
-		TransitSignWithAlgorithmRequest{ /* populate request parameters */ },
+		schema.TransitSignWithAlgorithmRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("transit"),
 	)
@@ -24334,7 +24334,7 @@ func main() {
 	resp, err := client.Secrets.TransitTrimKey(
 		context.Background(),
 		name,
-		TransitTrimKeyRequest{ /* populate request parameters */ },
+		schema.TransitTrimKeyRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("transit"),
 	)
@@ -24398,7 +24398,7 @@ func main() {
 	resp, err := client.Secrets.TransitVerify(
 		context.Background(),
 		name,
-		TransitVerifyRequest{ /* populate request parameters */ },
+		schema.TransitVerifyRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("transit"),
 	)
@@ -24464,7 +24464,7 @@ func main() {
 		context.Background(),
 		name,
 		urlalgorithm,
-		TransitVerifyWithAlgorithmRequest{ /* populate request parameters */ },
+		schema.TransitVerifyWithAlgorithmRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 		vault.WithMountPath("transit"),
 	)

--- a/docs/SystemApi.md
+++ b/docs/SystemApi.md
@@ -188,7 +188,7 @@ func main() {
 	resp, err := client.System.AuditingCalculateHash(
 		context.Background(),
 		path,
-		AuditingCalculateHashRequest{ /* populate request parameters */ },
+		schema.AuditingCalculateHashRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -368,7 +368,7 @@ func main() {
 	resp, err := client.System.AuditingEnableDevice(
 		context.Background(),
 		path,
-		AuditingEnableDeviceRequest{ /* populate request parameters */ },
+		schema.AuditingEnableDeviceRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -430,7 +430,7 @@ func main() {
 	resp, err := client.System.AuditingEnableRequestHeader(
 		context.Background(),
 		header,
-		AuditingEnableRequestHeaderRequest{ /* populate request parameters */ },
+		schema.AuditingEnableRequestHeaderRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -714,7 +714,7 @@ func main() {
 	resp, err := client.System.AuthEnableMethod(
 		context.Background(),
 		path,
-		AuthEnableMethodRequest{ /* populate request parameters */ },
+		schema.AuthEnableMethodRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -948,7 +948,7 @@ func main() {
 	resp, err := client.System.AuthTuneConfigurationParameters(
 		context.Background(),
 		path,
-		AuthTuneConfigurationParametersRequest{ /* populate request parameters */ },
+		schema.AuthTuneConfigurationParametersRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -1116,7 +1116,7 @@ func main() {
 
 	resp, err := client.System.CorsConfigure(
 		context.Background(),
-		CorsConfigureRequest{ /* populate request parameters */ },
+		schema.CorsConfigureRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -1271,7 +1271,7 @@ func main() {
 
 	resp, err := client.System.Decode(
 		context.Background(),
-		DecodeRequest{ /* populate request parameters */ },
+		schema.DecodeRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -1326,7 +1326,7 @@ func main() {
 
 	resp, err := client.System.EncryptionKeyConfigureRotation(
 		context.Background(),
-		EncryptionKeyConfigureRotationRequest{ /* populate request parameters */ },
+		schema.EncryptionKeyConfigureRotationRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -1531,7 +1531,7 @@ func main() {
 
 	resp, err := client.System.GenerateHash(
 		context.Background(),
-		GenerateHashRequest{ /* populate request parameters */ },
+		schema.GenerateHashRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -1588,7 +1588,7 @@ func main() {
 	resp, err := client.System.GenerateHashWithAlgorithm(
 		context.Background(),
 		urlalgorithm,
-		GenerateHashWithAlgorithmRequest{ /* populate request parameters */ },
+		schema.GenerateHashWithAlgorithmRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -1648,7 +1648,7 @@ func main() {
 
 	resp, err := client.System.GenerateRandom(
 		context.Background(),
-		GenerateRandomRequest{ /* populate request parameters */ },
+		schema.GenerateRandomRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -1705,7 +1705,7 @@ func main() {
 	resp, err := client.System.GenerateRandomWithBytes(
 		context.Background(),
 		urlbytes,
-		GenerateRandomWithBytesRequest{ /* populate request parameters */ },
+		schema.GenerateRandomWithBytesRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -1767,7 +1767,7 @@ func main() {
 	resp, err := client.System.GenerateRandomWithSource(
 		context.Background(),
 		source,
-		GenerateRandomWithSourceRequest{ /* populate request parameters */ },
+		schema.GenerateRandomWithSourceRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -1831,7 +1831,7 @@ func main() {
 		context.Background(),
 		source,
 		urlbytes,
-		GenerateRandomWithSourceAndBytesRequest{ /* populate request parameters */ },
+		schema.GenerateRandomWithSourceAndBytesRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -1945,7 +1945,7 @@ func main() {
 
 	resp, err := client.System.Initialize(
 		context.Background(),
-		InitializeRequest{ /* populate request parameters */ },
+		schema.InitializeRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -2000,7 +2000,7 @@ func main() {
 
 	resp, err := client.System.InternalClientActivityConfigure(
 		context.Background(),
-		InternalClientActivityConfigureRequest{ /* populate request parameters */ },
+		schema.InternalClientActivityConfigureRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -2463,7 +2463,7 @@ func main() {
 
 	resp, err := client.System.InternalGenerateOpenApiDocumentWithParameters(
 		context.Background(),
-		InternalGenerateOpenApiDocumentWithParametersRequest{ /* populate request parameters */ },
+		schema.InternalGenerateOpenApiDocumentWithParametersRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -3109,7 +3109,7 @@ func main() {
 
 	resp, err := client.System.LeasesReadLease(
 		context.Background(),
-		LeasesReadLeaseRequest{ /* populate request parameters */ },
+		schema.LeasesReadLeaseRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -3164,7 +3164,7 @@ func main() {
 
 	resp, err := client.System.LeasesRenewLease(
 		context.Background(),
-		LeasesRenewLeaseRequest{ /* populate request parameters */ },
+		schema.LeasesRenewLeaseRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -3221,7 +3221,7 @@ func main() {
 	resp, err := client.System.LeasesRenewLeaseWithId(
 		context.Background(),
 		urlLeaseId,
-		LeasesRenewLeaseWithIdRequest{ /* populate request parameters */ },
+		schema.LeasesRenewLeaseWithIdRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -3281,7 +3281,7 @@ func main() {
 
 	resp, err := client.System.LeasesRevokeLease(
 		context.Background(),
-		LeasesRevokeLeaseRequest{ /* populate request parameters */ },
+		schema.LeasesRevokeLeaseRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -3338,7 +3338,7 @@ func main() {
 	resp, err := client.System.LeasesRevokeLeaseWithId(
 		context.Background(),
 		urlLeaseId,
-		LeasesRevokeLeaseWithIdRequest{ /* populate request parameters */ },
+		schema.LeasesRevokeLeaseWithIdRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -3400,7 +3400,7 @@ func main() {
 	resp, err := client.System.LeasesRevokeLeaseWithPrefix(
 		context.Background(),
 		prefix,
-		LeasesRevokeLeaseWithPrefixRequest{ /* populate request parameters */ },
+		schema.LeasesRevokeLeaseWithPrefixRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -3891,7 +3891,7 @@ func main() {
 
 	resp, err := client.System.LoggersUpdateVerbosityLevel(
 		context.Background(),
-		LoggersUpdateVerbosityLevelRequest{ /* populate request parameters */ },
+		schema.LoggersUpdateVerbosityLevelRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -3948,7 +3948,7 @@ func main() {
 	resp, err := client.System.LoggersUpdateVerbosityLevelFor(
 		context.Background(),
 		name,
-		LoggersUpdateVerbosityLevelForRequest{ /* populate request parameters */ },
+		schema.LoggersUpdateVerbosityLevelForRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -4063,7 +4063,7 @@ func main() {
 
 	resp, err := client.System.MfaValidate(
 		context.Background(),
-		MfaValidateRequest{ /* populate request parameters */ },
+		schema.MfaValidateRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -4237,7 +4237,7 @@ func main() {
 	resp, err := client.System.MountsEnableSecretsEngine(
 		context.Background(),
 		path,
-		MountsEnableSecretsEngineRequest{ /* populate request parameters */ },
+		schema.MountsEnableSecretsEngineRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -4467,7 +4467,7 @@ func main() {
 	resp, err := client.System.MountsTuneConfigurationParameters(
 		context.Background(),
 		path,
-		MountsTuneConfigurationParametersRequest{ /* populate request parameters */ },
+		schema.MountsTuneConfigurationParametersRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -4761,7 +4761,7 @@ func main() {
 	resp, err := client.System.PluginsCatalogRegisterPlugin(
 		context.Background(),
 		name,
-		PluginsCatalogRegisterPluginRequest{ /* populate request parameters */ },
+		schema.PluginsCatalogRegisterPluginRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -4825,7 +4825,7 @@ func main() {
 		context.Background(),
 		name,
 		type_,
-		PluginsCatalogRegisterPluginWithTypeRequest{ /* populate request parameters */ },
+		schema.PluginsCatalogRegisterPluginWithTypeRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -5011,7 +5011,7 @@ func main() {
 
 	resp, err := client.System.PluginsReloadBackends(
 		context.Background(),
-		PluginsReloadBackendsRequest{ /* populate request parameters */ },
+		schema.PluginsReloadBackendsRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -5469,7 +5469,7 @@ func main() {
 	resp, err := client.System.PoliciesWriteAclPolicy(
 		context.Background(),
 		name,
-		PoliciesWriteAclPolicyRequest{ /* populate request parameters */ },
+		schema.PoliciesWriteAclPolicyRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -5531,7 +5531,7 @@ func main() {
 	resp, err := client.System.PoliciesWritePasswordPolicy(
 		context.Background(),
 		name,
-		PoliciesWritePasswordPolicyRequest{ /* populate request parameters */ },
+		schema.PoliciesWritePasswordPolicyRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -6165,7 +6165,7 @@ func main() {
 
 	resp, err := client.System.QueryTokenAccessorCapabilities(
 		context.Background(),
-		QueryTokenAccessorCapabilitiesRequest{ /* populate request parameters */ },
+		schema.QueryTokenAccessorCapabilitiesRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -6220,7 +6220,7 @@ func main() {
 
 	resp, err := client.System.QueryTokenCapabilities(
 		context.Background(),
-		QueryTokenCapabilitiesRequest{ /* populate request parameters */ },
+		schema.QueryTokenCapabilitiesRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -6275,7 +6275,7 @@ func main() {
 
 	resp, err := client.System.QueryTokenSelfCapabilities(
 		context.Background(),
-		QueryTokenSelfCapabilitiesRequest{ /* populate request parameters */ },
+		schema.QueryTokenSelfCapabilitiesRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -6330,7 +6330,7 @@ func main() {
 
 	resp, err := client.System.RateLimitQuotasConfigure(
 		context.Background(),
-		RateLimitQuotasConfigureRequest{ /* populate request parameters */ },
+		schema.RateLimitQuotasConfigureRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -6608,7 +6608,7 @@ func main() {
 	resp, err := client.System.RateLimitQuotasWrite(
 		context.Background(),
 		name,
-		RateLimitQuotasWriteRequest{ /* populate request parameters */ },
+		schema.RateLimitQuotasWriteRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -6848,7 +6848,7 @@ func main() {
 	resp, err := client.System.RawWrite(
 		context.Background(),
 		path,
-		RawWriteRequest{ /* populate request parameters */ },
+		schema.RawWriteRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -7110,7 +7110,7 @@ func main() {
 
 	resp, err := client.System.ReadWrappingProperties(
 		context.Background(),
-		ReadWrappingPropertiesRequest{ /* populate request parameters */ },
+		schema.ReadWrappingPropertiesRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -7219,7 +7219,7 @@ func main() {
 
 	resp, err := client.System.RekeyAttemptInitialize(
 		context.Background(),
-		RekeyAttemptInitializeRequest{ /* populate request parameters */ },
+		schema.RekeyAttemptInitializeRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -7324,7 +7324,7 @@ func main() {
 
 	resp, err := client.System.RekeyAttemptUpdate(
 		context.Background(),
-		RekeyAttemptUpdateRequest{ /* populate request parameters */ },
+		schema.RekeyAttemptUpdateRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -7681,7 +7681,7 @@ func main() {
 
 	resp, err := client.System.RekeyVerificationUpdate(
 		context.Background(),
-		RekeyVerificationUpdateRequest{ /* populate request parameters */ },
+		schema.RekeyVerificationUpdateRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -7795,7 +7795,7 @@ func main() {
 
 	resp, err := client.System.Remount(
 		context.Background(),
-		RemountRequest{ /* populate request parameters */ },
+		schema.RemountRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -7909,7 +7909,7 @@ func main() {
 
 	resp, err := client.System.Rewrap(
 		context.Background(),
-		RewrapRequest{ /* populate request parameters */ },
+		schema.RewrapRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -8016,7 +8016,7 @@ func main() {
 
 	resp, err := client.System.RootTokenGenerationInitialize(
 		context.Background(),
-		RootTokenGenerationInitializeRequest{ /* populate request parameters */ },
+		schema.RootTokenGenerationInitializeRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -8123,7 +8123,7 @@ func main() {
 
 	resp, err := client.System.RootTokenGenerationUpdate(
 		context.Background(),
-		RootTokenGenerationUpdateRequest{ /* populate request parameters */ },
+		schema.RootTokenGenerationUpdateRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -8332,7 +8332,7 @@ func main() {
 	resp, err := client.System.UiHeadersConfigure(
 		context.Background(),
 		header,
-		UiHeadersConfigureRequest{ /* populate request parameters */ },
+		schema.UiHeadersConfigureRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -8563,7 +8563,7 @@ func main() {
 
 	resp, err := client.System.Unseal(
 		context.Background(),
-		UnsealRequest{ /* populate request parameters */ },
+		schema.UnsealRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {
@@ -8618,7 +8618,7 @@ func main() {
 
 	resp, err := client.System.Unwrap(
 		context.Background(),
-		UnwrapRequest{ /* populate request parameters */ },
+		schema.UnwrapRequest{ /* populate request parameters */ },
 		vault.WithToken("my-token"),
 	)
 	if err != nil {

--- a/generate/templates/api_doc.handlebars
+++ b/generate/templates/api_doc.handlebars
@@ -40,16 +40,31 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-{{#each allParams}}{{#if isPathParam}}{{#endsWith baseName "_mount_path"}}{{else}}
-	{{paramName}} := {{{vendorExtensions.x-go-example}}} // {{{dataType}}} | {{#if description}}{{{description}}}{{/if}}{{#with defaultValue}} (defaults to {{{.}}}){{/with}}{{/endsWith}}{{/if}}{{/each}}{{#each allParams}}{{#if isQueryParam}}{{#neq paramName "list"}}
-	{{paramName}} := {{{vendorExtensions.x-go-example}}} // {{{dataType}}} | {{{description}}}{{#with defaultValue}} (defaults to {{{.}}}){{/with}}{{/neq}}{{/if}}{{/each}}
+{{! Oddly, vendorExtensions.x-go-example seems to only be available within allParams,
+	and not within pathParams, queryParams, etc. }}
+{{~#each allParams}}
+{{~#if (or
+		(and isPathParam (not (endsWith baseName "_mount_path")))
+		(and isQueryParam (neq baseName "list"))
+)}}
+	{{paramName}} := {{{vendorExtensions.x-go-example}}} // {{{dataType}}} | {{#if description}}{{{description}}}{{/if}}{{#with defaultValue}} (defaults to {{{.}}}){{/with}}
+{{~/if}}
+{{~/each}}
 	resp, err := client.{{cut classname "Api"}}.{{operationId}}(
-		context.Background(),{{#each pathParams}}{{#endsWith baseName "_mount_path"}}{{else}}
-		{{paramName}},{{/endsWith}}{{/each}}{{#each bodyParams}}
-		{{dataType}}{ /* populate request parameters */ },{{/each}}{{#each queryParams}}{{#neq paramName "list"}}
-		{{paramName}},{{/neq}}{{/each}}
-		vault.WithToken("my-token"),{{#each pathParams}}{{#endsWith baseName "_mount_path"}}
-		vault.WithMountPath({{#with defaultValue}}{{{.}}}{{/with}}),{{/endsWith}}{{/each}}
+		context.Background(),
+{{~#each pathParams}}{{#not (endsWith baseName "_mount_path")}}
+		{{paramName}},
+{{~/not}}{{/each}}
+{{~#each bodyParams}}
+		{{#if isModel}}schema.{{/if}}{{dataType}}{ /* populate request parameters */ },
+{{~/each}}
+{{~#each queryParams}}{{#neq baseName "list"}}
+		{{paramName}},
+{{~/neq}}{{/each}}
+		vault.WithToken("my-token"),
+{{~#each pathParams}}{{#endsWith baseName "_mount_path"}}
+		vault.WithMountPath({{#with defaultValue}}{{{.}}}{{/with}}),
+{{~/endsWith}}{{/each}}
 	)
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
Also refactor the affected portion of the Handlebars templates to use
whitespace control, which hopefully makes it more readable, as the
control tags for one thing to output are no longer concatenated on the
same line as literal text from the previous thing to output.
