### PR TITLE
Use constant value for unix socket so valid host is set in request URL

### DIFF
--- a/client.go
+++ b/client.go
@@ -155,8 +155,7 @@ func parseAddress(address string) (*url.URL, error) {
 		// used in the application layer and not to the transport layer. Hence,
 		// setting the fields accordingly.
 		parsed.Scheme = "http"
-		// fake host to construct valid URLs
-		parsed.Host = "unix.socket"
+		parsed.Host = "localhost"
 		parsed.Path = ""
 	}
 

--- a/client.go
+++ b/client.go
@@ -155,7 +155,7 @@ func parseAddress(address string) (*url.URL, error) {
 		// used in the application layer and not to the transport layer. Hence,
 		// setting the fields accordingly.
 		parsed.Scheme = "http"
-		parsed.Host = strings.TrimPrefix(address, "unix://") // socket
+		parsed.Host = "unix.socket"
 		parsed.Path = ""
 	}
 

--- a/client.go
+++ b/client.go
@@ -155,6 +155,7 @@ func parseAddress(address string) (*url.URL, error) {
 		// used in the application layer and not to the transport layer. Hence,
 		// setting the fields accordingly.
 		parsed.Scheme = "http"
+		// fake host to construct valid URLs
 		parsed.Host = "unix.socket"
 		parsed.Path = ""
 	}

--- a/generate/templates/client.handlebars
+++ b/generate/templates/client.handlebars
@@ -140,8 +140,7 @@ func parseAddress(address string) (*url.URL, error) {
 		// used in the application layer and not to the transport layer. Hence,
 		// setting the fields accordingly.
 		parsed.Scheme = "http"
-		// fake host to construct valid URLs
-		parsed.Host = "unix.socket"
+		parsed.Host = "localhost"
 		parsed.Path = ""
 	}
 

--- a/generate/templates/client.handlebars
+++ b/generate/templates/client.handlebars
@@ -140,6 +140,7 @@ func parseAddress(address string) (*url.URL, error) {
 		// used in the application layer and not to the transport layer. Hence,
 		// setting the fields accordingly.
 		parsed.Scheme = "http"
+		// fake host to construct valid URLs
 		parsed.Host = "unix.socket"
 		parsed.Path = ""
 	}

--- a/generate/templates/client.handlebars
+++ b/generate/templates/client.handlebars
@@ -140,7 +140,7 @@ func parseAddress(address string) (*url.URL, error) {
 		// used in the application layer and not to the transport layer. Hence,
 		// setting the fields accordingly.
 		parsed.Scheme = "http"
-		parsed.Host = strings.TrimPrefix(address, "unix://") // socket
+		parsed.Host = "unix.socket"
 		parsed.Path = ""
 	}
 


### PR DESCRIPTION
## Description
When unix socket is used, usually it's in form like VAULT_ADDR="unix:///var/run/vault.sock"
Currently library correctly detects usage of unix socket based on `unix://` prefix. However later `/var/run/vault.sock` is used as Host parameter in HTTP requests over unix socket. It's incorrect as golang URL library expects valid URL in such case so it will try to escape slashes and construct URL in form like: `http://%2Fvar%2Frun%2Fvault%2Fvault.sock/v1/secret/data/...` what will cause error as host is incorrect. 

I propose to use instead "fake" host which is still valid URL as `http://unix.socket/v1/secret/data` is correct from HTTP perspective - later dial function with unix socket will be used anyway ( https://github.com/hashicorp/vault-client-go/blob/b335dfa06f347b1ad9c1a51503cef9b79c3e7725/client.go#L97-L104 ) so host part of the URL will be ignored.

## How has this been tested?

Ran `go test ./...` and tested code locally.
