### PR TITLE
set KvV2WriteRequest data as required to match spec

### DIFF
--- a/docs/KvV2WriteRequest.md
+++ b/docs/KvV2WriteRequest.md
@@ -5,7 +5,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Data** | Pointer to **map[string]interface{}** | The contents of the data map will be stored and returned on read. | [optional] 
+**Data** | **map[string]interface{}** | The contents of the data map will be stored and returned on read. | 
 **Options** | Pointer to **map[string]interface{}** | Options for writing a KV entry. Set the \&quot;cas\&quot; value to use a Check-And-Set operation. If not set the write will be allowed. If set to 0 a write will only be allowed if the key doesn’t exist. If the index is non-zero the write will only be allowed if the key’s current version matches the version specified in the cas parameter. | [optional] 
 **Version** | Pointer to **int32** | If provided during a read, the value at the version number will be returned | [optional] 
 

--- a/openapi.json
+++ b/openapi.json
@@ -36917,7 +36917,10 @@
             "type": "integer",
             "description": "If provided during a read, the value at the version number will be returned"
           }
-        }
+        },
+          "required": [
+              "data"
+          ]
       },
       "KvV2WriteResponse": {
         "type": "object",

--- a/schema/model_kv_v2_write_request.go
+++ b/schema/model_kv_v2_write_request.go
@@ -8,7 +8,7 @@ package schema
 // KvV2WriteRequest struct for KvV2WriteRequest
 type KvV2WriteRequest struct {
 	// The contents of the data map will be stored and returned on read.
-	Data map[string]interface{} `json:"data,omitempty"`
+	Data map[string]interface{} `json:"data"`
 
 	// Options for writing a KV entry. Set the \"cas\" value to use a Check-And-Set operation. If not set the write will be allowed. If set to 0 a write will only be allowed if the key doesn’t exist. If the index is non-zero the write will only be allowed if the key’s current version matches the version specified in the cas parameter.
 	Options map[string]interface{} `json:"options,omitempty"`


### PR DESCRIPTION
## Description

data is a required field as per this documentation https://developer.hashicorp.com/vault/api-docs/secret/kv/kv-v2#create-update-secret

Resolves [# (issue)](https://github.com/hashicorp/vault-client-go/issues/258)

## How has this been tested?

- write secret with data to add keys
- write secret without data to remove all keys
