### PR TITLE
change RekeyAttempt started type from string to bool

### DIFF
--- a/docs/RekeyAttemptInitializeResponse.md
+++ b/docs/RekeyAttemptInitializeResponse.md
@@ -11,7 +11,7 @@ Name | Type | Description | Notes
 **PgpFingerprints** | Pointer to **[]string** |  | [optional] 
 **Progress** | Pointer to **int32** |  | [optional] 
 **Required** | Pointer to **int32** |  | [optional] 
-**Started** | Pointer to **string** |  | [optional] 
+**Started** | Pointer to **bool** |  | [optional] 
 **T** | Pointer to **int32** |  | [optional] 
 **VerificationNonce** | Pointer to **string** |  | [optional] 
 **VerificationRequired** | Pointer to **bool** |  | [optional] 

--- a/docs/RekeyAttemptReadProgressResponse.md
+++ b/docs/RekeyAttemptReadProgressResponse.md
@@ -11,7 +11,7 @@ Name | Type | Description | Notes
 **PgpFingerprints** | Pointer to **[]string** |  | [optional] 
 **Progress** | Pointer to **int32** |  | [optional] 
 **Required** | Pointer to **int32** |  | [optional] 
-**Started** | Pointer to **string** |  | [optional] 
+**Started** | Pointer to **bool** |  | [optional] 
 **T** | Pointer to **int32** |  | [optional] 
 **VerificationNonce** | Pointer to **string** |  | [optional] 
 **VerificationRequired** | Pointer to **bool** |  | [optional] 

--- a/docs/RekeyAttemptUpdateResponse.md
+++ b/docs/RekeyAttemptUpdateResponse.md
@@ -14,7 +14,7 @@ Name | Type | Description | Notes
 **PgpFingerprints** | Pointer to **[]string** |  | [optional] 
 **Progress** | Pointer to **int32** |  | [optional] 
 **Required** | Pointer to **int32** |  | [optional] 
-**Started** | Pointer to **string** |  | [optional] 
+**Started** | Pointer to **bool** |  | [optional] 
 **T** | Pointer to **int32** |  | [optional] 
 **VerificationNonce** | Pointer to **string** |  | [optional] 
 **VerificationRequired** | Pointer to **bool** |  | [optional] 

--- a/docs/RekeyVerificationCancelResponse.md
+++ b/docs/RekeyVerificationCancelResponse.md
@@ -8,7 +8,7 @@ Name | Type | Description | Notes
 **N** | Pointer to **int32** |  | [optional] 
 **Nounce** | Pointer to **string** |  | [optional] 
 **Progress** | Pointer to **int32** |  | [optional] 
-**Started** | Pointer to **string** |  | [optional] 
+**Started** | Pointer to **bool** |  | [optional] 
 **T** | Pointer to **int32** |  | [optional] 
 
 

--- a/docs/RekeyVerificationReadProgressResponse.md
+++ b/docs/RekeyVerificationReadProgressResponse.md
@@ -8,7 +8,7 @@ Name | Type | Description | Notes
 **N** | Pointer to **int32** |  | [optional] 
 **Nounce** | Pointer to **string** |  | [optional] 
 **Progress** | Pointer to **int32** |  | [optional] 
-**Started** | Pointer to **string** |  | [optional] 
+**Started** | Pointer to **bool** |  | [optional] 
 **T** | Pointer to **int32** |  | [optional] 
 
 

--- a/openapi.json
+++ b/openapi.json
@@ -48102,7 +48102,7 @@
             "type": "integer"
           },
           "started": {
-            "type": "string"
+            "type": "boolean"
           },
           "t": {
             "type": "integer"
@@ -48140,7 +48140,7 @@
             "type": "integer"
           },
           "started": {
-            "type": "string"
+            "type": "boolean"
           },
           "t": {
             "type": "integer"
@@ -48206,7 +48206,7 @@
             "type": "integer"
           },
           "started": {
-            "type": "string"
+            "type": "boolean"
           },
           "t": {
             "type": "integer"
@@ -48264,7 +48264,7 @@
             "type": "integer"
           },
           "started": {
-            "type": "string"
+            "type": "boolean"
           },
           "t": {
             "type": "integer"
@@ -48284,7 +48284,7 @@
             "type": "integer"
           },
           "started": {
-            "type": "string"
+            "type": "boolean"
           },
           "t": {
             "type": "integer"

--- a/schema/model_rekey_attempt_initialize_response.go
+++ b/schema/model_rekey_attempt_initialize_response.go
@@ -19,7 +19,7 @@ type RekeyAttemptInitializeResponse struct {
 
 	Required int32 `json:"required,omitempty"`
 
-	Started string `json:"started,omitempty"`
+	Started bool `json:"started,omitempty"`
 
 	T int32 `json:"t,omitempty"`
 

--- a/schema/model_rekey_attempt_read_progress_response.go
+++ b/schema/model_rekey_attempt_read_progress_response.go
@@ -19,7 +19,7 @@ type RekeyAttemptReadProgressResponse struct {
 
 	Required int32 `json:"required,omitempty"`
 
-	Started string `json:"started,omitempty"`
+	Started bool `json:"started,omitempty"`
 
 	T int32 `json:"t,omitempty"`
 

--- a/schema/model_rekey_attempt_update_response.go
+++ b/schema/model_rekey_attempt_update_response.go
@@ -25,7 +25,7 @@ type RekeyAttemptUpdateResponse struct {
 
 	Required int32 `json:"required,omitempty"`
 
-	Started string `json:"started,omitempty"`
+	Started bool `json:"started,omitempty"`
 
 	T int32 `json:"t,omitempty"`
 

--- a/schema/model_rekey_verification_cancel_response.go
+++ b/schema/model_rekey_verification_cancel_response.go
@@ -13,7 +13,7 @@ type RekeyVerificationCancelResponse struct {
 
 	Progress int32 `json:"progress,omitempty"`
 
-	Started string `json:"started,omitempty"`
+	Started bool `json:"started,omitempty"`
 
 	T int32 `json:"t,omitempty"`
 }

--- a/schema/model_rekey_verification_read_progress_response.go
+++ b/schema/model_rekey_verification_read_progress_response.go
@@ -13,7 +13,7 @@ type RekeyVerificationReadProgressResponse struct {
 
 	Progress int32 `json:"progress,omitempty"`
 
-	Started string `json:"started,omitempty"`
+	Started bool `json:"started,omitempty"`
 
 	T int32 `json:"t,omitempty"`
 }


### PR DESCRIPTION
## Description

The type of `started` in a rekey attempt should be `boolean` instead of `string`

Resolves # (issue)

This resolves: https://github.com/hashicorp/vault-client-go/issues/251
