### PR TITLE
Fix SetRequestCallbacks/SetResponseCallbacks

### DIFF
--- a/client.go
+++ b/client.go
@@ -216,7 +216,7 @@ func (c *Client) cloneClientRequestModifiers() requestModifiers {
 		customHeaders:             c.clientRequestModifiers.headers.customHeaders.Clone(),
 	}
 
-    clone.headers.mfaCredentials = append([]string{}, c.clientRequestModifiers.headers.mfaCredentials...)
+	clone.headers.mfaCredentials = append([]string{}, c.clientRequestModifiers.headers.mfaCredentials...)
 
 	return clone
 }

--- a/client.go
+++ b/client.go
@@ -204,8 +204,8 @@ func (c *Client) cloneClientRequestModifiers() requestModifiers {
 
 	var clone requestModifiers
 
-	clone.requestCallbacks = append(clone.requestCallbacks, c.clientRequestModifiers.requestCallbacks...)
-	clone.responseCallbacks = append(clone.responseCallbacks, c.clientRequestModifiers.responseCallbacks...)
+	clone.requestCallbacks = append([]RequestCallback{}, c.clientRequestModifiers.requestCallbacks...)
+	clone.responseCallbacks = append([]ResponseCallback{}, c.clientRequestModifiers.responseCallbacks...)
 
 	clone.headers = requestHeaders{
 		userAgent:                 c.clientRequestModifiers.headers.userAgent,
@@ -216,7 +216,7 @@ func (c *Client) cloneClientRequestModifiers() requestModifiers {
 		customHeaders:             c.clientRequestModifiers.headers.customHeaders.Clone(),
 	}
 
-    clone.headers.mfaCredentials = append(clone.headers.mfaCredentials, c.clientRequestModifiers.headers.mfaCredentials...)
+    clone.headers.mfaCredentials = append([]string{}, c.clientRequestModifiers.headers.mfaCredentials...)
 
 	return clone
 }

--- a/client.go
+++ b/client.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"slices"
 	"strings"
 	"sync"
 
@@ -204,8 +205,8 @@ func (c *Client) cloneClientRequestModifiers() requestModifiers {
 
 	var clone requestModifiers
 
-	clone.requestCallbacks = append([]RequestCallback{}, c.clientRequestModifiers.requestCallbacks...)
-	clone.responseCallbacks = append([]ResponseCallback{}, c.clientRequestModifiers.responseCallbacks...)
+	clone.requestCallbacks = slices.Clone(c.clientRequestModifiers.requestCallbacks)
+	clone.responseCallbacks = slices.Clone(c.clientRequestModifiers.responseCallbacks)
 
 	clone.headers = requestHeaders{
 		userAgent:                 c.clientRequestModifiers.headers.userAgent,
@@ -216,7 +217,7 @@ func (c *Client) cloneClientRequestModifiers() requestModifiers {
 		customHeaders:             c.clientRequestModifiers.headers.customHeaders.Clone(),
 	}
 
-	clone.headers.mfaCredentials = append([]string{}, c.clientRequestModifiers.headers.mfaCredentials...)
+	clone.headers.mfaCredentials = slices.Clone(c.clientRequestModifiers.headers.mfaCredentials)
 
 	return clone
 }

--- a/client.go
+++ b/client.go
@@ -204,8 +204,8 @@ func (c *Client) cloneClientRequestModifiers() requestModifiers {
 
 	var clone requestModifiers
 
-	copy(clone.requestCallbacks, c.clientRequestModifiers.requestCallbacks)
-	copy(clone.responseCallbacks, c.clientRequestModifiers.responseCallbacks)
+	clone.requestCallbacks = append(clone.requestCallbacks, c.clientRequestModifiers.requestCallbacks...)
+	clone.responseCallbacks = append(clone.responseCallbacks, c.clientRequestModifiers.responseCallbacks...)
 
 	clone.headers = requestHeaders{
 		userAgent:                 c.clientRequestModifiers.headers.userAgent,
@@ -216,7 +216,7 @@ func (c *Client) cloneClientRequestModifiers() requestModifiers {
 		customHeaders:             c.clientRequestModifiers.headers.customHeaders.Clone(),
 	}
 
-	copy(clone.headers.mfaCredentials, c.clientRequestModifiers.headers.mfaCredentials)
+    clone.headers.mfaCredentials = append(clone.headers.mfaCredentials, c.clientRequestModifiers.headers.mfaCredentials...)
 
 	return clone
 }

--- a/client_test.go
+++ b/client_test.go
@@ -5,6 +5,7 @@ package vault
 
 import (
 	"fmt"
+	"net/http"
 	"testing"
 	"time"
 
@@ -27,6 +28,12 @@ func Test_Client_Clone(t *testing.T) {
 
 	require.NoError(t, client.SetToken("test-token"))
 	require.NoError(t, client.SetNamespace("test-namespace"))
+	require.NoError(t, client.SetRequestCallbacks(func(req *http.Request) {
+		t.Log(req)
+	}))
+	require.NoError(t, client.SetResponseCallbacks(func(req *http.Request, resp *http.Response) {
+		t.Log(req, resp)
+	}))
 
 	clone := client.Clone()
 

--- a/generate/templates/client.handlebars
+++ b/generate/templates/client.handlebars
@@ -180,8 +180,8 @@ func (c *Client) cloneClientRequestModifiers() requestModifiers {
 
 	var clone requestModifiers
 
-	clone.requestCallbacks = append(clone.requestCallbacks, c.clientRequestModifiers.requestCallbacks...)
-	clone.responseCallbacks = append(clone.responseCallbacks, c.clientRequestModifiers.responseCallbacks...)
+	clone.requestCallbacks = append([]RequestCallback{}, c.clientRequestModifiers.requestCallbacks...)
+	clone.responseCallbacks = append([]ResponseCallback{}, c.clientRequestModifiers.responseCallbacks...)
 
 	clone.headers = requestHeaders{
 		userAgent:                 c.clientRequestModifiers.headers.userAgent,
@@ -192,7 +192,7 @@ func (c *Client) cloneClientRequestModifiers() requestModifiers {
 		customHeaders:             c.clientRequestModifiers.headers.customHeaders.Clone(),
 	}
 
-    clone.headers.mfaCredentials = append(clone.headers.mfaCredentials, c.clientRequestModifiers.headers.mfaCredentials...)
+    clone.headers.mfaCredentials = append([]string{}, c.clientRequestModifiers.headers.mfaCredentials...)
 
 	return clone
 }

--- a/generate/templates/client.handlebars
+++ b/generate/templates/client.handlebars
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"slices"
 	"strings"
 	"sync"
 
@@ -180,8 +181,8 @@ func (c *Client) cloneClientRequestModifiers() requestModifiers {
 
 	var clone requestModifiers
 
-	clone.requestCallbacks = append([]RequestCallback{}, c.clientRequestModifiers.requestCallbacks...)
-	clone.responseCallbacks = append([]ResponseCallback{}, c.clientRequestModifiers.responseCallbacks...)
+	clone.requestCallbacks = slices.Clone(c.clientRequestModifiers.requestCallbacks)
+	clone.responseCallbacks = slices.Clone(c.clientRequestModifiers.responseCallbacks)
 
 	clone.headers = requestHeaders{
 		userAgent:                 c.clientRequestModifiers.headers.userAgent,
@@ -192,7 +193,7 @@ func (c *Client) cloneClientRequestModifiers() requestModifiers {
 		customHeaders:             c.clientRequestModifiers.headers.customHeaders.Clone(),
 	}
 
-    clone.headers.mfaCredentials = append([]string{}, c.clientRequestModifiers.headers.mfaCredentials...)
+	clone.headers.mfaCredentials = slices.Clone(c.clientRequestModifiers.headers.mfaCredentials)
 
 	return clone
 }

--- a/generate/templates/client.handlebars
+++ b/generate/templates/client.handlebars
@@ -180,8 +180,8 @@ func (c *Client) cloneClientRequestModifiers() requestModifiers {
 
 	var clone requestModifiers
 
-	copy(clone.requestCallbacks, c.clientRequestModifiers.requestCallbacks)
-	copy(clone.responseCallbacks, c.clientRequestModifiers.responseCallbacks)
+	clone.requestCallbacks = append(clone.requestCallbacks, c.clientRequestModifiers.requestCallbacks...)
+	clone.responseCallbacks = append(clone.responseCallbacks, c.clientRequestModifiers.responseCallbacks...)
 
 	clone.headers = requestHeaders{
 		userAgent:                 c.clientRequestModifiers.headers.userAgent,
@@ -192,7 +192,7 @@ func (c *Client) cloneClientRequestModifiers() requestModifiers {
 		customHeaders:             c.clientRequestModifiers.headers.customHeaders.Clone(),
 	}
 
-	copy(clone.headers.mfaCredentials, c.clientRequestModifiers.headers.mfaCredentials)
+    clone.headers.mfaCredentials = append(clone.headers.mfaCredentials, c.clientRequestModifiers.headers.mfaCredentials...)
 
 	return clone
 }

--- a/replication_consistency.go
+++ b/replication_consistency.go
@@ -10,6 +10,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"net/http"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -228,8 +229,7 @@ func (c *replicationStateCache) clone() replicationStateCache {
 	/* */ c.statesLock.RLock()
 	defer c.statesLock.RUnlock()
 
-	cloned := make([]string, len(c.states))
-	copy(cloned, c.states)
+	cloned := slices.Clone(c.states)
 
 	return replicationStateCache{
 		statesLock: sync.RWMutex{},

--- a/replication_consistency.go
+++ b/replication_consistency.go
@@ -228,7 +228,7 @@ func (c *replicationStateCache) clone() replicationStateCache {
 	/* */ c.statesLock.RLock()
 	defer c.statesLock.RUnlock()
 
-	var cloned []string
+	cloned := make([]string, len(c.states))
 	copy(cloned, c.states)
 
 	return replicationStateCache{

--- a/request_modifiers.go
+++ b/request_modifiers.go
@@ -8,6 +8,7 @@ import (
 	"maps"
 	"net/http"
 	"net/url"
+	"slices"
 	"strings"
 	"time"
 	"unicode"
@@ -172,8 +173,7 @@ func (c *Client) ClearCustomHeaders() {
 // SetRequestCallbacks sets callbacks which will be invoked before each request.
 func (c *Client) SetRequestCallbacks(callbacks ...RequestCallback) error {
 	c.clientRequestModifiersLock.Lock()
-	c.clientRequestModifiers.requestCallbacks = make([]RequestCallback, len(callbacks))
-	copy(c.clientRequestModifiers.requestCallbacks, callbacks)
+	c.clientRequestModifiers.requestCallbacks = slices.Clone(callbacks)
 	c.clientRequestModifiersLock.Unlock()
 
 	return nil
@@ -190,8 +190,7 @@ func (c *Client) ClearRequestCallbacks() {
 // successful response.
 func (c *Client) SetResponseCallbacks(callbacks ...ResponseCallback) error {
 	c.clientRequestModifiersLock.Lock()
-	c.clientRequestModifiers.responseCallbacks = make([]ResponseCallback, len(callbacks))
-	copy(c.clientRequestModifiers.responseCallbacks, callbacks)
+	c.clientRequestModifiers.responseCallbacks = slices.Clone(callbacks)
 	c.clientRequestModifiersLock.Unlock()
 
 	return nil

--- a/request_modifiers.go
+++ b/request_modifiers.go
@@ -172,6 +172,7 @@ func (c *Client) ClearCustomHeaders() {
 // SetRequestCallbacks sets callbacks which will be invoked before each request.
 func (c *Client) SetRequestCallbacks(callbacks ...RequestCallback) error {
 	c.clientRequestModifiersLock.Lock()
+	c.clientRequestModifiers.requestCallbacks = make([]RequestCallback, len(callbacks))
 	copy(c.clientRequestModifiers.requestCallbacks, callbacks)
 	c.clientRequestModifiersLock.Unlock()
 
@@ -189,6 +190,7 @@ func (c *Client) ClearRequestCallbacks() {
 // successful response.
 func (c *Client) SetResponseCallbacks(callbacks ...ResponseCallback) error {
 	c.clientRequestModifiersLock.Lock()
+	c.clientRequestModifiers.responseCallbacks = make([]ResponseCallback, len(callbacks))
 	copy(c.clientRequestModifiers.responseCallbacks, callbacks)
 	c.clientRequestModifiersLock.Unlock()
 


### PR DESCRIPTION
## Description

`SetRequestCallbacks/SetResponseCallbacks` was incorrectly using the built-in `copy` function. As @joseph-reslv pointed out in https://github.com/hashicorp/vault-client-go/issues/241#issue-1941186005:

> Copy returns the number of elements copied, which will be the minimum of len(src) and len(dst).

Fixing the instances where we call `copy` incorrectly to fix the two functions.

Resolves #241 

## How has this been tested?

Unfortunately we don't have a robust testing framework, so I won't be able to properly test these use-cases. However, I've tested it in https://github.com/averche/vault-test/pull/4 and I see the new code working as expected.
