### PR TITLE
Populate default retry configuration options

### DIFF
--- a/client_configuration.go
+++ b/client_configuration.go
@@ -166,7 +166,7 @@ type RetryConfiguration struct {
 	// Default: 1000 milliseconds
 	RetryWaitMin time.Duration `env:"VAULT_RETRY_WAIT_MIN"`
 
-	// MaxRetryWait controls the maximum time to wait before retrying when
+	// RetryWaitMax controls the maximum time to wait before retrying when
 	// a 5xx or 412 error occurs.
 	// Default: 1500 milliseconds
 	RetryWaitMax time.Duration `env:"VAULT_RETRY_WAIT_MAX"`

--- a/client_option.go
+++ b/client_option.go
@@ -54,18 +54,34 @@ func WithRequestTimeout(timeout time.Duration) ClientOption {
 }
 
 // WithTLS configures the TLS settings in the base http.Client.
-func WithTLS(configuration TLSConfiguration) ClientOption {
+func WithTLS(tls TLSConfiguration) ClientOption {
 	return func(c *ClientConfiguration) error {
-		c.TLS = configuration
+		c.TLS = tls
 		return nil
 	}
 }
 
 // WithRetryConfiguration configures the internal go-retryablehttp client.
 // The library sets reasonable defaults for this setting.
-func WithRetryConfiguration(configuration RetryConfiguration) ClientOption {
+func WithRetryConfiguration(retry RetryConfiguration) ClientOption {
 	return func(c *ClientConfiguration) error {
-		c.RetryConfiguration = configuration
+		// if any of the required RetryConfiguration values are missing, use defaults
+		defaultRetryConfiguration := DefaultConfiguration().RetryConfiguration
+
+		if retry.CheckRetry == nil {
+			retry.CheckRetry = defaultRetryConfiguration.CheckRetry
+		}
+
+		if retry.Backoff == nil {
+			retry.Backoff = defaultRetryConfiguration.Backoff
+		}
+
+		if retry.ErrorHandler == nil {
+			retry.ErrorHandler = defaultRetryConfiguration.ErrorHandler
+		}
+
+		c.RetryConfiguration = retry
+
 		return nil
 	}
 }

--- a/client_test.go
+++ b/client_test.go
@@ -30,7 +30,7 @@ func Test_Client_Clone(t *testing.T) {
 
 	clone := client.Clone()
 
-	testEqual(t, client, clone)
+	assertEqual(t, client, clone)
 
 	assert.Equal(t, "http://test", clone.Configuration().Address)
 	assert.Equal(t, 30*time.Second, clone.Configuration().RequestTimeout)
@@ -40,8 +40,8 @@ func Test_Client_Clone(t *testing.T) {
 	assert.Equal(t, "test-namespace", clone.clientRequestModifiers.headers.namespace)
 }
 
-// We cannot compare the two objects directly since they have nested func pointers
-func testEqual(t *testing.T, c1 *Client, c2 *Client) {
+// assertEqual compares the two clients, accounting for nested func pointers
+func assertEqual(t *testing.T, c1 *Client, c2 *Client) {
 	assert.Equal(t, fmt.Sprintf("%v", c1.configuration), fmt.Sprintf("%v", c2.configuration))
 	assert.Equal(t, fmt.Sprintf("%v", c1.parsedBaseAddress), fmt.Sprintf("%v", c2.parsedBaseAddress))
 	assert.Equal(t, fmt.Sprintf("%v", c1.client), fmt.Sprintf("%v", c2.client))

--- a/client_test.go
+++ b/client_test.go
@@ -40,7 +40,8 @@ func Test_Client_Clone(t *testing.T) {
 	assert.Equal(t, "test-namespace", clone.clientRequestModifiers.headers.namespace)
 }
 
-// assertEqual compares the two clients, accounting for nested func pointers
+// assertEqual compares the two clients, accounting for the nested func pointers,
+// which are not comparable in Go (https://go.dev/ref/spec#Comparison_operators)
 func assertEqual(t *testing.T, c1 *Client, c2 *Client) {
 	assert.Equal(t, fmt.Sprintf("%v", c1.configuration), fmt.Sprintf("%v", c2.configuration))
 	assert.Equal(t, fmt.Sprintf("%v", c1.parsedBaseAddress), fmt.Sprintf("%v", c2.parsedBaseAddress))

--- a/client_test.go
+++ b/client_test.go
@@ -41,7 +41,7 @@ func Test_Client_Clone(t *testing.T) {
 }
 
 // assertEqual compares the two clients, accounting for the nested func pointers,
-// which are not comparable in Go (https://go.dev/ref/spec#Comparison_operators)
+// which are not comparable in Go (https://go.dev/ref/spec#Comparison_operators).
 func assertEqual(t *testing.T, c1 *Client, c2 *Client) {
 	assert.Equal(t, fmt.Sprintf("%v", c1.configuration), fmt.Sprintf("%v", c2.configuration))
 	assert.Equal(t, fmt.Sprintf("%v", c1.parsedBaseAddress), fmt.Sprintf("%v", c2.parsedBaseAddress))

--- a/client_test.go
+++ b/client_test.go
@@ -4,6 +4,7 @@
 package vault
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -29,7 +30,7 @@ func Test_Client_Clone(t *testing.T) {
 
 	clone := client.Clone()
 
-	assert.Equal(t, client, clone)
+	testEqual(t, client, clone)
 
 	assert.Equal(t, "http://test", clone.Configuration().Address)
 	assert.Equal(t, 30*time.Second, clone.Configuration().RequestTimeout)
@@ -37,4 +38,14 @@ func Test_Client_Clone(t *testing.T) {
 	assert.Equal(t, 900*time.Millisecond, clone.Configuration().RetryConfiguration.RetryWaitMax)
 	assert.Equal(t, "test-token", clone.clientRequestModifiers.headers.token)
 	assert.Equal(t, "test-namespace", clone.clientRequestModifiers.headers.namespace)
+}
+
+// We cannot compare the two objects directly since they have nested func pointers
+func testEqual(t *testing.T, c1 *Client, c2 *Client) {
+	assert.Equal(t, fmt.Sprintf("%v", c1.configuration), fmt.Sprintf("%v", c2.configuration))
+	assert.Equal(t, fmt.Sprintf("%v", c1.parsedBaseAddress), fmt.Sprintf("%v", c2.parsedBaseAddress))
+	assert.Equal(t, fmt.Sprintf("%v", c1.client), fmt.Sprintf("%v", c2.client))
+	assert.Equal(t, fmt.Sprintf("%v", c1.clientWithRetries), fmt.Sprintf("%v", c2.clientWithRetries))
+	assert.Equal(t, fmt.Sprintf("%v", c1.clientRequestModifiers), fmt.Sprintf("%v", c2.clientRequestModifiers))
+	assert.Equal(t, fmt.Sprintf("%v", c1.replicationStates.states), fmt.Sprintf("%v", c2.replicationStates.states))
 }


### PR DESCRIPTION
## Description

Populate the required retry parameters with defaults if omitted.

Resolves #229 

## How has this been tested?

Adjusted the clone test to account for `func` pointers.
