### PR TITLE
0.4.3 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## Unreleased ([diff][unreleased-diff])
 
+## [0.4.3][] ([diff][0.4.2-diff]) - 2023-12-15
+
+### Fixed
+
+- Fixed error parsing for errors with non-standard response bodies (#247)
+
 ## [0.4.2][] ([diff][0.4.2-diff]) - 2023-10-19
 
 ### Fixed
@@ -150,7 +156,9 @@ and this project adheres to
 <!-- diffs -->
 
 [unreleased-diff]:
-  https://github.com/hashicorp/vault-client-go/compare/v0.4.2...HEAD
+  https://github.com/hashicorp/vault-client-go/compare/v0.4.3...HEAD
+[0.4.3-diff]:
+  https://github.com/hashicorp/vault-client-go/compare/v0.4.2...v0.4.3
 [0.4.2-diff]:
   https://github.com/hashicorp/vault-client-go/compare/v0.4.1...v0.4.2
 [0.4.1-diff]:
@@ -174,6 +182,7 @@ and this project adheres to
 
 <!-- releases -->
 
+[0.4.3]: https://github.com/hashicorp/vault-client-go/releases/tag/v0.4.3
 [0.4.2]: https://github.com/hashicorp/vault-client-go/releases/tag/v0.4.2
 [0.4.1]: https://github.com/hashicorp/vault-client-go/releases/tag/v0.4.1
 [0.4.0]: https://github.com/hashicorp/vault-client-go/releases/tag/v0.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,11 @@ and this project adheres to
 
 ## Unreleased ([diff][unreleased-diff])
 
-## [0.4.3][] ([diff][0.4.2-diff]) - 2023-12-15
+## [0.4.3][] ([diff][0.4.3-diff]) - 2023-12-15
 
 ### Fixed
 
-- Fixed error parsing for errors with non-standard response bodies (#247)
+- Fixed error parsing for errors with non-standard response bodies (#247).
 
 ## [0.4.2][] ([diff][0.4.2-diff]) - 2023-10-19
 

--- a/client.go
+++ b/client.go
@@ -18,7 +18,7 @@ import (
 	"github.com/hashicorp/go-retryablehttp"
 )
 
-const ClientVersion = "0.4.2"
+const ClientVersion = "0.4.3"
 
 // Client manages communication with Vault, initialize it with vault.New(...)
 type Client struct {

--- a/generate/config.yaml
+++ b/generate/config.yaml
@@ -3,5 +3,5 @@
 
 additionalProperties:
   packageName: vault
-  packageVersion: 0.4.2
+  packageVersion: 0.4.3
 


### PR DESCRIPTION
## [0.4.3][] ([diff][0.4.3-diff]) - 2023-12-15

### Fixed

- Fixed error parsing for errors with non-standard response bodies.

[0.4.3-diff]:
  https://github.com/hashicorp/vault-client-go/compare/v0.4.2...v0.4.3
[0.4.3]: https://github.com/hashicorp/vault-client-go/releases/tag/v0.4.3