### PR TITLE
Switch to Go 1.21

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up go
         uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
         with:
-          go-version: 1.18
+          go-version: 1.21
 
       - name: Build
         run: go build -v ./...
@@ -35,7 +35,7 @@ jobs:
       - name: Set up go
         uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
         with:
-          go-version: 1.18
+          go-version: 1.21
 
       - name: Ensure the code has been properly regenerated with 'make regen'
         run: |

--- a/go.mod
+++ b/go.mod
@@ -1,22 +1,19 @@
 module github.com/hashicorp/vault-client-go
 
-go 1.18
+go 1.21
 
 require (
 	github.com/hashicorp/go-cleanhttp v0.5.2
-	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-retryablehttp v0.7.1
 	github.com/hashicorp/go-rootcerts v1.0.2
 	github.com/hashicorp/go-secure-stdlib/strutil v0.1.2
 	github.com/stretchr/testify v1.8.0
-	golang.org/x/exp v0.0.0-20230801115018-d63ba01acd4b
 	golang.org/x/sys v0.4.0
 	golang.org/x/time v0.0.0-20220922220347-f3bd1da661af
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/ryanuber/go-glob v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,15 +1,11 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
-github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
 github.com/hashicorp/go-hclog v0.9.2 h1:CG6TE5H9/JXsFWJCfoIVpKFIkFe6ysEuHirp4DxCsHI=
 github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
-github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
-github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/go-retryablehttp v0.7.1 h1:sUiuQAnLlbvmExtFQs72iFW/HXeUn8Z1aJLQ4LJJbTQ=
 github.com/hashicorp/go-retryablehttp v0.7.1/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
 github.com/hashicorp/go-rootcerts v1.0.2 h1:jzhAVGtqPKbwpyCPELlgNWhE1znq+qwJtW5Oi2viEzc=
@@ -28,8 +24,6 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
-golang.org/x/exp v0.0.0-20230801115018-d63ba01acd4b h1:r+vk0EmXNmekl0S0BascoeeoHk/L7wmaW2QF90K+kYI=
-golang.org/x/exp v0.0.0-20230801115018-d63ba01acd4b/go.mod h1:FXUEEKJgO7OQYeo8N01OfiKP8RXMtf6e8aTskBGqWdc=
 golang.org/x/sys v0.4.0 h1:Zr2JFtRQNX3BCZ8YtxRE9hNJYC8J6I1MVbMg6owUp18=
 golang.org/x/sys v0.4.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/time v0.0.0-20220922220347-f3bd1da661af h1:Yx9k8YCG3dvF87UAn2tu2HQLf2dt/eR1bXxpLMWeH+Y=

--- a/request_modifiers.go
+++ b/request_modifiers.go
@@ -5,14 +5,12 @@ package vault
 
 import (
 	"fmt"
+	"maps"
 	"net/http"
 	"net/url"
 	"strings"
 	"time"
 	"unicode"
-
-	"github.com/hashicorp/go-multierror"
-	"golang.org/x/exp/maps"
 )
 
 type (
@@ -310,17 +308,14 @@ func validateNamespace(namespace string) error {
 	return nil
 }
 
-func validateCustomHeaders(headers http.Header) (errs error) {
+func validateCustomHeaders(headers http.Header) error {
 	for key := range headers {
 		if strings.HasPrefix(strings.ToLower(key), "x-vault-") {
-			errs = multierror.Append(
-				errs,
-				fmt.Errorf("custom header key %q is not allowed: 'X-Vault-' prefix is for internal use only", key),
-			)
+			return fmt.Errorf("custom header key %q is not allowed: 'X-Vault-' prefix is for internal use only", key)
 		}
 	}
 
-	return errs
+	return nil
 }
 
 // printable returns true if the given string has no non-printable characters

--- a/request_option.go
+++ b/request_option.go
@@ -8,8 +8,6 @@ import (
 	"net/url"
 	"strings"
 	"time"
-
-	"github.com/hashicorp/go-multierror"
 )
 
 // RequestOption is a functional parameter used to modify a request
@@ -143,17 +141,13 @@ func WithReplicationForwardingMode(mode ReplicationForwardingMode) RequestOption
 }
 
 // requestOptionsToRequestModifiers constructs `requestModifiers` propagating the errors, if any
-func requestOptionsToRequestModifiers(options []RequestOption) (_ requestModifiers, errs error) {
+func requestOptionsToRequestModifiers(options []RequestOption) (requestModifiers, error) {
 	var modifiers requestModifiers
 
 	for _, option := range options {
 		if err := option(&modifiers); err != nil {
-			errs = multierror.Append(errs, err)
+			return requestModifiers{}, err
 		}
-	}
-
-	if errs != nil {
-		return requestModifiers{}, errs
 	}
 
 	return modifiers, nil


### PR DESCRIPTION
## Description

Switching to Go 1.21 and removing dependencies on the following:

- hashicorp/go-multierror
- golang.org/x/exp
