### PR TITLE
SecretIdTtl  must be int32 for automatic conversion

### DIFF
--- a/schema/model_app_role_look_up_secret_id_by_accessor_response.go
+++ b/schema/model_app_role_look_up_secret_id_by_accessor_response.go
@@ -27,7 +27,7 @@ type AppRoleLookUpSecretIdByAccessorResponse struct {
 	SecretIdNumUses int32 `json:"secret_id_num_uses,omitempty"`
 
 	// Duration in seconds after which the issued secret ID expires.
-	SecretIdTtl string `json:"secret_id_ttl,omitempty"`
+	SecretIdTtl int32 `json:"secret_id_ttl,omitempty"`
 
 	// List of CIDR blocks. If set, specifies the blocks of IP addresses which can use the returned token. Should be a subset of the token CIDR blocks listed on the role, if any.
 	TokenBoundCidrs []string `json:"token_bound_cidrs,omitempty"`


### PR DESCRIPTION
## Description

> Please describe the change proposed in this pull request, including relevant
> motivation and context.

Proposing to change the type of SecretIdTtl in the AppRoleLookUpSecretIdByAccessorResponse type for automatic json parsing.

I'm getting the following error while using the API

```
cannot unmarshal number into Go struct field AppRoleLookUpSecretIdByAccessorResponse.data.secret_id_ttl of type string
```

Resolves # (issue)

## How has this been tested?

> Please describe the tests you ran.
